### PR TITLE
CHA-328: Renaming of message field name "content" to "text"

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ const message = await room.messages.send('This was a great shot!');
   timeserial: 'string',
   clientId: 'string',
   roomId: 'string',
-  content: 'string',
+  text: 'string',
   createdAt: 'number',
 }
 ```

--- a/demo/src/components/MessageComponent/MessageComponent.tsx
+++ b/demo/src/components/MessageComponent/MessageComponent.tsx
@@ -68,7 +68,7 @@ export const MessageComponent: React.FC<MessageProps> = ({ id, self = false, mes
               ['rounded-bl justify-start bg-gray-300 text-gray-600']: !self,
             })}
           >
-            {message.content}
+            {message.text}
           </div>
         </div>
       </div>

--- a/src/ChatApi.ts
+++ b/src/ChatApi.ts
@@ -18,7 +18,7 @@ export interface CreateMessageResponse {
 }
 
 interface CreateMessageRequest {
-  content: string;
+  text: string;
 }
 
 /**
@@ -43,7 +43,7 @@ export class ChatApi {
           message.timeserial,
           message.clientId,
           message.roomId,
-          message.content,
+          message.text,
           new Date(message.createdAt),
         );
       });
@@ -56,7 +56,7 @@ export class ChatApi {
       `/chat/v1/rooms/${roomId}/messages`,
       'POST',
       {
-        content: text,
+        text: text,
       },
     );
   }

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -18,9 +18,9 @@ export interface Message {
   readonly roomId: string;
 
   /**
-   * The text content of the message.
+   * The text of the message.
    */
-  readonly content: string;
+  readonly text: string;
 
   /**
    * The timestamp at which the message was created.
@@ -74,7 +74,7 @@ export class DefaultMessage implements Message {
     public readonly timeserial: string,
     public readonly clientId: string,
     public readonly roomId: string,
-    public readonly content: string,
+    public readonly text: string,
     public readonly createdAt: Date,
   ) {
     this._calculatedTimeserial = DefaultMessage.calculateTimeserial(timeserial);

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -120,7 +120,7 @@ export interface Messages {
    * from the realtime channel. This means you may see the message that was just
    * sent in a callback to `subscribe` before the returned promise resolves.
    *
-   * @param text content of the message
+   * @param text text of the message
    * @returns A promise that resolves when the message was published.
    */
   send(text: string): Promise<Message>;
@@ -244,7 +244,7 @@ export class DefaultMessages extends EventEmitter<MessageEventsMap> implements M
   private parseNewMessage(channelEventMessage: Ably.InboundMessage): Message | undefined {
     interface MessagePayload {
       data?: {
-        content?: string;
+        text?: string;
       };
       clientId?: string;
       timestamp?: number;
@@ -252,6 +252,7 @@ export class DefaultMessages extends EventEmitter<MessageEventsMap> implements M
         timeserial?: string;
       };
     }
+
     const messageCreatedMessage = channelEventMessage as MessagePayload;
 
     if (!messageCreatedMessage.data) {
@@ -269,8 +270,8 @@ export class DefaultMessages extends EventEmitter<MessageEventsMap> implements M
       return;
     }
 
-    if (messageCreatedMessage.data.content === undefined) {
-      this._logger.error(`received incoming message without content`, channelEventMessage);
+    if (messageCreatedMessage.data.text === undefined) {
+      this._logger.error(`received incoming message without text`, channelEventMessage);
       return;
     }
 
@@ -288,7 +289,7 @@ export class DefaultMessages extends EventEmitter<MessageEventsMap> implements M
       messageCreatedMessage.extras.timeserial,
       messageCreatedMessage.clientId,
       this._roomId,
-      messageCreatedMessage.data.content,
+      messageCreatedMessage.data.text,
       new Date(messageCreatedMessage.timestamp),
     );
   }

--- a/test/Chat.integration.test.ts
+++ b/test/Chat.integration.test.ts
@@ -21,7 +21,7 @@ describe('Chat', () => {
 
     // Send a message, and expect it to succeed
     const message = await chat.rooms.get('test').messages.send('my message');
-    expect(message).toEqual(expect.objectContaining({ content: 'my message', clientId: chat.clientId }));
+    expect(message).toEqual(expect.objectContaining({ text: 'my message', clientId: chat.clientId }));
 
     // Request occupancy, and expect it to succeed
     const occupancy = await chat.rooms.get('test').occupancy.get();
@@ -30,7 +30,7 @@ describe('Chat', () => {
     // Request history, and expect it to succeed
     const history = (await chat.rooms.get('test').messages.query({ limit: 1 })).items;
     expect(history).toEqual(
-      expect.arrayContaining([expect.objectContaining({ content: 'my message', clientId: chat.clientId })]),
+      expect.arrayContaining([expect.objectContaining({ text: 'my message', clientId: chat.clientId })]),
     );
   });
 
@@ -39,7 +39,7 @@ describe('Chat', () => {
 
     // Send a message, and expect it to succeed
     const message = await chat.rooms.get('test').messages.send('my message');
-    expect(message).toEqual(expect.objectContaining({ content: 'my message', clientId: chat.clientId }));
+    expect(message).toEqual(expect.objectContaining({ text: 'my message', clientId: chat.clientId }));
 
     // Request occupancy, and expect it to succeed
     const occupancy = await chat.rooms.get('test').occupancy.get();
@@ -48,7 +48,7 @@ describe('Chat', () => {
     // Request history, and expect it to succeed
     const history = (await chat.rooms.get('test').messages.query({ limit: 1 })).items;
     expect(history).toEqual(
-      expect.arrayContaining([expect.objectContaining({ content: 'my message', clientId: chat.clientId })]),
+      expect.arrayContaining([expect.objectContaining({ text: 'my message', clientId: chat.clientId })]),
     );
   });
 });

--- a/test/Messages.integration.test.ts
+++ b/test/Messages.integration.test.ts
@@ -61,12 +61,12 @@ describe('messages integration', () => {
     // Check that the messages were received
     expect(messages).toEqual([
       expect.objectContaining({
-        content: 'Hello there!',
+        text: 'Hello there!',
         clientId: chat.clientId,
         timeserial: message1.timeserial,
       }),
       expect.objectContaining({
-        content: 'I have the high ground!',
+        text: 'I have the high ground!',
         clientId: chat.clientId,
         timeserial: message2.timeserial,
       }),
@@ -88,17 +88,17 @@ describe('messages integration', () => {
 
     expect(history.items).toEqual([
       expect.objectContaining({
-        content: 'Hello there!',
+        text: 'Hello there!',
         clientId: chat.clientId,
         timeserial: message1.timeserial,
       }),
       expect.objectContaining({
-        content: 'I have the high ground!',
+        text: 'I have the high ground!',
         clientId: chat.clientId,
         timeserial: message2.timeserial,
       }),
       expect.objectContaining({
-        content: 'You underestimate my power!',
+        text: 'You underestimate my power!',
         clientId: chat.clientId,
         timeserial: message3.timeserial,
       }),
@@ -124,17 +124,17 @@ describe('messages integration', () => {
 
     expect(history1.items).toEqual([
       expect.objectContaining({
-        content: 'Hello there!',
+        text: 'Hello there!',
         clientId: chat.clientId,
         timeserial: message1.timeserial,
       }),
       expect.objectContaining({
-        content: 'I have the high ground!',
+        text: 'I have the high ground!',
         clientId: chat.clientId,
         timeserial: message2.timeserial,
       }),
       expect.objectContaining({
-        content: 'You underestimate my power!',
+        text: 'You underestimate my power!',
         clientId: chat.clientId,
         timeserial: message3.timeserial,
       }),
@@ -148,7 +148,7 @@ describe('messages integration', () => {
 
     expect(history2?.items).toEqual([
       expect.objectContaining({
-        content: "Don't try it!",
+        text: "Don't try it!",
         clientId: chat.clientId,
         timeserial: message4.timeserial,
       }),
@@ -174,17 +174,17 @@ describe('messages integration', () => {
 
     expect(history1.items).toEqual([
       expect.objectContaining({
-        content: "Don't try it!",
+        text: "Don't try it!",
         clientId: chat.clientId,
         timeserial: message4.timeserial,
       }),
       expect.objectContaining({
-        content: 'You underestimate my power!',
+        text: 'You underestimate my power!',
         clientId: chat.clientId,
         timeserial: message3.timeserial,
       }),
       expect.objectContaining({
-        content: 'I have the high ground!',
+        text: 'I have the high ground!',
         clientId: chat.clientId,
         timeserial: message2.timeserial,
       }),
@@ -198,7 +198,7 @@ describe('messages integration', () => {
 
     expect(history2?.items).toEqual([
       expect.objectContaining({
-        content: 'Hello there!',
+        text: 'Hello there!',
         clientId: chat.clientId,
         timeserial: message1.timeserial,
       }),

--- a/test/Messages.test.ts
+++ b/test/Messages.test.ts
@@ -90,7 +90,7 @@ describe('Messages', () => {
       expect(message).toEqual(
         expect.objectContaining({
           timeserial: 'abcdefghij@1672531200000-123',
-          content: 'hello there',
+          text: 'hello there',
           clientId: 'clientId',
           createdAt: new Date(timestamp),
           roomId: 'coffee-room-chat',
@@ -111,7 +111,7 @@ describe('Messages', () => {
               expect(message).toEqual(
                 expect.objectContaining({
                   timeserial: 'abcdefghij@1672531200000-123',
-                  content: 'may the fourth be with you',
+                  text: 'may the fourth be with you',
                   clientId: 'yoda',
                   createdAt: new Date(publishTimestamp),
                   roomId: room.roomId,
@@ -127,7 +127,7 @@ describe('Messages', () => {
               clientId: 'yoda',
               name: 'message.created',
               data: {
-                content: 'may the fourth be with you',
+                text: 'may the fourth be with you',
               },
               extras: {
                 timeserial: 'abcdefghij@1672531200000-123',
@@ -206,7 +206,7 @@ describe('Messages', () => {
           context.emulateBackendPublish({
             name: 'message.created',
             data: {
-              content: 'may the fourth be with you',
+              text: 'may the fourth be with you',
             },
             extras: {
               timeserial: 'abcdefghij@1672531200000-123',
@@ -235,7 +235,7 @@ describe('Messages', () => {
             name: 'message.created',
             clientId: 'abc',
             data: {
-              content: 'may the fourth be with you',
+              text: 'may the fourth be with you',
             },
             timestamp: publishTimestamp,
           });
@@ -261,7 +261,7 @@ describe('Messages', () => {
             name: 'message.created',
             clientId: 'abc',
             data: {
-              content: 'may the fourth be with you',
+              text: 'may the fourth be with you',
             },
             extras: {},
             timestamp: publishTimestamp,
@@ -275,13 +275,13 @@ describe('Messages', () => {
         });
     }));
 
-  it<TestContext>('should raise an error if no content in incoming message', (context) =>
+  it<TestContext>('should raise an error if no text in incoming message', (context) =>
     new Promise<void>((done, reject) => {
       const publishTimestamp = new Date().getTime();
       const room = makeRoom(context);
       room.messages
         .subscribe(() => {
-          reject(new Error('should not have received message without content'));
+          reject(new Error('should not have received message without text'));
         })
         .then(() => {
           context.emulateBackendPublish({
@@ -314,7 +314,7 @@ describe('Messages', () => {
             name: 'message.created',
             clientId: 'abc',
             data: {
-              content: 'may the fourth be with you',
+              text: 'may the fourth be with you',
             },
             extras: {
               timeserial: 'abcdefghij@1672531200000-123',


### PR DESCRIPTION
### Context

* [CHA-328] - Renaming of message field name
* There is a related backend change in realtime

### Description

I have renamed the message field here from **content** to **text** to be more chat idiomatic. This has also been done in the realtime backend so that history requests and message publish both use the new field name. 
Also some minor prettier forced changes to the readme layout.

I have QA'd this against the relevant realtime changes, the test here will fail until those changes are merged and deployed to sandbox.


### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

### Testing Instructions (Optional)

* If you wish to test this PR fully, you will need to checkout the branch in realtime related to the CHA-328 changes and run the SDK test suite against local./


[CHA-328]: https://ably.atlassian.net/browse/CHA-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ