### PR TITLE
fix: test race conditions due to shared test context

### DIFF
--- a/test/Presence.integration.test.ts
+++ b/test/Presence.integration.test.ts
@@ -43,208 +43,196 @@ describe('UserPresence', () => {
     });
   }
 
-  describe('When entering presence', async () => {
-    // Test for successful entering with clientId and custom user data
-    it<TestContext>('successfully enter with clientId and custom user data', async (context) => {
-      const enterEventPromise = waitForEvent(
-        context.realtime,
-        'enter',
-        context.chatRoom.messages.realtimeChannelName,
-        (member) => {
-          expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(
-            context.defaultTestClientId,
-          );
-          expect(member.data, 'data should be equal to supplied userCustomData').toEqual(
-            '{"userCustomData":{"customKeyOne":1}}',
-          );
-        },
-      );
-      // Enter with custom user data
-      await context.chatRoom.presence.enter({ customKeyOne: 1 });
-      // Wait for the enter event to be received
-      await enterEventPromise;
-    }, 5000);
+  // Test for successful entering with clientId and custom user data
+  it<TestContext>('successfully enter presence with clientId and custom user data', async (context) => {
+    const enterEventPromise = waitForEvent(
+      context.realtime,
+      'enter',
+      context.chatRoom.messages.realtimeChannelName,
+      (member) => {
+        expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(
+          context.defaultTestClientId,
+        );
+        expect(member.data, 'data should be equal to supplied userCustomData').toEqual(
+          '{"userCustomData":{"customKeyOne":1}}',
+        );
+      },
+    );
+    // Enter with custom user data
+    await context.chatRoom.presence.enter({ customKeyOne: 1 });
+    // Wait for the enter event to be received
+    await enterEventPromise;
+  }, 5000);
+
+  // Test for successful sending of presence update with clientId and custom user data
+  it<TestContext>('should successfully send presence update with clientId and custom user data', async (context) => {
+    const enterEventPromise = waitForEvent(
+      context.realtime,
+      'update',
+      context.chatRoom.messages.realtimeChannelName,
+      (member) => {
+        expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(
+          context.defaultTestClientId,
+        );
+        expect(member.data, 'data should be equal to supplied userCustomData').toEqual(
+          '{"userCustomData":{"customKeyOne":1}}',
+        );
+      },
+    );
+    // Enter with custom user data
+    await context.chatRoom.presence.enter({ customKeyOne: 1 });
+    // Send presence update with custom user data
+    await context.chatRoom.presence.update({ customKeyOne: 1 });
+    // Wait for the update event to be received
+    await enterEventPromise;
+  }, 5000);
+
+  // Test for successful leaving of presence
+  it<TestContext>('should successfully leave presence', async (context) => {
+    const enterEventPromise = waitForEvent(
+      context.realtime,
+      'leave',
+      context.chatRoom.messages.realtimeChannelName,
+      (member) => {
+        expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(
+          context.defaultTestClientId,
+        );
+        expect(member.data, 'data should be equal to supplied userCustomData').toEqual(
+          '{"userCustomData":{"customKeyOne":1}}',
+        );
+      },
+    );
+    // Enter with custom user data
+    await context.chatRoom.presence.enter({ customKeyOne: 1 });
+    // Leave with custom user data
+    await context.chatRoom.presence.leave({ customKeyOne: 1 });
+    // Wait for the leave event to be received
+    await enterEventPromise;
+  }, 5000);
+
+  // Test for successful fetching of presence users
+  it<TestContext>('should successfully fetch presence users ', async (context) => {
+    // Connect 3 clients to the same channel
+    const client1 = ablyRealtimeClient({ clientId: 'clientId1' }).channels.get(
+      context.chatRoom.messages.realtimeChannelName,
+    );
+    const client2 = ablyRealtimeClient({ clientId: 'clientId2' }).channels.get(
+      context.chatRoom.messages.realtimeChannelName,
+    );
+    const client3 = ablyRealtimeClient({ clientId: 'clientId3' }).channels.get(
+      context.chatRoom.messages.realtimeChannelName,
+    );
+
+    // Data payload to check if the custom data is fetched correctly
+    const testData: PresenceData = {
+      userCustomData: { customKeyOne: 1 },
+    };
+
+    // Enter presence for each client
+    await client1.presence.enterClient('clientId1');
+    await client2.presence.enterClient('clientId2', JSON.stringify(testData));
+    await client3.presence.enterClient('clientId3');
+
+    // Check if all clients are present
+    const fetchedPresence = await context.chatRoom.presence.get();
+    // Expect statements
+    expect(fetchedPresence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          clientId: 'clientId1',
+          action: 'present',
+          data: undefined,
+        }),
+        expect.objectContaining({
+          clientId: 'clientId2',
+          action: 'present',
+          data: { customKeyOne: 1 },
+        }),
+        expect.objectContaining({
+          clientId: 'clientId3',
+          action: 'present',
+          data: undefined,
+        }),
+      ]),
+    );
+
+    // Check if clients leaves presence, the clients are no longer present in the fetched list.
+    await client1.presence.leave();
+    await client2.presence.leave();
+    const fetchedPresenceAfterLeave = await context.chatRoom.presence.get();
+    expect(fetchedPresenceAfterLeave, 'fetched presence should not contain clientId3').not.toEqual(
+      expect.arrayContaining([{ clientId: 'clientId3', status: 'present' }]),
+    );
+  }, 5000);
+
+  it<TestContext>('should successfully fetch a single presence user ', async (context) => {
+    // Enter presence for a client
+    await context.chatRoom.presence.enter();
+    // Fetch the presence list and check if the client is present
+    const userIsPresent = await context.chatRoom.presence.userIsPresent(context.defaultTestClientId);
+    expect(userIsPresent, 'user with clientId should be present').toEqual(true);
+    // Ensure that a user that has not entered presence is not present
+    const userIsNotPresent = await context.chatRoom.presence.userIsPresent('clientId2');
+    expect(userIsNotPresent, 'user with clientId1 should not be present').toEqual(false);
   });
 
-  describe('When sending presence updates', async () => {
-    // Test for successful sending of presence update with clientId and custom user data
-    it<TestContext>('should successfully send presence update with clientId and custom user data', async (context) => {
-      const enterEventPromise = waitForEvent(
-        context.realtime,
-        'update',
-        context.chatRoom.messages.realtimeChannelName,
-        (member) => {
-          expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(
-            context.defaultTestClientId,
-          );
-          expect(member.data, 'data should be equal to supplied userCustomData').toEqual(
-            '{"userCustomData":{"customKeyOne":1}}',
-          );
-        },
-      );
-      // Enter with custom user data
-      await context.chatRoom.presence.enter({ customKeyOne: 1 });
-      // Send presence update with custom user data
-      await context.chatRoom.presence.update({ customKeyOne: 1 });
-      // Wait for the update event to be received
-      await enterEventPromise;
-    }, 5000);
-  });
-
-  describe('When leaving presence', async () => {
-    // Test for successful leaving of presence
-    it<TestContext>('should successfully leave presence ', async (context) => {
-      const enterEventPromise = waitForEvent(
-        context.realtime,
-        'leave',
-        context.chatRoom.messages.realtimeChannelName,
-        (member) => {
-          expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(
-            context.defaultTestClientId,
-          );
-          expect(member.data, 'data should be equal to supplied userCustomData').toEqual(
-            '{"userCustomData":{"customKeyOne":1}}',
-          );
-        },
-      );
-      // Enter with custom user data
-      await context.chatRoom.presence.enter({ customKeyOne: 1 });
-      // Leave with custom user data
-      await context.chatRoom.presence.leave({ customKeyOne: 1 });
-      // Wait for the leave event to be received
-      await enterEventPromise;
-    }, 5000);
-  });
-
-  describe('When fetching presence users', () => {
-    // Test for successful fetching of presence users
-    it<TestContext>('should successfully fetch presence users ', async (context) => {
-      // Connect 3 clients to the same channel
-      const client1 = ablyRealtimeClient({ clientId: 'clientId1' }).channels.get(
-        context.chatRoom.messages.realtimeChannelName,
-      );
-      const client2 = ablyRealtimeClient({ clientId: 'clientId2' }).channels.get(
-        context.chatRoom.messages.realtimeChannelName,
-      );
-      const client3 = ablyRealtimeClient({ clientId: 'clientId3' }).channels.get(
-        context.chatRoom.messages.realtimeChannelName,
-      );
-
-      // Data payload to check if the custom data is fetched correctly
-      const testData: PresenceData = {
-        userCustomData: { customKeyOne: 1 },
-      };
-
-      // Enter presence for each client
-      await client1.presence.enterClient('clientId1');
-      await client2.presence.enterClient('clientId2', JSON.stringify(testData));
-      await client3.presence.enterClient('clientId3');
-
-      // Check if all clients are present
-      const fetchedPresence = await context.chatRoom.presence.get();
-      // Expect statements
-      expect(fetchedPresence).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            clientId: 'clientId1',
-            action: 'present',
-            data: undefined,
-          }),
-          expect.objectContaining({
-            clientId: 'clientId2',
-            action: 'present',
-            data: { customKeyOne: 1 },
-          }),
-          expect.objectContaining({
-            clientId: 'clientId3',
-            action: 'present',
-            data: undefined,
-          }),
-        ]),
-      );
-
-      // Check if clients leaves presence, the clients are no longer present in the fetched list.
-      await client1.presence.leave();
-      await client2.presence.leave();
-      const fetchedPresenceAfterLeave = await context.chatRoom.presence.get();
-      expect(fetchedPresenceAfterLeave, 'fetched presence should not contain clientId3').not.toEqual(
-        expect.arrayContaining([{ clientId: 'clientId3', status: 'present' }]),
-      );
-    }, 5000);
-  });
-
-  describe('When fetching a single presence user', () => {
-    it<TestContext>('should successfully fetch a single presence user ', async (context) => {
-      // Enter presence for a client
-      await context.chatRoom.presence.enter();
-      // Fetch the presence list and check if the client is present
-      const userIsPresent = await context.chatRoom.presence.userIsPresent(context.defaultTestClientId);
-      expect(userIsPresent, 'user with clientId should be present').toEqual(true);
-      // Ensure that a user that has not entered presence is not present
-      const userIsNotPresent = await context.chatRoom.presence.userIsPresent('clientId2');
-      expect(userIsNotPresent, 'user with clientId1 should not be present').toEqual(false);
-    });
-  });
-
-  describe('When subscribing to presence events', () => {
-    // Test for successful subscription to enter events
-    it<TestContext>('should successfully subscribe to enter events ', async (context) => {
-      // Subscribe to enter events
-      let presenceEvent: PresenceEvent;
-      const enterEventPromise = new Promise<void>((resolve) => {
-        context.chatRoom.presence.subscribe(PresenceEvents.enter, (member) => {
-          presenceEvent = member;
-          resolve();
-        });
+  // Test for successful subscription to enter events
+  it<TestContext>('should successfully subscribe to enter events ', async (context) => {
+    // Subscribe to enter events
+    let presenceEvent: PresenceEvent;
+    const enterEventPromise = new Promise<void>((resolve) => {
+      context.chatRoom.presence.subscribe(PresenceEvents.enter, (member) => {
+        presenceEvent = member;
+        resolve();
       });
-      // Enter presence to trigger the enter event
-      await context.chatRoom.presence.enter({ customKeyOne: 1 });
-      // Wait for the enter event to be received
-      await enterEventPromise;
-      expect(presenceEvent.clientId, 'client id should be equal to defaultTestClientId').toEqual(
-        context.defaultTestClientId,
-      );
-      expect(presenceEvent.data, 'data should be equal to supplied userCustomData').toEqual({ customKeyOne: 1 });
     });
+    // Enter presence to trigger the enter event
+    await context.chatRoom.presence.enter({ customKeyOne: 1 });
+    // Wait for the enter event to be received
+    await enterEventPromise;
+    expect(presenceEvent.clientId, 'client id should be equal to defaultTestClientId').toEqual(
+      context.defaultTestClientId,
+    );
+    expect(presenceEvent.data, 'data should be equal to supplied userCustomData').toEqual({ customKeyOne: 1 });
+  });
 
-    it<TestContext>('should successfully subscribe to update events ', async (context) => {
-      // Subscribe to update events
-      let presenceEvent: PresenceEvent;
-      const updateEventPromise = new Promise<void>((resolve) => {
-        context.chatRoom.presence.subscribe(PresenceEvents.update, (member) => {
-          presenceEvent = member;
-          resolve();
-        });
+  it<TestContext>('should successfully subscribe to update events ', async (context) => {
+    // Subscribe to update events
+    let presenceEvent: PresenceEvent;
+    const updateEventPromise = new Promise<void>((resolve) => {
+      context.chatRoom.presence.subscribe(PresenceEvents.update, (member) => {
+        presenceEvent = member;
+        resolve();
       });
-      // Enter presence and update presence to trigger the update event
-      await context.chatRoom.presence.enter();
-      await context.chatRoom.presence.update({ customKeyOne: 1 });
-      // Wait for the update event to be received
-      await updateEventPromise;
-      expect(presenceEvent.data, 'data should be equal to supplied userCustomData').toEqual({ customKeyOne: 1 });
-      expect(presenceEvent.clientId, 'client id should be equal to defaultTestClientId').toEqual(
-        context.defaultTestClientId,
-      );
     });
+    // Enter presence and update presence to trigger the update event
+    await context.chatRoom.presence.enter();
+    await context.chatRoom.presence.update({ customKeyOne: 1 });
+    // Wait for the update event to be received
+    await updateEventPromise;
+    expect(presenceEvent.data, 'data should be equal to supplied userCustomData').toEqual({ customKeyOne: 1 });
+    expect(presenceEvent.clientId, 'client id should be equal to defaultTestClientId').toEqual(
+      context.defaultTestClientId,
+    );
+  });
 
-    it<TestContext>('should successfully subscribe to leave events ', async (context) => {
-      // Subscribe to leave events
-      let presenceEvent: PresenceEvent;
-      const leaveEventPromise = new Promise<void>((resolve) => {
-        context.chatRoom.presence.subscribe(PresenceEvents.leave, (member) => {
-          presenceEvent = member;
-          resolve();
-        });
+  it<TestContext>('should successfully subscribe to leave events ', async (context) => {
+    // Subscribe to leave events
+    let presenceEvent: PresenceEvent;
+    const leaveEventPromise = new Promise<void>((resolve) => {
+      context.chatRoom.presence.subscribe(PresenceEvents.leave, (member) => {
+        presenceEvent = member;
+        resolve();
       });
-      // Enter presence and leave presence to trigger the leave event
-      await context.chatRoom.presence.enter();
-      await context.chatRoom.presence.leave({ customKeyOne: 1 });
-      // Wait for the leave event to be received
-      await leaveEventPromise;
-      expect(presenceEvent.clientId, 'client id should be equal to defaultTestClientId').toEqual(
-        context.defaultTestClientId,
-      );
-      expect(presenceEvent.data, 'data should be equal to supplied userCustomData').toEqual({ customKeyOne: 1 });
     });
+    // Enter presence and leave presence to trigger the leave event
+    await context.chatRoom.presence.enter();
+    await context.chatRoom.presence.leave({ customKeyOne: 1 });
+    // Wait for the leave event to be received
+    await leaveEventPromise;
+    expect(presenceEvent.clientId, 'client id should be equal to defaultTestClientId').toEqual(
+      context.defaultTestClientId,
+    );
+    expect(presenceEvent.data, 'data should be equal to supplied userCustomData').toEqual({ customKeyOne: 1 });
   });
 });

--- a/test/SubscriptionManager.test.ts
+++ b/test/SubscriptionManager.test.ts
@@ -246,99 +246,94 @@ describe('subscription manager', () => {
       await waitForChannelStateChange(channel, 'detached');
     },
   );
-  describe('When entering presence', async () => {
-    it<TestContext>('should attach to the channel', async (context) => {
-      const { channel, subscriptionManager } = context;
-      // sending an enter should implicitly attach the channel
-      await subscriptionManager.presenceEnterClient(context.defaultClientId);
-      await waitForChannelStateChange(channel, 'attached');
-    });
-    it<TestContext>('should emit an enter event with supplied data', async (context) => {
-      const receivedMessages: PresenceMessage[] = [];
-      const listener = (message) => {
-        receivedMessages.push(message);
-      };
-      // subscribe to presence events
-      await context.subscriptionManager.presenceSubscribe(listener);
-      // enter presence and wait for the event
-      await context.subscriptionManager.presenceEnterClient(context.defaultClientId, 'test-data');
-      // should receive one enter event
-      await waitForMessages(receivedMessages, 1);
-      expect(receivedMessages[0].action).toBe('enter');
-      expect(receivedMessages[0].data).toBe('test-data');
-    });
+  it<TestContext>('should attach to the channel when entering presence', async (context) => {
+    const { channel, subscriptionManager } = context;
+    // sending an enter should implicitly attach the channel
+    await subscriptionManager.presenceEnterClient(context.defaultClientId);
+    await waitForChannelStateChange(channel, 'attached');
   });
-  describe('When updating presence', async () => {
-    it<TestContext>('should attach to the channel', async (context) => {
-      const { channel, subscriptionManager } = context;
-      // sending an update should implicitly attach the channel
-      await subscriptionManager.presenceUpdateClient(context.defaultClientId);
-      await waitForChannelStateChange(channel, 'attached');
-    });
-    it<TestContext>('should emit an event enter when joining for the first time', async (context) => {
-      const receivedMessages: PresenceMessage[] = [];
-      const listener = (message) => {
-        receivedMessages.push(message);
-      };
-      // subscribe to presence events
-      await context.subscriptionManager.presenceSubscribe(listener);
-      // update presence, triggering an enter event
-      await context.subscriptionManager.presenceUpdateClient(context.defaultClientId, 'test-data');
-      // should receive one enter event
-      await waitForMessages(receivedMessages, 1);
-      expect(receivedMessages[0].action).toBe('enter');
-      expect(receivedMessages[0].data).toBe('test-data');
-    });
-    it<TestContext>('should emit an event update event when already in joined', async (context) => {
-      const receivedMessages: PresenceMessage[] = [];
-      const listener = (message) => {
-        receivedMessages.push(message);
-      };
-      // Join presence first
-      await context.subscriptionManager.presenceEnterClient(context.defaultClientId);
-      // subscribe to presence events
-      await context.subscriptionManager.presenceSubscribe(listener);
-      // update presence and wait for the event
-      await context.subscriptionManager.presenceUpdateClient(context.defaultClientId, 'test-data');
-      // should receive one enter event
-      await waitForMessages(receivedMessages, 1);
-      expect(receivedMessages[0].action).toBe('update');
-      expect(receivedMessages[0].data).toBe('test-data');
-    });
+  it<TestContext>('should emit an enter event with supplied data when entering presence', async (context) => {
+    const receivedMessages: PresenceMessage[] = [];
+    const listener = (message) => {
+      receivedMessages.push(message);
+    };
+    // subscribe to presence events
+    await context.subscriptionManager.presenceSubscribe(listener);
+    // enter presence and wait for the event
+    await context.subscriptionManager.presenceEnterClient(context.defaultClientId, 'test-data');
+    // should receive one enter event
+    await waitForMessages(receivedMessages, 1);
+    expect(receivedMessages[0].action).toBe('enter');
+    expect(receivedMessages[0].data).toBe('test-data');
   });
-  describe('When leaving presence', async () => {
-    it<TestContext>('should detach from the channel if no listeners are subscribed', async (context) => {
-      const { channel, subscriptionManager } = context;
-      // sending an enter should implicitly attach the channel
-      await subscriptionManager.presenceEnterClient(context.defaultClientId);
+  it<TestContext>('should attach to the channel when updating presence', async (context) => {
+    const { channel, subscriptionManager } = context;
+    // sending an update should implicitly attach the channel
+    await subscriptionManager.presenceUpdateClient(context.defaultClientId);
+    await waitForChannelStateChange(channel, 'attached');
+  });
+  it<TestContext>('should emit an event enter when joining for the first time', async (context) => {
+    const receivedMessages: PresenceMessage[] = [];
+    const listener = (message) => {
+      receivedMessages.push(message);
+    };
+    // subscribe to presence events
+    await context.subscriptionManager.presenceSubscribe(listener);
+    // update presence, triggering an enter event
+    await context.subscriptionManager.presenceUpdateClient(context.defaultClientId, 'test-data');
+    // should receive one enter event
+    await waitForMessages(receivedMessages, 1);
+    expect(receivedMessages[0].action).toBe('enter');
+    expect(receivedMessages[0].data).toBe('test-data');
+  });
+  it<TestContext>('should emit an update event if already enter presence', async (context) => {
+    const receivedMessages: PresenceMessage[] = [];
+    const listener = (message) => {
+      receivedMessages.push(message);
+    };
+    // Join presence first
+    await context.subscriptionManager.presenceEnterClient(context.defaultClientId);
+    // subscribe to presence events
+    await context.subscriptionManager.presenceSubscribe(listener);
+    // update presence and wait for the event
+    await context.subscriptionManager.presenceUpdateClient(context.defaultClientId, 'test-data');
+    // should receive one enter event
+    await waitForMessages(receivedMessages, 1);
+    expect(receivedMessages[0].action).toBe('update');
+    expect(receivedMessages[0].data).toBe('test-data');
+  });
 
-      // trigger a leave event and detach from the channel
-      await subscriptionManager.presenceLeaveClient(context.defaultClientId);
-      await waitForChannelStateChange(channel, 'detached');
-    });
-    it<TestContext>('should not detach from the channel if listeners are still subscribed', async (context) => {
-      const { channel, subscriptionManager } = context;
-      // Add a listener, which implicitly attaches, should prevent the channel from detaching during the leave event
-      await subscriptionManager.presenceSubscribe(() => {});
-      // trigger a leave event
-      await subscriptionManager.presenceLeaveClient(context.defaultClientId);
-      // should not detach from the channel
-      await assertNoChannelStateChange(channel, 'detached');
-    });
+  it<TestContext>('should leave presence and detach from the channel if no listeners are subscribed', async (context) => {
+    const { channel, subscriptionManager } = context;
+    // sending an enter should implicitly attach the channel
+    await subscriptionManager.presenceEnterClient(context.defaultClientId);
 
-    it<TestContext>('should emit a leave event with supplied data', async (context) => {
-      const receivedMessages: PresenceMessage[] = [];
-      const listener = (message) => {
-        receivedMessages.push(message);
-      };
-      // subscribe to presence events
-      await context.subscriptionManager.presenceSubscribe(listener);
-      // enter presence and wait for the event
-      await context.subscriptionManager.presenceLeaveClient(context.defaultClientId, 'test-data');
-      // should receive one enter event
-      await waitForMessages(receivedMessages, 1);
-      expect(receivedMessages[0].action).toBe('leave');
-      expect(receivedMessages[0].data).toBe('test-data');
-    });
+    // trigger a leave event and detach from the channel
+    await subscriptionManager.presenceLeaveClient(context.defaultClientId);
+    await waitForChannelStateChange(channel, 'detached');
+  });
+  it<TestContext>('should leave presence, but not detach from the channel if listeners are still subscribed', async (context) => {
+    const { channel, subscriptionManager } = context;
+    // Add a listener, which implicitly attaches, should prevent the channel from detaching during the leave event
+    await subscriptionManager.presenceSubscribe(() => {});
+    // trigger a leave event
+    await subscriptionManager.presenceLeaveClient(context.defaultClientId);
+    // should not detach from the channel
+    await assertNoChannelStateChange(channel, 'detached');
+  });
+
+  it<TestContext>('should emit a leave event with supplied data when leaving presence', async (context) => {
+    const receivedMessages: PresenceMessage[] = [];
+    const listener = (message) => {
+      receivedMessages.push(message);
+    };
+    // subscribe to presence events
+    await context.subscriptionManager.presenceSubscribe(listener);
+    // enter presence and wait for the event
+    await context.subscriptionManager.presenceLeaveClient(context.defaultClientId, 'test-data');
+    // should receive one enter event
+    await waitForMessages(receivedMessages, 1);
+    expect(receivedMessages[0].action).toBe('leave');
+    expect(receivedMessages[0].data).toBe('test-data');
   });
 });


### PR DESCRIPTION
Race condition on subscription tests caused by other tests re-using the same context, and thus the same channel, still having present members. This caused the tests to fail in CI infrequently due to receiving unexpected `Present` events. I've also removed the nesting of the presence tests as the potential for race conditions exists there too.

- Removed nesting of tests in both SubscriptionManager tests and Presence.integration tests