### PR TITLE
style: enforce import and export soring in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,8 +9,8 @@ module.exports = {
   parserOptions: {
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint', 'security', 'jsdoc', 'import'],
-  extends: ['eslint:recommended', 'plugin:security/recommended-legacy'],
+  plugins: ['@typescript-eslint', 'security', 'jsdoc', 'import', 'simple-import-sort'],
+  extends: ['eslint:recommended', 'plugin:security/recommended-legacy', 'plugin:import/recommended'],
   rules: {
     'eol-last': 'error',
     // security/detect-object-injection just gives a lot of false positives
@@ -18,12 +18,15 @@ module.exports = {
     'security/detect-object-injection': 'off',
     // the code problem checked by this ESLint rule is automatically checked by the TypeScript compiler
     'no-redeclare': 'off',
+    'simple-import-sort/imports': 'error',
+    'simple-import-sort/exports': 'error',
   },
   overrides: [
     {
       files: ['**/*.{ts,tsx}'],
       rules: {
         '@typescript-eslint/no-unused-vars': ['error'],
+        'import/no-unresolved': 'off',
         // TypeScript already enforces these rules better than any eslint setup can
         'no-undef': 'off',
         'no-dupe-class-members': 'off',

--- a/__mocks__/ably/index.ts
+++ b/__mocks__/ably/index.ts
@@ -85,4 +85,4 @@ class MockRealtime {
 
 class MockErrorInfo extends Ably.ErrorInfo {}
 
-export { MockRealtime as Realtime, MockErrorInfo as ErrorInfo };
+export { MockErrorInfo as ErrorInfo,MockRealtime as Realtime };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.7",
         "eslint-plugin-security": "^3.0.0",
+        "eslint-plugin-simple-import-sort": "^12.1.0",
         "jsonwebtoken": "^9.0.2",
         "prettier": "^3.3.1",
         "typedoc": "^0.25.13",
@@ -2352,6 +2353,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.0.tgz",
+      "integrity": "sha512-Y2fqAfC11TcG/WP3TrI1Gi3p3nc8XJyEOJYHyEPEGI/UAgNx6akxxlX74p7SbAQdLcgASKhj8M0GKvH3vq/+ig==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",
     "eslint-plugin-security": "^3.0.0",
+    "eslint-plugin-simple-import-sort": "^12.1.0",
     "jsonwebtoken": "^9.0.2",
     "prettier": "^3.3.1",
     "typedoc": "^0.25.13",

--- a/src/Chat.ts
+++ b/src/Chat.ts
@@ -1,8 +1,9 @@
 import * as Ably from 'ably';
-import { Rooms, DefaultRooms } from './Rooms.js';
-import { AGENT_STRING } from './version.js';
-import { RealtimeWithOptions } from './realtimeextensions.js';
+
 import { ClientOptions } from './config.js';
+import { RealtimeWithOptions } from './realtimeextensions.js';
+import { DefaultRooms, Rooms } from './Rooms.js';
+import { AGENT_STRING } from './version.js';
 
 /**
  * This is the core client for Ably chat. It provides access to chat rooms.

--- a/src/ChatApi.ts
+++ b/src/ChatApi.ts
@@ -1,6 +1,7 @@
-import { OccupancyEvent } from './Occupancy.js';
-import { Message } from './Message.js';
 import * as Ably from 'ably';
+
+import { Message } from './Message.js';
+import { OccupancyEvent } from './Occupancy.js';
 import { PaginatedResult } from './query.js';
 
 export interface GetMessagesQueryParams {

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -1,10 +1,11 @@
 import * as Ably from 'ably';
+
 import { ChatApi } from './ChatApi.js';
 import { MessageEvents } from './events.js';
-import EventEmitter, { inspect, InvalidArgumentError, EventListener } from './utils/EventEmitter.js';
-import { Message, DefaultMessage } from './Message.js';
-import { SubscriptionManager } from './SubscriptionManager.js';
+import { DefaultMessage, Message } from './Message.js';
 import { PaginatedResult } from './query.js';
+import { SubscriptionManager } from './SubscriptionManager.js';
+import EventEmitter, { EventListener, inspect, InvalidArgumentError } from './utils/EventEmitter.js';
 
 interface MessageEventsMap {
   [MessageEvents.created]: MessageEventPayload;

--- a/src/Occupancy.ts
+++ b/src/Occupancy.ts
@@ -1,7 +1,8 @@
 import * as Ably from 'ably';
-import EventEmitter from './utils/EventEmitter.js';
-import { SubscriptionManager } from './SubscriptionManager.js';
+
 import { ChatApi } from './ChatApi.js';
+import { SubscriptionManager } from './SubscriptionManager.js';
+import EventEmitter from './utils/EventEmitter.js';
 
 /**
  * Represents the occupancy (number of connections, publishers, and subscribers) of a chat room.

--- a/src/Presence.ts
+++ b/src/Presence.ts
@@ -1,7 +1,8 @@
 import * as Ably from 'ably';
+
 import { PresenceEvents } from './events.js';
-import EventEmitter from './utils/EventEmitter.js';
 import { SubscriptionManager } from './SubscriptionManager.js';
+import EventEmitter from './utils/EventEmitter.js';
 
 /**
  * Interface for PresenceEventsMap

--- a/src/Room.ts
+++ b/src/Room.ts
@@ -1,13 +1,14 @@
 import * as Ably from 'ably';
+
 import { ChatApi } from './ChatApi.js';
-import { DefaultMessages, Messages } from './Messages.js';
-import { DefaultPresence, Presence } from './Presence.js';
-import { DefaultSubscriptionManager } from './SubscriptionManager.js';
-import { DEFAULT_CHANNEL_OPTIONS } from './version.js';
-import { DefaultTypingIndicator, TypingIndicators } from './TypingIndicator.js';
-import { DefaultOccupancy, Occupancy } from './Occupancy.js';
 import { ClientOptions } from './config.js';
+import { DefaultMessages, Messages } from './Messages.js';
+import { DefaultOccupancy, Occupancy } from './Occupancy.js';
+import { DefaultPresence, Presence } from './Presence.js';
 import { DefaultRoomReactions, RoomReactions } from './RoomReactions.js';
+import { DefaultSubscriptionManager } from './SubscriptionManager.js';
+import { DefaultTypingIndicator, TypingIndicators } from './TypingIndicator.js';
+import { DEFAULT_CHANNEL_OPTIONS } from './version.js';
 
 /**
  * Represents a chat room.

--- a/src/RoomReactions.ts
+++ b/src/RoomReactions.ts
@@ -1,7 +1,8 @@
 import * as Ably from 'ably';
+
+import { RoomReactionEvents } from './events.js';
 import { SubscriptionManager } from './SubscriptionManager.js';
 import EventEmitter from './utils/EventEmitter.js';
-import { RoomReactionEvents } from './events.js';
 
 /**
  * Represents a room-level reaction.

--- a/src/Rooms.ts
+++ b/src/Rooms.ts
@@ -1,7 +1,8 @@
 import * as Ably from 'ably';
+
 import { ChatApi } from './ChatApi.js';
-import { DefaultRoom, Room } from './Room.js';
 import { ClientOptions, DefaultClientOptions } from './config.js';
+import { DefaultRoom, Room } from './Room.js';
 
 /**
  * Manages the lifecycle of chat rooms.

--- a/src/TypingIndicator.ts
+++ b/src/TypingIndicator.ts
@@ -1,8 +1,9 @@
-import EventEmitter from './utils/EventEmitter.js';
-import { TypingIndicatorEvents } from './events.js';
 import * as Ably from 'ably';
-import { DEFAULT_CHANNEL_OPTIONS } from './version.js';
+
+import { TypingIndicatorEvents } from './events.js';
 import { DefaultSubscriptionManager, SubscriptionManager } from './SubscriptionManager.js';
+import EventEmitter from './utils/EventEmitter.js';
+import { DEFAULT_CHANNEL_OPTIONS } from './version.js';
 
 /**
  * Represents the typing indicator events mapped to their respective event payloads.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,20 @@
 export { ChatClient } from './Chat.js';
+export type { ClientOptions, DefaultClientOptions } from './config.js';
+export type { ErrorInfo } from './errors.js';
 export { MessageEvents, PresenceEvents } from './events.js';
 export type { Message } from './Message.js';
-export type { Room } from './Room.js';
-export type { Rooms } from './Rooms.js';
+export type { Direction, MessageEventPayload, MessageListener, Messages, QueryOptions } from './Messages.js';
+export type { Occupancy, OccupancyEvent, OccupancyListener } from './Occupancy.js';
 export type {
   Presence,
+  PresenceData,
   PresenceEvent,
   PresenceListener,
   PresenceMember,
-  PresenceData,
   PresenceParams,
 } from './Presence.js';
-export type { TypingIndicators, TypingIndicatorEvent, TypingListener } from './TypingIndicator.js';
-export type { ClientOptions, DefaultClientOptions } from './config.js';
-export type { Messages, MessageListener, QueryOptions, Direction, MessageEventPayload } from './Messages.js';
 export type { PaginatedResult } from './query.js';
-export type { Reaction, RoomReactions, RoomReactionListener } from './RoomReactions.js';
-export type { Occupancy, OccupancyEvent, OccupancyListener } from './Occupancy.js';
-export type { ErrorInfo } from './errors.js';
+export type { Room } from './Room.js';
+export type { Reaction, RoomReactionListener, RoomReactions } from './RoomReactions.js';
+export type { Rooms } from './Rooms.js';
+export type { TypingIndicatorEvent, TypingIndicators, TypingListener } from './TypingIndicator.js';

--- a/test/Chat.integration.test.ts
+++ b/test/Chat.integration.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { ChatClient } from '../src/Chat.js';
-import { ablyRealtimeClient } from './helper/realtimeClient.js';
 import { ClientOptions } from 'ably';
+import { describe, expect, it } from 'vitest';
+
+import { ChatClient } from '../src/Chat.js';
 import { RealtimeWithOptions } from '../src/realtimeextensions.js';
+import { ablyRealtimeClient } from './helper/realtimeClient.js';
 
 interface OptionsWithAgent extends ClientOptions {
   agents?: Record<string, string | undefined>;

--- a/test/Message.test.ts
+++ b/test/Message.test.ts
@@ -1,5 +1,6 @@
+import { describe, expect, it } from 'vitest';
+
 import { DefaultMessage } from '../src/Message.js';
-import { describe, it, expect } from 'vitest';
 
 describe('ChatMessage', () => {
   it('is the same as another message', () => {

--- a/test/Messages.integration.test.ts
+++ b/test/Messages.integration.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, it, expect } from 'vitest';
-import { ablyRealtimeClientWithToken } from './helper/realtimeClient.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { ChatClient } from '../src/Chat.ts';
 import { Message } from '../src/entities.ts';
-import { randomRoomId } from './helper/identifier.ts';
 import { RealtimeChannelWithOptions } from '../src/realtimeextensions.ts';
+import { randomRoomId } from './helper/identifier.ts';
+import { ablyRealtimeClientWithToken } from './helper/realtimeClient.ts';
 
 interface TestContext {
   chat: ChatClient;

--- a/test/Messages.test.ts
+++ b/test/Messages.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as Ably from 'ably';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { ChatApi } from '../src/ChatApi.js';
-import { DefaultRoom } from '../src/Room.js';
 import { MessageEvents } from '../src/events.js';
+import { DefaultRoom } from '../src/Room.js';
 import { randomRoomId } from './helper/identifier.js';
 
 interface TestContext {

--- a/test/Occupancy.integration.test.ts
+++ b/test/Occupancy.integration.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, it } from 'vitest';
-import { ablyRealtimeClientWithToken } from './helper/realtimeClient.js';
+
 import { ChatClient } from '../src/Chat.js';
-import { randomRoomId } from './helper/identifier.js';
-import { Room } from '../src/Room.js';
 import { OccupancyEvent } from '../src/Occupancy.js';
+import { Room } from '../src/Room.js';
+import { randomRoomId } from './helper/identifier.js';
+import { ablyRealtimeClientWithToken } from './helper/realtimeClient.js';
 
 interface TestContext {
   chat: ChatClient;

--- a/test/Occupany.test.ts
+++ b/test/Occupany.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, vi, it, expect } from 'vitest';
 import * as Ably from 'ably';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { ChatApi } from '../src/ChatApi.js';
+import { OccupancyEvent } from '../src/Occupancy.js';
 import { DefaultRoom } from '../src/Room.js';
 import { randomRoomId } from './helper/identifier.js';
-import { OccupancyEvent } from '../src/Occupancy.js';
 import { ablyRealtimeClient } from './helper/realtimeClient.js';
 
 interface TestContext {

--- a/test/Presence.integration.test.ts
+++ b/test/Presence.integration.test.ts
@@ -1,13 +1,14 @@
 // Import necessary modules and dependencies
-import { PresenceData, PresenceEvent } from '../src/Presence.js';
 import * as Ably from 'ably';
 import { PresenceAction, Realtime } from 'ably';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { ablyRealtimeClient } from './helper/realtimeClient.js';
+
 import { PresenceEvents } from '../src/events.js';
+import { PresenceData, PresenceEvent } from '../src/Presence.js';
 import { Room } from '../src/Room.js';
-import { Rooms, DefaultRooms } from '../src/Rooms.js';
+import { DefaultRooms, Rooms } from '../src/Rooms.js';
 import { randomRoomId } from './helper/identifier.js';
+import { ablyRealtimeClient } from './helper/realtimeClient.js';
 
 // Define the test context interface
 interface TestContext {

--- a/test/RoomReactions.integration.test.ts
+++ b/test/RoomReactions.integration.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, it, expect } from 'vitest';
-import { ablyRealtimeClientWithToken } from './helper/realtimeClient.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { ChatClient } from '../src/Chat.ts';
-import { randomRoomId } from './helper/identifier.ts';
 import { RealtimeChannelWithOptions } from '../src/realtimeextensions.ts';
 import { Reaction } from '../src/RoomReactions.ts';
+import { randomRoomId } from './helper/identifier.ts';
+import { ablyRealtimeClientWithToken } from './helper/realtimeClient.ts';
 
 interface TestContext {
   chat: ChatClient;

--- a/test/RoomReactions.test.ts
+++ b/test/RoomReactions.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, vi, it, expect } from 'vitest';
 import * as Ably from 'ably';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { ChatApi } from '../src/ChatApi.js';
-import { DefaultRoom } from '../src/Room.js';
 import { DefaultClientOptions } from '../src/config.js';
+import { DefaultRoom } from '../src/Room.js';
 
 interface TestContext {
   realtime: Ably.Realtime;

--- a/test/SubscriptionManager.test.ts
+++ b/test/SubscriptionManager.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it } from 'vitest';
 import * as Ably from 'ably';
-import { ablyRealtimeClient } from './helper/realtimeClient.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { DefaultSubscriptionManager } from '../src/SubscriptionManager.ts';
 import { randomString } from './helper/identifier.ts';
+import { ablyRealtimeClient } from './helper/realtimeClient.ts';
 
 interface TestContext {
   channel: Ably.RealtimeChannel;

--- a/test/TypingIndicators.integration.test.ts
+++ b/test/TypingIndicators.integration.test.ts
@@ -1,11 +1,12 @@
 // Import necessary modules and dependencies
 import * as Ably from 'ably';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { ablyRealtimeClient } from './helper/realtimeClient.js';
+
 import { Room } from '../src/Room.js';
 import { DefaultRooms, Rooms } from '../src/Rooms.js';
-import { randomClientId, randomRoomId } from './helper/identifier.js';
 import { TypingIndicatorEvent } from '../src/TypingIndicator.js';
+import { randomClientId, randomRoomId } from './helper/identifier.js';
+import { ablyRealtimeClient } from './helper/realtimeClient.js';
 
 const TEST_TIMEOUT = 10000;
 

--- a/test/TypingIndicators.test.ts
+++ b/test/TypingIndicators.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as Ably from 'ably';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatClient } from '../src/Chat.js';
 import { Room } from '../src/Room.js';
 import { randomRoomId } from './helper/identifier.js';
-import { ChatClient } from '../src/Chat.js';
 
 interface TestContext {
   realtime: Ably.Realtime;

--- a/test/helper/realtimeClient.ts
+++ b/test/helper/realtimeClient.ts
@@ -1,5 +1,6 @@
 import * as Ably from 'ably';
 import * as jwt from 'jsonwebtoken';
+
 import { ablyApiKey, isLocalEnvironment, testEnvironment } from './environment.js';
 import { randomClientId } from './identifier.js';
 

--- a/test/utils/EventEmitter.test.ts
+++ b/test/utils/EventEmitter.test.ts
@@ -1,5 +1,6 @@
 // todo EventEmitter has been copied from @ably/spaces, it's better to move it in separate library
-import { it, describe, expect, beforeEach, afterEach, vi, Mock } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
 import EventEmitter, { removeListener } from '../../src/utils/EventEmitter.js';
 
 describe('removeListener', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, configDefaults } from 'vitest/config'
+import { configDefaults, defineConfig } from 'vitest/config'
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
Enables the import plugin to enforce that we order our imports in certain groups.

Also enables a simple sorting plugin to ensure our imports are alphabetically named.

### Context

[CHA-287]

### Description

Enables the import plugin to enforce that we order our imports in certain groups (e.g. externals first, then siblings, then imports etc.

Also enables a simple sorting plugin to ensure our imports are alphabetically ordered.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

### Testing Instructions (Optional)

Not applicable.


[CHA-287]: https://ably.atlassian.net/browse/CHA-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ