### PR TITLE
chat: mark setAgent as internal for typedoc

### DIFF
--- a/src/Chat.ts
+++ b/src/Chat.ts
@@ -86,6 +86,7 @@ export class ChatClient {
 
   /**
    * Sets the agent string for the client.
+   * @internal
    */
   private setAgent(): void {
     const realtime = this._realtime as RealtimeWithOptions;


### PR DESCRIPTION
### Description

Library users don't need to know about `setAgent` so hide it from typedoc.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

### Testing Instructions (Optional)

Check typedoc and see it magically gone!
