### PR TITLE
Make all imports of ably the same

### DIFF
--- a/__mocks__/ably/index.ts
+++ b/__mocks__/ably/index.ts
@@ -1,4 +1,4 @@
-import Ably from 'ably';
+import * as Ably from 'ably';
 
 const MOCK_CLIENT_ID = 'MOCK_CLIENT_ID';
 

--- a/demo/api/ably-token-request/index.ts
+++ b/demo/api/ably-token-request/index.ts
@@ -1,5 +1,5 @@
 import * as dotenv from 'dotenv';
-import Ably from 'ably'
+import * as Ably from 'ably';
 import { HandlerEvent } from '@netlify/functions';
 
 dotenv.config();

--- a/demo/src/main.tsx
+++ b/demo/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import Ably from 'ably'
+import * as Ably from 'ably';
 import { Chat } from '@ably-labs/chat';
 import { nanoid } from 'nanoid';
 import App from './App.tsx';

--- a/src/Chat.ts
+++ b/src/Chat.ts
@@ -1,4 +1,4 @@
-import { Realtime, Connection } from 'ably';
+import * as Ably from 'ably';
 import { Rooms } from './Rooms.js';
 import { AGENT_STRING } from './version.js';
 import { RealtimeWithOptions } from './realtimeextensions.js';
@@ -8,10 +8,10 @@ import { ClientOptions } from './config.js';
  * This is the core client for Ably chat. It provides access to chat rooms.
  */
 export class Chat {
-  private readonly _realtime: Realtime;
+  private readonly _realtime: Ably.Realtime;
   private readonly _rooms: Rooms;
 
-  constructor(realtime: Realtime, clientOptions?: ClientOptions) {
+  constructor(realtime: Ably.Realtime, clientOptions?: ClientOptions) {
     this._realtime = realtime;
     this._rooms = new Rooms(realtime, clientOptions);
     this.setAgent();
@@ -32,7 +32,7 @@ export class Chat {
    *
    * @returns The connection object.
    */
-  get connection(): Connection {
+  get connection(): Ably.Connection {
     return this._realtime.connection;
   }
 

--- a/src/ChatApi.ts
+++ b/src/ChatApi.ts
@@ -1,6 +1,6 @@
 import { OccupancyEvent } from './Occupancy.js';
 import { Message } from './entities.js';
-import { Realtime, ErrorInfo } from 'ably';
+import * as Ably from 'ably';
 import { PaginatedResult } from './query.js';
 
 export interface GetMessagesQueryParams {
@@ -23,9 +23,9 @@ interface CreateMessageRequest {
  * Chat SDK Backend
  */
 export class ChatApi {
-  private readonly realtime: Realtime;
+  private readonly realtime: Ably.Realtime;
 
-  constructor(realtime: Realtime) {
+  constructor(realtime: Ably.Realtime) {
     this.realtime = realtime;
   }
 
@@ -53,7 +53,7 @@ export class ChatApi {
     body?: REQ,
   ): Promise<RES> {
     const response = await this.realtime.request(method, url, 1.1, {}, body);
-    if (!response.success) throw new ErrorInfo(response.errorMessage, response.errorCode, response.statusCode);
+    if (!response.success) throw new Ably.ErrorInfo(response.errorMessage, response.errorCode, response.statusCode);
     const [result] = response.items;
     return result as RES;
   }
@@ -64,7 +64,7 @@ export class ChatApi {
     body?: REQ,
   ): Promise<PaginatedResult<RES>> {
     const response = await this.realtime.request('GET', url, 1.1, params, body);
-    if (!response.success) throw new ErrorInfo(response.errorMessage, response.errorCode, response.statusCode);
+    if (!response.success) throw new Ably.ErrorInfo(response.errorMessage, response.errorCode, response.statusCode);
     return response;
   }
 }

--- a/src/Presence.ts
+++ b/src/Presence.ts
@@ -1,4 +1,4 @@
-import Ably, { PresenceMessage as AblyPresenceMessage, RealtimePresenceParams } from 'ably';
+import * as Ably from 'ably';
 import { PresenceEvents } from './events.js';
 import EventEmitter, { EventListener } from './utils/EventEmitter.js';
 import { SubscriptionManager } from './SubscriptionManager.js';
@@ -89,7 +89,7 @@ export class Presence extends EventEmitter<PresenceEventsMap> {
    * Method to get list of the current online users and returns the latest presence messages associated to it.
    * @returns {Promise<PresenceMessage[]>} or upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
    */
-  async get(params?: RealtimePresenceParams): Promise<PresenceMember[]> {
+  async get(params?: Ably.RealtimePresenceParams): Promise<PresenceMember[]> {
     const userOnPresence = await this.subscriptionManager.channel.presence.get(params);
     return userOnPresence.map((user) => ({
       clientId: user.clientId,
@@ -218,7 +218,7 @@ export class Presence extends EventEmitter<PresenceEventsMap> {
    * @returns void - Emits a transformed event to all subscribers, or upon failure,
    * the promise will be rejected with an {@link ErrorInfo} object which explains the error.
    */
-  subscribeToEvents = (member: AblyPresenceMessage) => {
+  subscribeToEvents = (member: Ably.PresenceMessage) => {
     try {
       const parsedData = JSON.parse(member.data);
       this.emit(PresenceEvents[member.action], {

--- a/src/Room.ts
+++ b/src/Room.ts
@@ -1,4 +1,4 @@
-import Ably from 'ably';
+import * as Ably from 'ably';
 import { ChatApi } from './ChatApi.js';
 import { Messages, DefaultMessages } from './Messages.js';
 import { Presence } from './Presence.js';

--- a/src/RoomReactions.ts
+++ b/src/RoomReactions.ts
@@ -1,4 +1,4 @@
-import Ably from 'ably';
+import * as Ably from 'ably';
 import { SubscriptionManager } from './SubscriptionManager.js';
 import EventEmitter from './utils/EventEmitter.js';
 import { RoomReactionEvents } from './events.js';

--- a/src/Rooms.ts
+++ b/src/Rooms.ts
@@ -1,4 +1,4 @@
-import Ably from 'ably';
+import * as Ably from 'ably';
 import { ChatApi } from './ChatApi.js';
 import { Room } from './Room.js';
 import { ClientOptions, DefaultClientOptions } from './config.js';

--- a/src/TypingIndicator.ts
+++ b/src/TypingIndicator.ts
@@ -1,6 +1,6 @@
 import EventEmitter from './utils/EventEmitter.js';
 import { TypingIndicatorEvents } from './events.js';
-import Ably, { PresenceMessage, RealtimeChannel } from 'ably';
+import * as Ably from 'ably';
 import { DEFAULT_CHANNEL_OPTIONS } from './version.js';
 import { DefaultSubscriptionManager, SubscriptionManager } from './SubscriptionManager.js';
 
@@ -69,7 +69,7 @@ export interface TypingIndicators {
    * Get the name of the realtime channel underpinning typing indicators.
    * @returns The name of the realtime channel.
    */
-  channel: RealtimeChannel;
+  channel: Ably.RealtimeChannel;
 }
 
 /**
@@ -135,7 +135,7 @@ export class DefaultTypingIndicator extends EventEmitter<TypingIndicatorEventsMa
   /**
    * @inheritdoc TypingIndicators
    */
-  get channel(): RealtimeChannel {
+  get channel(): Ably.RealtimeChannel {
     return this._managedChannel.channel;
   }
 
@@ -203,7 +203,7 @@ export class DefaultTypingIndicator extends EventEmitter<TypingIndicatorEventsMa
    * Subscribe to internal events. This will listen to presence events and convert them into associated typing events,
    * while also updating the currentlyTypingClientIds set.
    */
-  private readonly _internalSubscribeToEvents = (member: PresenceMessage) => {
+  private readonly _internalSubscribeToEvents = (member: Ably.PresenceMessage) => {
     switch (member.action) {
       case 'enter':
       case 'present':

--- a/test/SubscriptionManager.test.ts
+++ b/test/SubscriptionManager.test.ts
@@ -1,18 +1,18 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { Message, PresenceMessage, RealtimeChannel } from 'ably';
+import * as Ably from 'ably';
 import { ablyRealtimeClient } from './helper/realtimeClient.ts';
 import { DefaultSubscriptionManager } from '../src/SubscriptionManager.ts';
 import { randomString } from './helper/identifier.ts';
 
 interface TestContext {
-  channel: RealtimeChannel;
-  publishChannel: RealtimeChannel;
+  channel: Ably.RealtimeChannel;
+  publishChannel: Ably.RealtimeChannel;
   subscriptionManager: DefaultSubscriptionManager;
   defaultClientId: string;
 }
 
 // Wait for the messages to be received
-const waitForMessages = (messages: Message[], expectedCount: number) => {
+const waitForMessages = (messages: Ably.Message[], expectedCount: number) => {
   return new Promise<void>((resolve, reject) => {
     const interval = setInterval(() => {
       if (messages.length === expectedCount) {
@@ -73,7 +73,7 @@ describe('subscription manager', () => {
   it<TestContext>('subscribes to channel with implicit attach', async (context) => {
     const { channel, publishChannel, subscriptionManager } = context;
 
-    const receivedMessages: Message[] = [];
+    const receivedMessages: Ably.Message[] = [];
     const listener = (message) => {
       receivedMessages.push(message);
     };
@@ -93,7 +93,7 @@ describe('subscription manager', () => {
   it<TestContext>('subscribes to channel with implicit attach on all events', async (context) => {
     const { channel, publishChannel, subscriptionManager } = context;
 
-    const receivedMessages: Message[] = [];
+    const receivedMessages: Ably.Message[] = [];
     const listener = (message) => {
       receivedMessages.push(message);
     };
@@ -115,7 +115,7 @@ describe('subscription manager', () => {
   it<TestContext>('subscribes to channel with implicit attach on presence all events', async (context) => {
     const { channel, publishChannel, subscriptionManager } = context;
 
-    const receivedMessages: PresenceMessage[] = [];
+    const receivedMessages: Ably.PresenceMessage[] = [];
     const listener = (message) => {
       receivedMessages.push(message);
     };
@@ -133,7 +133,7 @@ describe('subscription manager', () => {
   it<TestContext>('subscribes to channel with implicit attach on presence select events', async (context) => {
     const { channel, publishChannel, subscriptionManager } = context;
 
-    const receivedMessages: PresenceMessage[] = [];
+    const receivedMessages: Ably.PresenceMessage[] = [];
     const listener = (message) => {
       receivedMessages.push(message);
     };
@@ -253,7 +253,7 @@ describe('subscription manager', () => {
     await waitForChannelStateChange(channel, 'attached');
   });
   it<TestContext>('should emit an enter event with supplied data when entering presence', async (context) => {
-    const receivedMessages: PresenceMessage[] = [];
+    const receivedMessages: Ably.PresenceMessage[] = [];
     const listener = (message) => {
       receivedMessages.push(message);
     };
@@ -273,7 +273,7 @@ describe('subscription manager', () => {
     await waitForChannelStateChange(channel, 'attached');
   });
   it<TestContext>('should emit an event enter when joining for the first time', async (context) => {
-    const receivedMessages: PresenceMessage[] = [];
+    const receivedMessages: Ably.PresenceMessage[] = [];
     const listener = (message) => {
       receivedMessages.push(message);
     };
@@ -287,7 +287,7 @@ describe('subscription manager', () => {
     expect(receivedMessages[0].data).toBe('test-data');
   });
   it<TestContext>('should emit an update event if already enter presence', async (context) => {
-    const receivedMessages: PresenceMessage[] = [];
+    const receivedMessages: Ably.PresenceMessage[] = [];
     const listener = (message) => {
       receivedMessages.push(message);
     };
@@ -323,7 +323,7 @@ describe('subscription manager', () => {
   });
 
   it<TestContext>('should emit a leave event with supplied data when leaving presence', async (context) => {
-    const receivedMessages: PresenceMessage[] = [];
+    const receivedMessages: Ably.PresenceMessage[] = [];
     const listener = (message) => {
       receivedMessages.push(message);
     };


### PR DESCRIPTION
The import is now consistently

    import * as Ably from 'ably';

[CHA-288]


[CHA-288]: https://ably.atlassian.net/browse/CHA-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ