### PR TITLE
style: convert snake_case to camelCase for type field names

### DIFF
--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -87,11 +87,11 @@ export class Messages extends EventEmitter<MessageEventsMap> {
     const response = await this.chatApi.sendMessage(this.roomId, text);
 
     return {
-      id: response.timeserial,
+      timeserial: response.timeserial,
       content: text,
-      created_by: this.clientId,
-      created_at: response.createdAt,
-      room_id: this.roomId,
+      createdBy: this.clientId,
+      createdAt: response.createdAt,
+      roomId: this.roomId,
     };
   }
 
@@ -212,10 +212,10 @@ export class Messages extends EventEmitter<MessageEventsMap> {
     switch (name) {
       case MessageEvents.created: {
         const message: Message = {
-          id: channelEventMessage.extras.timeserial,
-          created_by: channelEventMessage.clientId!,
-          created_at: channelEventMessage.timestamp!,
-          room_id: this.roomId,
+          timeserial: channelEventMessage.extras.timeserial,
+          createdBy: channelEventMessage.clientId!,
+          createdAt: channelEventMessage.timestamp!,
+          roomId: this.roomId,
           content: data,
         };
         this.emit(MessageEvents.created, { type: name, message: message });

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -1,7 +1,7 @@
 export interface Message {
-  id: string;
-  created_by: string;
-  room_id: string;
+  timeserial: string;
+  createdBy: string;
+  roomId: string;
   content: string;
-  created_at: number;
+  createdAt: number;
 }

--- a/test/Messages.integration.test.ts
+++ b/test/Messages.integration.test.ts
@@ -50,13 +50,13 @@ describe('integration', () => {
       expect(messages).toEqual([
         expect.objectContaining({
           content: 'Hello there!',
-          created_by: defaultTestClientId,
-          id: message1.id,
+          createdBy: defaultTestClientId,
+          timeserial: message1.timeserial,
         }),
         expect.objectContaining({
           content: 'I have the high ground!',
-          created_by: defaultTestClientId,
-          id: message2.id,
+          createdBy: defaultTestClientId,
+          timeserial: message2.timeserial,
         }),
       ]);
     });

--- a/test/Messages.test.ts
+++ b/test/Messages.test.ts
@@ -54,11 +54,11 @@ describe('Messages', () => {
 
       expect(message).toEqual(
         expect.objectContaining({
-          id: 'abcdefghij@1672531200000-123',
+          timeserial: 'abcdefghij@1672531200000-123',
           content: 'hello there',
-          created_by: 'clientId',
-          created_at: timestamp,
-          room_id: 'coffee-room-chat',
+          createdBy: 'clientId',
+          createdAt: timestamp,
+          roomId: 'coffee-room-chat',
         }),
       );
     });
@@ -76,11 +76,11 @@ describe('Messages', () => {
             try {
               expect(message).toEqual(
                 expect.objectContaining({
-                  id: 'abcdefg',
+                  timeserial: 'abcdefg',
                   content: 'may the fourth be with you',
-                  created_by: 'yoda',
-                  created_at: publishTimestamp,
-                  room_id: 'sw',
+                  createdBy: 'yoda',
+                  createdAt: publishTimestamp,
+                  roomId: 'sw',
                 }),
               );
             } catch (err) {


### PR DESCRIPTION
This is consistent with the rest of Ably's API.