### PR TITLE
chat/version: apply agent versioning for analytics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,8 @@
       - The second number represents a minor release, which lets users know new functionality or features have been added.
       - The third number represents a patch release, which represents bug-fixes and may be used when no action should be required from users.
    2. The commit should update `package.json` and `package-lock.json`. Running `npm install` after changing `package.json` will update `package-lock.json`.
-   3. Update the README.md for any references to the new version.
+   3. The commit should also update `version.ts` to set the agent headers.
+   4. Update the README.md for any references to the new version.
 3. Merge the commit into main.
 4. Tag a release using [Github releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release). The version needs to match the one from the commit. Use the "Generate release notes" button to
    add changelog notes and update as required.

--- a/src/Chat.ts
+++ b/src/Chat.ts
@@ -1,20 +1,52 @@
-import Ably from 'ably';
+import { Realtime, Connection } from 'ably';
 import { Rooms } from './Rooms.js';
+import { AGENT_STRING } from './version.js';
+import { RealtimeWithOptions } from './realtimeextensions.js';
 
+/**
+ * This is the core client for Ably chat. It provides access to chat rooms.
+ */
 export class Chat {
-  private readonly realtime: Ably.Realtime;
-  readonly rooms: Rooms;
+  private readonly _realtime: Realtime;
+  private readonly _rooms: Rooms;
 
-  constructor(realtime: Ably.Realtime) {
-    this.realtime = realtime;
-    this.rooms = new Rooms(realtime);
+  constructor(realtime: Realtime) {
+    this._realtime = realtime;
+    this._rooms = new Rooms(realtime);
+    this.setAgent();
   }
 
-  get connection() {
-    return this.realtime.connection;
+  /**
+   * Returns the rooms object, which provides access to chat rooms.
+   *
+   * @returns The rooms object.
+   */
+  get rooms(): Rooms {
+    return this._rooms;
   }
 
-  get clientId() {
-    return this.realtime.auth.clientId;
+  /**
+   * Returns the underlying connection to Ably, which can be used to monitor the clients
+   * connection to Ably servers.
+   *
+   * @returns The connection object.
+   */
+  get connection(): Connection {
+    return this._realtime.connection;
+  }
+
+  /**
+   * Returns the clientId of the current client.
+   *
+   * @returns The clientId.
+   */
+  get clientId(): string {
+    return this._realtime.auth.clientId;
+  }
+
+  private setAgent(): void {
+    const realtime = this._realtime as RealtimeWithOptions;
+    const agent = { chat: AGENT_STRING };
+    realtime.options.agents = { ...(realtime.options.agents ?? realtime.options.agents), ...agent };
   }
 }

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -4,6 +4,7 @@ import { Message } from './entities.js';
 import { MessageEvents } from './events.js';
 import EventEmitter, { inspect, InvalidArgumentError, EventListener } from './utils/EventEmitter.js';
 import { ChatMessage } from './ChatMessage.js';
+import { DEFAULT_CHANNEL_OPTIONS } from './version.js';
 
 interface MessageEventsMap {
   [MessageEvents.created]: MessageEventPayload;
@@ -43,7 +44,7 @@ export type MessageListener = EventListener<MessageEventsMap, keyof MessageEvent
  */
 export class Messages extends EventEmitter<MessageEventsMap> {
   private readonly roomId: string;
-  private readonly channel: Ably.RealtimeChannel;
+  private readonly _channel: Ably.RealtimeChannel;
   private readonly chatApi: ChatApi;
   private readonly clientId: string;
 
@@ -54,7 +55,7 @@ export class Messages extends EventEmitter<MessageEventsMap> {
   constructor(roomId: string, realtime: Ably.Realtime, chatApi: ChatApi, clientId: string) {
     super();
     this.roomId = roomId;
-    this.channel = realtime.channels.get(this.realtimeChannelName);
+    this._channel = realtime.channels.get(this.realtimeChannelName, DEFAULT_CHANNEL_OPTIONS);
     this.chatApi = chatApi;
     this.clientId = clientId;
   }
@@ -65,6 +66,15 @@ export class Messages extends EventEmitter<MessageEventsMap> {
    */
   get realtimeChannelName(): string {
     return `${this.roomId}::$chat::$chatMessages`;
+  }
+
+  /**
+   * Get the underlying Ably realtime channel used for the messages in this chat room.
+   *
+   * @returns The Ably realtime channel.
+   */
+  get channel(): Ably.RealtimeChannel {
+    return this._channel;
   }
 
   // eslint-disable-next-line

--- a/src/realtimeextensions.ts
+++ b/src/realtimeextensions.ts
@@ -1,0 +1,21 @@
+import * as Ably from 'ably';
+
+/**
+ * Exposes the agents option in the Ably Realtime client for typescript.
+ *
+ * @internal
+ */
+export interface RealtimeWithOptions extends Ably.Realtime {
+  options: {
+    agents?: Record<string, string | undefined>;
+  };
+}
+
+/**
+ * Exposes the channelOptions property in the Ably Realtime channel for typescript.
+ *
+ * @internal
+ */
+export interface RealtimeChannelWithOptions extends Ably.RealtimeChannel {
+  channelOptions: Ably.ChannelOptions;
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,6 @@
+// Update this when you release a new version
+const VERSION = '0.0.1';
+const AGENT_STRING = 'chat-js/' + VERSION;
+const DEFAULT_CHANNEL_OPTIONS = { params: { agent: AGENT_STRING } };
+
+export { AGENT_STRING, DEFAULT_CHANNEL_OPTIONS };

--- a/test/Chat.integration.test.ts
+++ b/test/Chat.integration.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { Chat } from '../src/Chat.js';
+import { ablyRealtimeClient } from './helper/realtimeClient.js';
+import { ClientOptions } from 'ably';
+import { RealtimeWithOptions } from '../src/realtimeextensions.js';
+
+interface OptionsWithAgent extends ClientOptions {
+  agents?: Record<string, string | undefined>;
+}
+
+describe('Chat', () => {
+  it('should set the agent string', () => {
+    const options: OptionsWithAgent = {};
+    const realtime = ablyRealtimeClient(options) as RealtimeWithOptions;
+    /* eslint-disable-next-line */
+    const chat = new Chat(realtime);
+
+    expect(realtime.options.agents).toEqual({ chat: 'chat-js/0.0.1' });
+  });
+});

--- a/test/Messages.integration.test.ts
+++ b/test/Messages.integration.test.ts
@@ -3,6 +3,7 @@ import { ablyRealtimeClientWithToken } from './helper/realtimeClient.ts';
 import { Chat } from '../src/Chat.ts';
 import { Message } from '../src/entities.ts';
 import { randomRoomId } from './helper/identifier.ts';
+import { RealtimeChannelWithOptions } from '../src/realtimeextensions.ts';
 
 interface TestContext {
   chat: Chat;
@@ -26,6 +27,16 @@ const waitForMessages = (messages: Message[], expectedCount: number) => {
 describe('messages integration', () => {
   beforeEach<TestContext>((context) => {
     context.chat = new Chat(ablyRealtimeClientWithToken());
+  });
+
+  it<TestContext>('sets the agent version on the channel', async (context) => {
+    const { chat } = context;
+
+    const roomName = Math.random().toString(36).substring(7);
+    const room = chat.rooms.get(roomName);
+    const channel = room.messages.channel as RealtimeChannelWithOptions;
+
+    expect(channel.channelOptions.params).toEqual({ agent: 'chat-js/0.0.1' });
   });
 
   it<TestContext>('should be able to send and receive chat messages', async (context) => {


### PR DESCRIPTION
This change adds agent versioning to the code and adds that version information to the realtime client itself as well as to the messages channel.

Future PRs will need to add this versioning scheme to any other channels used.

[CHA-199]

[CHA-199]: https://ably.atlassian.net/browse/CHA-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ