### PR TITLE
Make the chat demo app use production Ably by default

### DIFF
--- a/demo/src/main.tsx
+++ b/demo/src/main.tsx
@@ -30,8 +30,8 @@ const clientId = function(){
 
 const ablyClient = new Ably.Realtime({
   authUrl: `/api/ably-token-request?clientId=${clientId}`,
-  restHost: import.meta.env.VITE_ABLY_HOST,
-  realtimeHost: import.meta.env.VITE_ABLY_HOST,
+  restHost: import.meta?.env?.VITE_ABLY_HOST ? import.meta.env.VITE_ABLY_HOST : undefined,
+  realtimeHost: import.meta?.env?.VITE_ABLY_HOST ? import.meta.env.VITE_ABLY_HOST : undefined,
   clientId,
 })
 


### PR DESCRIPTION
[CHA-326] Make the demo app use production by default so users don't have to do anything to try it out.


### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

[CHA-326]: https://ably.atlassian.net/browse/CHA-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ