### PR TITLE
presence: rename PresenceEvent.type to action

### DIFF
--- a/src/Presence.ts
+++ b/src/Presence.ts
@@ -39,7 +39,7 @@ export interface PresenceEvent {
   /**
    * The type of the presence event.
    */
-  type: PresenceEvents;
+  action: PresenceEvents;
 
   /**
    * The clientId of the client that triggered the presence event.
@@ -343,7 +343,7 @@ export class DefaultPresence extends EventEmitter<PresenceEventsMap> implements 
     try {
       const parsedData = JSON.parse(member.data);
       this.emit(PresenceEvents[member.action], {
-        type: PresenceEvents[member.action],
+        action: PresenceEvents[member.action],
         clientId: member.clientId,
         timestamp: member.timestamp,
         data: parsedData.userCustomData,


### PR DESCRIPTION
### Context

[CHA-329].

### Description

- Renames `PresenceEvent.type` to `action`. This is consistent with the rest of presence.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

### Testing Instructions (Optional)

N/A


[CHA-329]: https://ably.atlassian.net/browse/CHA-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ