### PR TITLE
dependabot: reduce update frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,15 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily" # weekdays (Monday to Friday)
+      interval: "monthly"
     labels: [ ] # prevent the default `dependencies` label from being added to pull requests
   - package-ecosystem: "npm"
     directory: "/demo/"
     schedule:
-      interval: "daily" # weekdays (Monday to Friday)
+      interval: "monthly"
     labels: [ ] # prevent the default `dependencies` label from being added to pull requests
   - package-ecosystem: "npm"
     directory: "/demo/api/ably-token-request"
     schedule:
-      interval: "daily" # weekdays (Monday to Friday)
+      interval: "monthly"
     labels: [ ] # prevent the default `dependencies` label from being added to pull requests


### PR DESCRIPTION
### Description

Reduces the frequency to monthly, to reduce the spam.

Doesn't affect security updates, which will happen as-and-when.