### PR TITLE
demo: dont use chat development cluster

### DIFF
--- a/demo/.env.example
+++ b/demo/.env.example
@@ -1,3 +1,5 @@
-ABLY_API_KEY=
-VITE_ABLY_HOST=eu-west-2-a.primary.chat.cluster.ably-nonprod.net
+# Your Ably API key
+VITE_ABLY_CHAT_API_KEY=
 
+# Optional if you're using a custom domain for Ably
+#VITE_ABLY_HOST=my-personal-domain.ably-realtime.com

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,3 +1,17 @@
-# ChatSDK Demo
+# Chat SDK Demo
 
 An app showcasing the usage of Chat SDK to build chat
+
+## Installation
+
+1. First of all, you need to build the main Chat SDK from the root directory.
+2. Run `npm install`.
+
+## Credential Setup
+
+1. Copy `.env.example` to `.env.` and set the `VITE_ABLY_CHAT_API_KEY` to your Ably API key.
+2. If you're using a custom Ably domain, also set the `VITE_ABLY_HOST` to your custom domain.
+
+## Running
+
+Run `npm run dev`


### PR DESCRIPTION
- Update `.env.example` to remove reference to chat dev cluster, as this is being decommissioned.
- Add information to the README about getting the demo up-and-running.