### PR TITLE
Fix - Enforce MessageEvent Subscription in DefaultMessages

### DIFF
--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -88,6 +88,7 @@ enum MessagesInternalState {
  * @param event The message event that was received.
  */
 export type MessageListener = (event: MessageEventPayload) => void;
+
 /**
  * This class is used to interact with messages in a chat room including subscribing
  * to them, fetching history, or sending messages.
@@ -284,7 +285,7 @@ export class DefaultMessages extends EventEmitter<MessageEventsMap> implements M
   private async doAttach(channelHandler: Ably.messageCallback<Ably.InboundMessage>) {
     const unsubscribeFromChannel = () => this.channel.unsubscribe(channelHandler);
     this.unsubscribeFromChannel = unsubscribeFromChannel;
-    await this.channel.subscribe(channelHandler);
+    await this.channel.subscribe(Object.values(MessageEvents), channelHandler);
 
     if (this.unsubscribeFromChannel !== unsubscribeFromChannel) return;
 

--- a/test/Messages.test.ts
+++ b/test/Messages.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, vi, it, expect } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as Ably from 'ably';
 import { ChatApi } from '../src/ChatApi.js';
 import { DefaultRoom } from '../src/Room.js';
@@ -23,13 +23,14 @@ describe('Messages', () => {
     vi.spyOn(channel, 'subscribe').mockImplementation(
       // @ts-ignore
       async (
-        nameOrListener: string | Ably.messageCallback<Ably.Message>,
+        eventsOrListeners: Array<string> | Ably.messageCallback<Ably.Message>,
         listener: Ably.messageCallback<Ably.Message>,
       ) => {
-        if (typeof nameOrListener === 'string') {
+        if (Array.isArray(eventsOrListeners)) {
+          expect(eventsOrListeners, 'array should only contain MessageEvents').toEqual(Object.values(MessageEvents));
           listeners.push(listener);
         } else {
-          listeners.push(nameOrListener);
+          listeners.push(eventsOrListeners);
         }
         // @ts-ignore
         context.emulateBackendPublish = (msg) => {


### PR DESCRIPTION
Due to the fact we use the same underlying channel for occupancy and chat messages, we were receiving occupancy events in the chat message class listeners and throwing since it is not a supported message type here.

- Updated the chat message processEvent function to noop events of type '[meta]occupancy'.