### PR TITLE
test: make default log level silent

### DIFF
--- a/test/helper/logger.ts
+++ b/test/helper/logger.ts
@@ -11,4 +11,4 @@ export const makeTestLogger = (): Logger => {
 };
 
 // testLoggingLevel returns the log level specified by the VITE_TEST_LOG_LEVEL environment variable.
-export const testLoggingLevel = (): LogLevel | undefined => (process.env.VITE_TEST_LOG_LEVEL as LogLevel) ?? undefined;
+export const testLoggingLevel = (): LogLevel => (process.env.VITE_TEST_LOG_LEVEL as LogLevel) ?? LogLevel.silent;


### PR DESCRIPTION
### Context

If you look at the CI output, you'll see its littered with logs and quite hard to read.

### Description

It gets a bit noisy when testing error conditions, so make the logs silent by default. We can always change the level if we need to.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

### Testing Instructions (Optional)

N/A