### PR TITLE
reactions: use correct endpoint for reaction delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ const reaction = await conversation.messages.addReaction(msgId, {
 Delete reaction:
 
 ```ts
-await conversation.messages.removeReaction(reactionId)
+await conversation.messages.removeReaction(msgId, reactionId)
 ```
 
 ### Reaction object

--- a/demo/src/containers/Chat/Chat.tsx
+++ b/demo/src/containers/Chat/Chat.tsx
@@ -48,7 +48,7 @@ export const Chat = () => {
 
   const handleRemoveReaction = useCallback(() => {
     if (!selectedMessage?.reactions?.mine?.[0]) return;
-    removeReaction(selectedMessage.reactions.mine[0].id);
+    removeReaction(selectedMessage.id, selectedMessage.reactions.mine[0].id);
     setSelectedMessage(null);
     setValue('');
   }, [selectedMessage, removeReaction]);

--- a/demo/src/hooks/useMessages.ts
+++ b/demo/src/hooks/useMessages.ts
@@ -40,8 +40,8 @@ export const useMessages = () => {
   );
 
   const removeReaction = useCallback(
-    (reactionId: string) => {
-      conversation.messages.removeReaction(reactionId);
+    (messageId: string, reactionId: string) => {
+      conversation.messages.removeReaction(messageId, reactionId);
     },
     [conversation],
   );

--- a/src/ChatApi.ts
+++ b/src/ChatApi.ts
@@ -104,8 +104,11 @@ export class ChatApi {
     );
   }
 
-  async deleteMessageReaction(reactionId: string): Promise<void> {
-    await this.makeAuthorisedRequest(`/conversations/v1/reactions/${reactionId}`, 'DELETE');
+  async deleteMessageReaction(conversationId: string, messageId: string, reactionId: string): Promise<void> {
+    await this.makeAuthorisedRequest(
+      `/conversations/v1/conversations/${conversationId}/messages/${messageId}/reactions/${reactionId}`,
+      'DELETE',
+    );
   }
 
   private async makeAuthorisedRequest<RES, REQ = undefined>(

--- a/src/MessageReactions.ts
+++ b/src/MessageReactions.ts
@@ -35,9 +35,9 @@ export class MessageReactions extends EventEmitter<ReactionEventsMap> {
     });
   }
 
-  async remove(reactionId: string) {
+  async remove(messageId: string, reactionId: string) {
     return this.makeApiCallAndWaitForRealtimeResult(ReactionEvents.deleted, async () => {
-      await this.chatApi.deleteMessageReaction(reactionId);
+      await this.chatApi.deleteMessageReaction(this.conversationId, messageId, reactionId);
       return reactionId;
     });
   }

--- a/src/Messages.test.ts
+++ b/src/Messages.test.ts
@@ -339,7 +339,7 @@ describe('Messages', () => {
       vi.spyOn(chatApi, 'deleteMessageReaction').mockResolvedValue(undefined);
 
       const conversation = new Conversation('conversationId', realtime, chatApi);
-      const reactionPromise = conversation.messages.removeReaction('reactionId');
+      const reactionPromise = conversation.messages.removeReaction('messageId', 'reactionId');
 
       context.emulateBackendPublish({
         clientId: 'clientId',
@@ -366,7 +366,7 @@ describe('Messages', () => {
     it<TestContext>('should return reaction if chat backend request come after realtime', async (context) => {
       const { chatApi, realtime } = context;
 
-      vi.spyOn(chatApi, 'deleteMessageReaction').mockImplementation(async (reactionId) => {
+      vi.spyOn(chatApi, 'deleteMessageReaction').mockImplementation(async (conversationId, messageId, reactionId) => {
         context.emulateBackendPublish({
           clientId: 'clientId',
           data: {
@@ -379,7 +379,7 @@ describe('Messages', () => {
       });
 
       const conversation = new Conversation('conversationId', realtime, chatApi);
-      const reaction = await conversation.messages.removeReaction('reactionId');
+      const reaction = await conversation.messages.removeReaction('messageId', 'reactionId');
 
       expect(reaction).toEqual(
         expect.objectContaining({

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -98,8 +98,8 @@ export class Messages extends EventEmitter<MessageEventsMap> {
     return this.reactions.add(messageId, reactionType);
   }
 
-  async removeReaction(reactionId: string) {
-    return this.reactions.remove(reactionId);
+  async removeReaction(messageId: string, reactionId: string) {
+    return this.reactions.remove(messageId, reactionId);
   }
 
   subscribe<K extends keyof MessageEventsMap>(


### PR DESCRIPTION
The internal docs for reaction delete's specification were outdated, so had an old endpoint for this. This change modifies the method signatures so the correct endpoint can be called.