### PR TITLE
auth: add smoke test for chat with basic auth

### DIFF
--- a/test/Chat.integration.test.ts
+++ b/test/Chat.integration.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { RealtimeWithOptions } from '../src/realtimeextensions.js';
 import { newChatClient } from './helper/chat.js';
 import { testClientOptions } from './helper/options.js';
+import { ablyRealtimeClient } from './helper/realtimeClient.js';
 
 describe('Chat', () => {
   it('should set the agent string', () => {
@@ -13,5 +14,18 @@ describe('Chat', () => {
   it('should mix in the client options', () => {
     const chat = newChatClient(testClientOptions({ typingTimeoutMs: 1000 }));
     expect(chat.clientOptions.typingTimeoutMs).toBe(1000);
+  });
+
+  it('should work using basic auth', async () => {
+    const chat = newChatClient(undefined, ablyRealtimeClient({}));
+
+    // Send a message, and expect it to succeed
+    await chat.rooms.get('test').messages.send('my message');
+
+    // Request occupancy, and expect it to succeed
+    await chat.rooms.get('test').occupancy.get();
+
+    // Request history, and expect it to succeed
+    await chat.rooms.get('test').messages.query({ limit: 1 });
   });
 });


### PR DESCRIPTION
### Context

[CHA-319]

### Description

- Add a test that checks we can use chat with basic auth, as a smoke test for any potential issues.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

### Testing Instructions (Optional)

Run the test!


[CHA-319]: https://ably.atlassian.net/browse/CHA-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ