### PR TITLE
ci: dont run docs job on dependabot pull requests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    if: github.actor != 'dependabot[bot]' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       deployments: write


### PR DESCRIPTION
Dependabot should never update anything that causes the docs to change. Equally, it doesn't have access to the secrets necessary. This change skips the docs job when dependabot is opening PRs, so our process will go green.