### PR TITLE
messages: change edit event name

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ conversation.messages.subscribe(({ type, message }) => {
       case 'message.created':
         console.log(message);
         break;
-      case 'message.updated':
+      case 'message.edited':
         console.log(message);
         break;
       case 'message.deleted':

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,6 +1,6 @@
 export const enum MessageEvents {
   created = 'message.created',
-  updated = 'message.updated',
+  edited = 'message.edited',
   deleted = 'message.deleted',
 }
 


### PR DESCRIPTION
Changes `message.updated` to `message.edited` to reflect how the event is exposed by realtime