### PR TITLE
[CHA-355] Remove Presence data stringify and enforced type

### DIFF
--- a/demo/src/components/MessageComponent/MessageComponent.tsx
+++ b/demo/src/components/MessageComponent/MessageComponent.tsx
@@ -2,34 +2,45 @@ import { Message } from '@ably-labs/chat';
 import React, { useCallback } from 'react';
 import clsx from 'clsx';
 
-function twoDigits(input : number) : string {
+function twoDigits(input: number): string {
   if (input === 0) {
-    return "00";
+    return '00';
   }
   if (input < 10) {
-    return "0"+input;
+    return '0' + input;
   }
-  return ""+input;
+  return '' + input;
 }
 
 interface MessageProps {
   id: string;
   self?: boolean;
   message: Message;
+
   onMessageClick?(id: string): void;
 }
+
 export const MessageComponent: React.FC<MessageProps> = ({ id, self = false, message, onMessageClick }) => {
   const handleMessageClick = useCallback(() => {
     onMessageClick?.(id);
   }, [id, onMessageClick]);
 
-  let displayCreatedAt : string;
+  let displayCreatedAt: string;
   if (new Date().getTime() - message.createdAt.getTime() < 1000 * 60 * 60 * 24) {
     // last 24h show the time
-    displayCreatedAt = twoDigits(message.createdAt.getHours()) + ":" + twoDigits(message.createdAt.getMinutes());
+    displayCreatedAt = twoDigits(message.createdAt.getHours()) + ':' + twoDigits(message.createdAt.getMinutes());
   } else {
     // older, show full date
-    displayCreatedAt = message.createdAt.getDate()+"/"+message.createdAt.getMonth()+"/"+message.createdAt.getFullYear() + " " + twoDigits(message.createdAt.getHours()) + ":" + twoDigits(message.createdAt.getMinutes());
+    displayCreatedAt =
+      message.createdAt.getDate() +
+      '/' +
+      message.createdAt.getMonth() +
+      '/' +
+      message.createdAt.getFullYear() +
+      ' ' +
+      twoDigits(message.createdAt.getHours()) +
+      ':' +
+      twoDigits(message.createdAt.getMinutes());
   }
 
   return (
@@ -44,14 +55,20 @@ export const MessageComponent: React.FC<MessageProps> = ({ id, self = false, mes
             ['items-start order-2']: !self,
           })}
         >
-          <div className="text-xs"><span>{ message.clientId }</span> &middot; <span className="sent-at-time"><span className="short">{ displayCreatedAt }</span><span className="long">{ message.createdAt.toLocaleString() }</span></span></div>
+          <div className="text-xs">
+            <span>{message.clientId}</span> &middot;{' '}
+            <span className="sent-at-time">
+              <span className="short">{displayCreatedAt}</span>
+              <span className="long">{message.createdAt.toLocaleString()}</span>
+            </span>
+          </div>
           <div
             className={clsx('px-4 py-2 rounded-lg inline-block', {
               ['rounded-br bg-blue-600 text-white']: self,
               ['rounded-bl justify-start bg-gray-300 text-gray-600']: !self,
             })}
           >
-            { message.content }
+            {message.content}
           </div>
         </div>
       </div>

--- a/src/SubscriptionManager.ts
+++ b/src/SubscriptionManager.ts
@@ -19,11 +19,11 @@ export interface SubscriptionManager {
 
   presenceUnsubscribe(listener: PresenceListener): Promise<void>;
 
-  presenceEnterClient(clientId: string, data?: string): Promise<void>;
+  presenceEnterClient(clientId: string, data?: unknown): Promise<void>;
 
-  presenceUpdateClient(clientId: string, data?: string): Promise<void>;
+  presenceUpdateClient(clientId: string, data?: unknown): Promise<void>;
 
-  presenceLeaveClient(clientId: string, data?: string): Promise<void>;
+  presenceLeaveClient(clientId: string, data?: unknown): Promise<void>;
 
   get channel(): Ably.RealtimeChannel;
 }
@@ -161,13 +161,13 @@ export class DefaultSubscriptionManager implements SubscriptionManager {
     return this._channel.detach();
   }
 
-  presenceEnterClient(clientId: string, data?: string): Promise<void> {
+  presenceEnterClient(clientId: string, data?: unknown): Promise<void> {
     this._logger.trace('DefaultSubscriptionManager.presenceEnterClient();', { clientId });
     this._presenceEntered = true;
     return this._channel.presence.enterClient(clientId, data);
   }
 
-  async presenceLeaveClient(clientId: string, data?: string): Promise<void> {
+  async presenceLeaveClient(clientId: string, data?: unknown): Promise<void> {
     this._logger.trace('DefaultSubscriptionManager.presenceLeaveClient();', { clientId });
     this._presenceEntered = false;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-misused-promises
@@ -176,7 +176,7 @@ export class DefaultSubscriptionManager implements SubscriptionManager {
     });
   }
 
-  presenceUpdateClient(clientId: string, data?: string): Promise<void> {
+  presenceUpdateClient(clientId: string, data?: unknown): Promise<void> {
     this._logger.trace('DefaultSubscriptionManager.presenceUpdateClient();', { clientId });
     this._presenceEntered = true;
     return this._channel.presence.updateClient(clientId, data);


### PR DESCRIPTION
### Context
[CHA-101]

We currently handle presence data by enforcing some typing on it, this means a user must specify an map regardless of the data they wish to send. Also, we stringify the presence data in the SDK before emitting a presence event via ably-js, but ably-js already stringifies presence data, so this is redundant.

### Description

* Removed enforced typing from PresenceData object, so users have more flexibility.
* Removed the stringify of presence data at the chat SDK level.

* Added missing param in Presence docs

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

[CHA-101]: https://ably.atlassian.net/browse/CHA-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ