### PR TITLE
chat/room: rename Room export from RoomController to Room

### DIFF
--- a/demo/src/containers/RoomContext/RoomContext.ts
+++ b/demo/src/containers/RoomContext/RoomContext.ts
@@ -1,9 +1,9 @@
 import { createContext } from 'react';
-import { Chat, RoomController } from '@ably-labs/chat';
+import { Chat, Room } from '@ably-labs/chat';
 
 interface ChatContextProps {
   client: Chat;
-  room: RoomController;
+  room: Room;
 }
 
 export const RoomContext = createContext<ChatContextProps | undefined>(undefined);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { Chat } from './Chat.js';
 export { MessageEvents } from './events.js';
 export type { Message } from './entities.js';
-export type { Room as RoomController } from './Room.js';
+export type { Room } from './Room.js';
 export type { MessageListener } from './Messages.js';


### PR DESCRIPTION
For consistency with the class name and also because it looks odd in typedoc