### PR TITLE
options: make typing timeout optional, add mixin logic

### DIFF
--- a/demo/src/main.tsx
+++ b/demo/src/main.tsx
@@ -35,7 +35,7 @@ const ablyClient = new Ably.Realtime({
 //   clientId,
 // })
 
-const chatClient = new ChatClient(ablyClient, {logLevel: LogLevel.debug, typingTimeoutMs: 5000});
+const chatClient = new ChatClient(ablyClient, {logLevel: LogLevel.debug });
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/Chat.ts
+++ b/src/Chat.ts
@@ -1,6 +1,6 @@
 import * as Ably from 'ably';
 
-import { ClientOptions, DefaultClientOptions } from './config.js';
+import { ClientOptions, normaliseClientOptions, NormalisedClientOptions } from './config.js';
 import { makeLogger } from './logger.js';
 import { RealtimeWithOptions } from './realtimeextensions.js';
 import { DefaultRooms, Rooms } from './Rooms.js';
@@ -21,16 +21,21 @@ export class ChatClient {
   private readonly _rooms: Rooms;
 
   /**
+   * @internal
+   */
+  private readonly _clientOptions: NormalisedClientOptions;
+
+  /**
    * Constructor for Chat
    * @param realtime - The Ably Realtime client.
    * @param clientOptions - The client options.
    */
   constructor(realtime: Ably.Realtime, clientOptions?: ClientOptions) {
     this._realtime = realtime;
-    clientOptions = clientOptions ?? DefaultClientOptions;
-    const logger = makeLogger(clientOptions);
+    this._clientOptions = normaliseClientOptions(clientOptions);
+    const logger = makeLogger(this._clientOptions);
 
-    this._rooms = new DefaultRooms(realtime, clientOptions, logger);
+    this._rooms = new DefaultRooms(realtime, this._clientOptions, logger);
     this.setAgent();
     logger.trace(`ably chat client version ${VERSION}; initialised`);
   }
@@ -69,6 +74,14 @@ export class ChatClient {
    */
   get realtime(): Ably.Realtime {
     return this._realtime;
+  }
+
+  /**
+   * Returns the resolved client options for the client, including any defaults that have been set.
+   * @returns The client options.
+   */
+  get clientOptions(): ClientOptions {
+    return this._clientOptions;
   }
 
   /**

--- a/src/Room.ts
+++ b/src/Room.ts
@@ -1,7 +1,7 @@
 import * as Ably from 'ably';
 
 import { ChatApi } from './ChatApi.js';
-import { ClientOptions } from './config.js';
+import { NormalisedClientOptions } from './config.js';
 import { Logger } from './logger.js';
 import { DefaultMessages, Messages } from './Messages.js';
 import { DefaultOccupancy, Occupancy } from './Occupancy.js';
@@ -75,7 +75,13 @@ export class DefaultRoom implements Room {
    * @param chatApi An instance of the ChatApi.
    * @param clientOptions The client options from the chat instance.
    */
-  constructor(roomId: string, realtime: Ably.Realtime, chatApi: ChatApi, clientOptions: ClientOptions, logger: Logger) {
+  constructor(
+    roomId: string,
+    realtime: Ably.Realtime,
+    chatApi: ChatApi,
+    clientOptions: NormalisedClientOptions,
+    logger: Logger,
+  ) {
     this._roomId = roomId;
     this.chatApi = chatApi;
     const messagesChannelName = `${this._roomId}::$chat::$chatMessages`;

--- a/src/Rooms.ts
+++ b/src/Rooms.ts
@@ -1,7 +1,7 @@
 import * as Ably from 'ably';
 
 import { ChatApi } from './ChatApi.js';
-import { ClientOptions } from './config.js';
+import { ClientOptions, NormalisedClientOptions } from './config.js';
 import { Logger } from './logger.js';
 import { DefaultRoom, Room } from './Room.js';
 
@@ -44,7 +44,7 @@ export interface Rooms {
 export class DefaultRooms implements Rooms {
   private readonly realtime: Ably.Realtime;
   private readonly chatApi: ChatApi;
-  private readonly _clientOptions: ClientOptions;
+  private readonly _clientOptions: NormalisedClientOptions;
   private rooms: Record<string, Room> = {};
   private _logger: Logger;
 
@@ -54,7 +54,7 @@ export class DefaultRooms implements Rooms {
    * @param realtime An instance of the Ably Realtime client.
    * @param clientOptions The client options from the chat instance.
    */
-  constructor(realtime: Ably.Realtime, clientOptions: ClientOptions, logger: Logger) {
+  constructor(realtime: Ably.Realtime, clientOptions: NormalisedClientOptions, logger: Logger) {
     this.realtime = realtime;
     this.chatApi = new ChatApi(realtime, logger);
     this._clientOptions = clientOptions;

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ export interface ClientOptions {
    * The time in milliseconds after which the client will emit a stopped typing event, if the user has not typed anything.
    * @defaultValue 3000
    */
-  typingTimeoutMs: number;
+  typingTimeoutMs?: number;
 
   /**
    * A custom log handler that will be used to log messages from the client.
@@ -26,7 +26,34 @@ export interface ClientOptions {
 /**
  * Default configuration options for the chat client.
  */
-export const DefaultClientOptions: ClientOptions = {
+const defaultClientOptions = {
   typingTimeoutMs: 3000,
   logLevel: LogLevel.error,
+};
+
+/**
+ * This type is used to modify the properties of one type with the properties of another type and thus
+ * can be used to turn clientoptions into normalised client options.
+ */
+type Modify<T, R> = Omit<T, keyof R> & R;
+
+/**
+ * These are the normalised client options, with default values filled in for any missing properties.
+ */
+export type NormalisedClientOptions = Modify<
+  ClientOptions,
+  {
+    typingTimeoutMs: number;
+    logLevel: LogLevel;
+  }
+>;
+
+export const normaliseClientOptions = (options?: ClientOptions): NormalisedClientOptions => {
+  options = options ?? {};
+
+  return {
+    ...options,
+    typingTimeoutMs: options.typingTimeoutMs ?? defaultClientOptions.typingTimeoutMs,
+    logLevel: options.logLevel ?? defaultClientOptions.logLevel,
+  };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { ChatClient } from './Chat.js';
-export type { ClientOptions, DefaultClientOptions } from './config.js';
+export type { ClientOptions } from './config.js';
 export { MessageEvents, PresenceEvents } from './events.js';
 export type { LogContext, LogHandler } from './logger.js';
 export { LogLevel } from './logger.js';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,4 @@
-import { ClientOptions } from './config.js';
+import { NormalisedClientOptions } from './config.js';
 
 /**
  * Interface for loggers.
@@ -124,11 +124,10 @@ const consoleLogger = (message: string, level: LogLevel, context?: LogContext) =
   }
 };
 
-export const makeLogger = (options: ClientOptions): Logger => {
-  const logLevel = options.logLevel || LogLevel.error;
+export const makeLogger = (options: NormalisedClientOptions): Logger => {
   const logHandler = options.logHandler || consoleLogger;
 
-  return new DefaultLogger(logHandler, logLevel);
+  return new DefaultLogger(logHandler, options.logLevel);
 };
 
 /**

--- a/test/Chat.integration.test.ts
+++ b/test/Chat.integration.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
-import { DefaultClientOptions } from '../src/config.js';
 import { RealtimeWithOptions } from '../src/realtimeextensions.js';
 import { newChatClient } from './helper/chat.js';
+import { testClientOptions } from './helper/options.js';
 
 describe('Chat', () => {
   it('should set the agent string', () => {
-    const chat = newChatClient(DefaultClientOptions);
+    const chat = newChatClient(testClientOptions());
     expect((chat.realtime as RealtimeWithOptions).options.agents).toEqual({ chat: 'chat-js/0.0.1' });
+  });
+
+  it('should mix in the client options', () => {
+    const chat = newChatClient(testClientOptions({ typingTimeoutMs: 1000 }));
+    expect(chat.clientOptions.typingTimeoutMs).toBe(1000);
   });
 });

--- a/test/Messages.test.ts
+++ b/test/Messages.test.ts
@@ -6,6 +6,7 @@ import { MessageEvents } from '../src/events.js';
 import { DefaultRoom } from '../src/Room.js';
 import { randomRoomId } from './helper/identifier.js';
 import { makeTestLogger } from './helper/logger.js';
+import { testClientOptions } from './helper/options.js';
 
 interface TestContext {
   realtime: Ably.Realtime;
@@ -18,7 +19,7 @@ vi.mock('ably');
 
 // Helper function to create a room
 const makeRoom = (context: TestContext) =>
-  new DefaultRoom(randomRoomId(), context.realtime, context.chatApi, { typingTimeoutMs: 1000 }, makeTestLogger());
+  new DefaultRoom(randomRoomId(), context.realtime, context.chatApi, testClientOptions(), makeTestLogger());
 
 describe('Messages', () => {
   beforeEach<TestContext>((context) => {

--- a/test/Occupany.test.ts
+++ b/test/Occupany.test.ts
@@ -6,6 +6,7 @@ import { OccupancyEvent } from '../src/Occupancy.js';
 import { DefaultRoom } from '../src/Room.js';
 import { randomRoomId } from './helper/identifier.js';
 import { makeTestLogger } from './helper/logger.js';
+import { testClientOptions } from './helper/options.js';
 
 interface TestContext {
   realtime: Ably.Realtime;
@@ -20,7 +21,7 @@ vi.mock('ably');
 
 // Helper function to create a room
 const makeRoom = (context: TestContext) =>
-  new DefaultRoom(context.roomId, context.realtime, context.chatApi, { typingTimeoutMs: 1000 }, makeTestLogger());
+  new DefaultRoom(context.roomId, context.realtime, context.chatApi, testClientOptions(), makeTestLogger());
 
 describe('Occupancy', () => {
   beforeEach<TestContext>((context) => {

--- a/test/Presence.integration.test.ts
+++ b/test/Presence.integration.test.ts
@@ -3,13 +3,13 @@ import * as Ably from 'ably';
 import { PresenceAction, Realtime } from 'ably';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { DefaultClientOptions } from '../src/config.js';
 import { PresenceEvents } from '../src/events.js';
 import { PresenceData, PresenceEvent } from '../src/Presence.js';
 import { Room } from '../src/Room.js';
 import { DefaultRooms, Rooms } from '../src/Rooms.js';
 import { randomRoomId } from './helper/identifier.js';
 import { makeTestLogger } from './helper/logger.js';
+import { testClientOptions } from './helper/options.js';
 import { ablyRealtimeClient } from './helper/realtimeClient.js';
 
 // Define the test context interface
@@ -25,7 +25,7 @@ describe('UserPresence', { timeout: 10000 }, () => {
   beforeEach<TestContext>(async (context) => {
     context.realtime = ablyRealtimeClient();
     const roomId = randomRoomId();
-    context.chat = new DefaultRooms(context.realtime, DefaultClientOptions, makeTestLogger());
+    context.chat = new DefaultRooms(context.realtime, testClientOptions(), makeTestLogger());
     context.defaultTestClientId = context.realtime.auth.clientId;
     context.chatRoom = context.chat.get(roomId);
   });

--- a/test/RoomReactions.test.ts
+++ b/test/RoomReactions.test.ts
@@ -2,9 +2,9 @@ import * as Ably from 'ably';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatApi } from '../src/ChatApi.js';
-import { DefaultClientOptions } from '../src/config.js';
 import { DefaultRoom } from '../src/Room.js';
 import { makeTestLogger } from './helper/logger.js';
+import { testClientOptions } from './helper/options.js';
 
 interface TestContext {
   realtime: Ably.Realtime;
@@ -67,7 +67,7 @@ describe('Reactions', () => {
       new Promise<void>((done, reject) => {
         const publishTimestamp = new Date().getTime();
         const { chatApi, realtime } = context;
-        const room = new DefaultRoom('abcd', realtime, chatApi, DefaultClientOptions, makeTestLogger());
+        const room = new DefaultRoom('abcd', realtime, chatApi, testClientOptions(), makeTestLogger());
 
         room.reactions
           .subscribe((reaction) => {
@@ -104,7 +104,7 @@ describe('Reactions', () => {
       new Promise<void>((done, reject) => {
         const publishTimestamp = new Date().getTime();
         const { chatApi, realtime } = context;
-        const room = new DefaultRoom('abcd', realtime, chatApi, DefaultClientOptions, makeTestLogger());
+        const room = new DefaultRoom('abcd', realtime, chatApi, testClientOptions(), makeTestLogger());
 
         room.reactions
           .subscribe((reaction) => {
@@ -142,7 +142,7 @@ describe('Reactions', () => {
     it<TestContext>('should be able to send a reaction and see it back on the realtime channel', (context) =>
       new Promise<void>((done, reject) => {
         const { chatApi, realtime } = context;
-        const room = new DefaultRoom('abcd', realtime, chatApi, DefaultClientOptions, makeTestLogger());
+        const room = new DefaultRoom('abcd', realtime, chatApi, testClientOptions(), makeTestLogger());
 
         room.reactions
           .subscribe((reaction) => {

--- a/test/helper/chat.ts
+++ b/test/helper/chat.ts
@@ -1,14 +1,16 @@
 import Ably from 'ably';
 
 import { ChatClient } from '../../src/Chat.js';
-import { ClientOptions, DefaultClientOptions } from '../../src/config.js';
+import { ClientOptions, normaliseClientOptions } from '../../src/config.js';
 import { testLoggingLevel } from './logger.js';
 import { ablyRealtimeClientWithToken } from './realtimeClient.js';
 
 export const newChatClient = (options?: ClientOptions, realtimeClient?: Ably.Realtime): ChatClient => {
-  options = options ?? DefaultClientOptions;
-  options.logLevel = options.logLevel ?? testLoggingLevel();
+  const normalisedOptions = normaliseClientOptions({
+    ...options,
+    logLevel: testLoggingLevel(),
+  });
   realtimeClient = realtimeClient ?? ablyRealtimeClientWithToken();
 
-  return new ChatClient(realtimeClient, options);
+  return new ChatClient(realtimeClient, normalisedOptions);
 };

--- a/test/helper/logger.ts
+++ b/test/helper/logger.ts
@@ -1,9 +1,14 @@
+import { normaliseClientOptions } from '../../src/config.js';
 import { Logger, LogLevel, makeLogger } from '../../src/logger.js';
 
 // makeTestLogger creates a logger that logs at the level specified by the VITE_TEST_LOG_LEVEL environment variable.
 export const makeTestLogger = (): Logger => {
-  return makeLogger({ logLevel: testLoggingLevel(), typingTimeoutMs: 1000 });
+  return makeLogger(
+    normaliseClientOptions({
+      logLevel: testLoggingLevel(),
+    }),
+  );
 };
 
 // testLoggingLevel returns the log level specified by the VITE_TEST_LOG_LEVEL environment variable.
-export const testLoggingLevel = (): LogLevel => process.env.VITE_TEST_LOG_LEVEL as LogLevel;
+export const testLoggingLevel = (): LogLevel | undefined => (process.env.VITE_TEST_LOG_LEVEL as LogLevel) ?? undefined;

--- a/test/helper/options.ts
+++ b/test/helper/options.ts
@@ -1,0 +1,12 @@
+import { ClientOptions, normaliseClientOptions, NormalisedClientOptions } from '../../src/config.js';
+import { LogLevel } from '../../src/logger.js';
+
+const defaults: NormalisedClientOptions = {
+  typingTimeoutMs: 5000,
+  logLevel: LogLevel.error,
+};
+
+export const testClientOptions = (options?: ClientOptions): NormalisedClientOptions => {
+  options = options ?? defaults;
+  return normaliseClientOptions(options);
+};

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { DefaultClientOptions } from '../src/config.js';
+import { normaliseClientOptions } from '../src/config.js';
 import { LogContext, LogLevel, makeLogger } from '../src/logger.js';
 
 const defaultLogContext = { contextKey: 'contextValue' };
@@ -27,14 +27,15 @@ describe('logger', () => {
     `logs %s when configured level %s`,
     (logLevel: LogLevel, configuredLevel: LogLevel, logContext?: LogContext) =>
       new Promise((done, reject) => {
-        const options = DefaultClientOptions;
-        options.logLevel = configuredLevel;
-        options.logHandler = (message: string, level: LogLevel, context?: LogContext) => {
-          expect(message).toBe('test');
-          expect(level).toBe(logLevel);
-          expect(context).toEqual(logContext);
-          done();
-        };
+        const options = normaliseClientOptions({
+          logLevel: configuredLevel,
+          logHandler: (message: string, level: LogLevel, context?: LogContext) => {
+            expect(message).toBe('test');
+            expect(level).toBe(logLevel);
+            expect(context).toEqual(logContext);
+            done();
+          },
+        });
 
         const logger = makeLogger(options);
         logger[logLevel]('test', logContext);
@@ -62,11 +63,12 @@ describe('logger', () => {
     'does not log below the log level',
     (configuredLevel: LogLevel, logLevel: LogLevel) =>
       new Promise((done, reject) => {
-        const options = DefaultClientOptions;
-        options.logLevel = configuredLevel;
-        options.logHandler = () => {
-          reject('Expected logHandler to not be called');
-        };
+        const options = normaliseClientOptions({
+          logLevel: configuredLevel,
+          logHandler: () => {
+            reject('Expected logHandler to not be called');
+          },
+        });
 
         const logger = makeLogger(options);
         logger[logLevel]('test');


### PR DESCRIPTION
### Context

[CHA-301]

### Description

Makes the typing timeout field of client options optional, so it doesn't have to be specified when options are provided.

Also adds in logic to mixin the defaults and return a more concrete type for use around the rest of the codebase, that ensures type safety.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

### Testing Instructions (Optional)

Pass in client options to `Chat` without typing timeout, observe that there are no typing errors. Also observe that the `ClientOptions` returned resolve typing timeout to the default.


[CHA-101]: https://ably.atlassian.net/browse/CHA-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CHA-301]: https://ably.atlassian.net/browse/CHA-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ