### PR TITLE
Adding a PR Template To The Repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+### Context
+
+* Provide name of JIRA ticket that this PR is related to (if applicable).
+    * e.g. [CHA-101] - this will automatically link the PR to the JIRA ticket.
+* Provide names of any related DRs (if applicable).
+* Provide links to any related PRs
+
+### Description
+
+* Describe the changes introduced in this PR
+* Provide relevant context or considerations for reviewers.
+    * Such as why the changes are necessary,
+      or how they affect the system.
+
+### Checklist
+
+* [ ] QA'd by the author.
+* [ ] Unit tests created (if applicable).
+* [ ] Integration tests created (if applicable).
+* [ ] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
+* [ ] TypeDoc updated (if applicable).
+* [ ] (Optional) Update documentation for new features.
+
+### Testing Instructions (Optional)
+
+* Explain how to test the changes in this PR.
+* Provide specific steps or commands to execute.


### PR DESCRIPTION
**Description:**

As part of the chat retro this sprint, we decided to implement a basic PR template, this should help standardise our PR's a bit. It can be added to as we need, and is also a guide NOT a requirement.