### PR TITLE
Add a link to the typedoc in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The **Chat SDK** offers a seamless and customizable API designed to facilitate d
 in-app conversations scenarios, encompassing live comments, in-app chat functionalities,
 and the management of real-time updates and user interactions.
 
+[Read the API docs here](https://sdk.ably.com/builds/ably-labs/ably-chat-js/main/typedoc/)
+
 ## Prerequisites
 
 To start using this SDK, you will need the following:


### PR DESCRIPTION
### Context

Add a link to the typedoc in readme. For now it's to the main branch docs but I think after release this should be a link to the latest released version.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [ x Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.