### PR TITLE
reactions: remove method to get realtime channel name directly

### DIFF
--- a/src/RoomReactions.ts
+++ b/src/RoomReactions.ts
@@ -80,9 +80,6 @@ export interface RoomReactions {
    */
   unsubscribe(listener: RoomReactionListener): Promise<void>;
 
-  /** Returns the full name of the Ably realtime channel used for room-level reactions. */
-  get realtimeChannelName(): string;
-
   /**
    * Returns an instance of the Ably realtime channel used for room-level reactions.
    * Avoid using this directly unless special features that cannot otherwise be implemented are needed.
@@ -161,10 +158,6 @@ export class DefaultRoomReactions extends EventEmitter<RoomReactionEventsMap> im
       return this.onLastUnsubscribe();
     }
     return Promise.resolve();
-  }
-
-  get realtimeChannelName(): string {
-    return this._managedChannel.channel.name;
   }
 
   get channel(): Ably.RealtimeChannel {


### PR DESCRIPTION
### Context

This can be achieved by using the `name` property on the channel object directly and is the pattern we use elsewhere.

### Description

- Removes the `realtimeChannelName` method from room reactions.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

### Testing Instructions (Optional)

N/A.