### PR TITLE
[CHA-280] - implement get previous messages for subscribed listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,27 @@ if (historicalMessages.hasNext()) {
 }
 ```
 
+### Query message history for a subscribed listener
+
+Another useful method the messages object exposes is the `getBeforeSubscriptionStart` method. It can be used to return
+historical messages in the chat room that were sent up to the point a particular listener was subscribed. It returns a
+paginated response that can be used to query for more messages.
+
+```typescript
+const listener = () => {
+  console.log('New message received');
+};
+room.messages.subscribe(listener);
+const historicalMessages = await room.messages.getBeforeSubscriptionStart(listener, { limit: 50 });
+console.log(historicalMessages.items);
+if (historicalMessages.hasNext()) {
+  const next = await historicalMessages.next();
+  console.log(next);
+} else {
+  console.log('End of messages');
+}
+```
+
 ## Connection and Ably channels statuses
 
 You can monitor the status of the overall connection to Ably using the `connection` member of the Realtime client that you

--- a/__mocks__/ably/index.ts
+++ b/__mocks__/ably/index.ts
@@ -47,6 +47,12 @@ function createMockChannel() {
     publish: () => {},
     subscriptions: createMockEmitter(),
     setOptions: methodReturningVoidPromise,
+    whenState: methodReturningVoidPromise,
+    properties: {
+      attachSerial: '',
+      channelSerial: '',
+    },
+    state: '',
   };
 }
 

--- a/src/ChatApi.ts
+++ b/src/ChatApi.ts
@@ -10,6 +10,14 @@ export interface GetMessagesQueryParams {
   end?: number;
   direction?: 'forwards' | 'backwards';
   limit?: number;
+  /**
+   * Timeserial indicating the starting point for message retrieval.
+   * This timeserial is specific to the region of the channel the client is connected to. Messages published within
+   * the same region of the channel are guaranteed to be received in increasing timeserial order.
+   *
+   * @defaultValue undefined (not used if not specified)
+   */
+  fromSerial?: string;
 }
 
 export interface CreateMessageResponse {

--- a/src/Timeserial.ts
+++ b/src/Timeserial.ts
@@ -1,0 +1,153 @@
+/**
+ * Represents a parsed timeserial.
+ */
+export interface Timeserial {
+  /**
+   * The series ID of the timeserial.
+   */
+  readonly seriesId: string;
+
+  /**
+   * The timestamp of the timeserial.
+   */
+  readonly timestamp: number;
+
+  /**
+   * The counter of the timeserial.
+   */
+  readonly counter: number;
+
+  /**
+   * The index of the timeserial.
+   */
+  readonly index?: number;
+
+  toString(): string;
+
+  before(timeserial: Timeserial | string): boolean;
+
+  after(timeserial: Timeserial | string): boolean;
+
+  equal(timeserial: Timeserial | string): boolean;
+}
+
+/**
+ * Default implementation of the Timeserial interface. Used internally to parse and compare timeserials.
+ *
+ * @internal
+ */
+export class DefaultTimeserial implements Timeserial {
+  public readonly seriesId: string;
+  public readonly timestamp: number;
+  public readonly counter: number;
+  public readonly index?: number;
+
+  private constructor(seriesId: string, timestamp: number, counter: number, index?: number) {
+    this.seriesId = seriesId;
+    this.timestamp = timestamp;
+    this.counter = counter;
+    this.index = index;
+  }
+
+  /**
+   * Returns the string representation of the timeserial object.
+   * @returns The timeserial string.
+   */
+  toString(): string {
+    return `${this.seriesId}@${this.timestamp.toString()}-${this.counter.toString()}${this.index ? `:${this.index.toString()}` : ''}`;
+  }
+
+  /**
+   * Calculate the timeserial object from a timeserial string.
+   *
+   * @param timeserial The timeserial string to parse.
+   * @returns The parsed timeserial object.
+   * @throws {@link ErrorInfo} if timeserial is invalid.
+   */
+  public static calculateTimeserial(timeserial: string): Timeserial {
+    const [seriesId, rest] = timeserial.split('@');
+    if (!seriesId || !rest) {
+      throw new Error('Invalid timeserial');
+    }
+
+    const [timestamp, counterAndIndex] = rest.split('-');
+    if (!timestamp || !counterAndIndex) {
+      throw new Error('Invalid timeserial');
+    }
+
+    const [counter, index] = counterAndIndex.split(':');
+    if (!counter) {
+      throw new Error('Invalid timeserial');
+    }
+
+    return new DefaultTimeserial(seriesId, Number(timestamp), Number(counter), index ? Number(index) : undefined);
+  }
+
+  /**
+   * Compares this timeserial to the supplied timeserial, returning a number indicating their relative order.
+   * @param timeserialToCompare The timeserial to compare against. Can be a string or a Timeserial object.
+   * @returns 0 if the timeserials are equal, <0 if the first timeserial is less than the second, >0 if the first timeserial is greater than the second.
+   * @throws {@link ErrorInfo} if comparison timeserial is invalid.
+   */
+  private timeserialCompare(timeserialToCompare: string | Timeserial): number {
+    const secondTimeserial =
+      typeof timeserialToCompare === 'string'
+        ? DefaultTimeserial.calculateTimeserial(timeserialToCompare)
+        : timeserialToCompare;
+
+    // Compare the timestamp
+    const timestampDiff = this.timestamp - secondTimeserial.timestamp;
+    if (timestampDiff) {
+      return timestampDiff;
+    }
+
+    // Compare the counter
+    const counterDiff = this.counter - secondTimeserial.counter;
+    if (counterDiff) {
+      return counterDiff;
+    }
+
+    // Compare the seriesId lexicographically
+    const seriesIdDiff =
+      this.seriesId !== secondTimeserial.seriesId ? (this.seriesId < secondTimeserial.seriesId ? -1 : 1) : 0;
+
+    if (seriesIdDiff) {
+      return seriesIdDiff;
+    }
+
+    // Compare the index, if present
+    return this.index !== undefined && secondTimeserial.index !== undefined ? this.index - secondTimeserial.index : 0;
+  }
+
+  /**
+   * Determines if this timeserial occurs logically before the given timeserial.
+   *
+   * @param timeserial The timeserial to compare against. Can be a string or a Timeserial object.
+   * @returns true if this timeserial precedes the given timeserial, in global order.
+   * @throws {@link ErrorInfo} if the given timeserial is invalid.
+   */
+  before(timeserial: Timeserial | string): boolean {
+    return this.timeserialCompare(timeserial) < 0;
+  }
+
+  /**
+   * Determines if this timeserial occurs logically after the given timeserial.
+   *
+   * @param timeserial The timeserial to compare against. Can be a string or a Timeserial object.
+   * @returns true if this timeserial follows the given timeserial, in global order.
+   * @throws {@link ErrorInfo} if the given timeserial is invalid.
+   */
+  after(timeserial: Timeserial | string): boolean {
+    return this.timeserialCompare(timeserial) > 0;
+  }
+
+  /**
+   * Determines if this timeserial is equal to the given timeserial.
+   * @param timeserial The timeserial to compare against. Can be a string or a Timeserial object.
+   * @returns true if this timeserial is equal to the given timeserial.
+   * @throws {@link ErrorInfo} if the given timeserial is invalid.
+   */
+  equal(timeserial: Timeserial | string): boolean {
+    return this.timeserialCompare(timeserial) === 0;
+  }
+}

--- a/test/Message.test.ts
+++ b/test/Message.test.ts
@@ -55,20 +55,10 @@ describe('ChatMessage', () => {
     expect(firstMessage.equal(secondMessage)).toBe(false);
   });
 
-  it.each([
-    ['abcdefghij@1672531200000-123:1', 'abcdefghij@1672531200000-124:2', true], // Earlier index
-    ['abcdefghij@1672531200000-124:2', 'abcdefghij@1672531200000-123:1', false], // Later index
-    ['abcdefghij@1672531200000-123:1', 'abcdefghij@1672531200000-123:1', false], // Same index
-    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-124', true], // Earlier counter
-    ['abcdefghij@1672531200000-124', 'abcdefghij@1672531200000-123', false], // Later counter
-    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-123', false], // Same counter
-    ['abcdefghi@1672531200000-123', 'abcdefghij@1672531200000-123', true], // Earlier series id
-    ['abcdefghij@1672531200000-123', 'abcdefghi@1672531200000-123', false], // Later series id
-    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-123', false], // Same series id
-    ['abcdefghi@1672531200000-123', 'abcdefghij@1672531200001-123', true], // Earlier timestamp
-    ['abcdefghij@1672531200001-123', 'abcdefghij@1672531200000-123', false], // Later timestamp
-    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-123', false], // Same timestamp]
-  ])(`is before another message %s, %s -> %o`, (firstTimeserial, secondTimeserial, expected) => {
+  it('is before another message', () => {
+    const firstTimeserial = 'abcdefghij@1672531200000-123';
+    const secondTimeserial = 'abcdefghij@1672531200000-124';
+
     const firstMessage = new DefaultMessage(
       firstTimeserial,
       'clientId',
@@ -88,23 +78,12 @@ describe('ChatMessage', () => {
       {},
     );
 
-    expect(firstMessage.before(secondMessage)).toBe(expected);
+    expect(firstMessage.before(secondMessage)).toBe(true);
   });
+  it('is after another message', () => {
+    const firstTimeserial = 'abcdefghij@1672531200000-124';
+    const secondTimeserial = 'abcdefghij@1672531200000-123';
 
-  it.each([
-    ['abcdefghij@1672531200000-123:1', 'abcdefghij@1672531200000-124:2', false], // Earlier index
-    ['abcdefghij@1672531200000-124:2', 'abcdefghij@1672531200000-123:1', true], // Later index
-    ['abcdefghij@1672531200000-123:1', 'abcdefghij@1672531200000-123:1', false], // Same index
-    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-124', false], // Earlier counter
-    ['abcdefghij@1672531200000-124', 'abcdefghij@1672531200000-123', true], // Later counter
-    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-123', false], // Same counter
-    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-124', false], // Earlier series id
-    ['abcdefghij@1672531200000-124', 'abcdefghij@1672531200000-123', true], // Later series id
-    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-123', false], // Same series id
-    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200001-123', false], // Earlier timestamp
-    ['abcdefghij@1672531200001-123', 'abcdefghij@1672531200000-123', true], // Later timestamp
-    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-123', false], // Same timestamp
-  ])('is after another message %s, %s -> %o', (firstTimeserial, secondTimeserial, expected) => {
     const firstMessage = new DefaultMessage(
       firstTimeserial,
       'clientId',
@@ -124,16 +103,21 @@ describe('ChatMessage', () => {
       {},
     );
 
-    expect(firstMessage.after(secondMessage)).toBe(expected);
+    expect(firstMessage.after(secondMessage)).toBe(true);
   });
 
-  it.each([
-    ['abcdefghij@1672531200000'], // No counter
-    ['abcdefghij@'], // No timestamp
-    ['abcdefghij'], // No series id
-  ])('throws an error with an invalid timeserial %s', (timeserial) => {
+  it('throws an error with an invalid timeserial', () => {
     expect(
-      () => new DefaultMessage(timeserial, 'clientId', 'roomId', 'hello there', new Date(1672531200000), {}, {}),
+      () =>
+        new DefaultMessage(
+          'not a valid timeserial',
+          'clientId',
+          'roomId',
+          'hello there',
+          new Date(1672531200000),
+          {},
+          {},
+        ),
     ).toThrow(new Error('Invalid timeserial'));
   });
 });

--- a/test/Messages.test.ts
+++ b/test/Messages.test.ts
@@ -1,7 +1,8 @@
 import * as Ably from 'ably';
+import { ErrorInfo, RealtimeChannel } from 'ably';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ChatApi } from '../src/ChatApi.js';
+import { ChatApi, GetMessagesQueryParams } from '../src/ChatApi.js';
 import { normaliseClientOptions } from '../src/config.js';
 import { MessageEvents } from '../src/events.js';
 import { DefaultRoom } from '../src/Room.js';
@@ -13,6 +14,8 @@ interface TestContext {
   realtime: Ably.Realtime;
   chatApi: ChatApi;
   emulateBackendPublish: Ably.messageCallback<Partial<Ably.InboundMessage>>;
+  emulateBackendStateChange: (event: string, cb: Ably.ChannelStateChange) => void;
+  channelStateListeners: Map<string, Ably.channelEventCallback[]>;
   channelLevelListeners: Map<Ably.messageCallback<Ably.Message>, string[]>;
 }
 
@@ -27,6 +30,7 @@ describe('Messages', () => {
     context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
     context.channelLevelListeners = new Map<Ably.messageCallback<Ably.Message>, string[]>();
     context.chatApi = new ChatApi(context.realtime, makeTestLogger());
+    context.channelStateListeners = new Map<string, Ably.channelEventCallback[]>();
 
     const channel = context.realtime.channels.get('roomId');
     vi.spyOn(channel, 'subscribe').mockImplementation(
@@ -51,12 +55,33 @@ describe('Messages', () => {
       },
     );
 
+    vi.spyOn(channel, 'on').mockImplementation(
+      // @ts-expect-error overriding mock
+      (event: Ably.ChannelEvent, callback: Ably.channelEventCallback) => {
+        if (!context.channelStateListeners.has(event)) {
+          context.channelStateListeners.set(event, []);
+        }
+        // Add the callback to the list of listeners for this event
+        context.channelStateListeners.get(event)?.push(callback);
+        context.emulateBackendStateChange = (event, stateChange) => {
+          context.channelStateListeners.get(event)?.forEach((cb) => {
+            cb(stateChange);
+          });
+        };
+      },
+    );
+
     vi.spyOn(channel, 'unsubscribe').mockImplementation(
       // @ts-expect-error overriding mock
       (listener: Ably.messageCallback<Ably.Message>) => {
         context.channelLevelListeners.delete(listener);
       },
     );
+
+    // Return a non-resolving promise for whenState as we aren't attached to the channel yet
+    vi.spyOn(channel, 'whenState').mockImplementation(async () => {
+      return new Promise(() => {});
+    });
 
     // Mock the attach
     vi.spyOn(channel, 'attach').mockImplementation(async () => {
@@ -439,4 +464,467 @@ describe('Messages', () => {
           reject(error as Error);
         });
     }));
+
+  // Tests for getBeforeSubscriptionStart
+  it<TestContext>('should throw an error for listener history if not subscribed', async (context) => {
+    // Create a room instance
+    const room = makeRoom(context);
+
+    let caughtError: ErrorInfo | undefined;
+
+    try {
+      // Attempt to query message history before subscribing a listener
+      await room.messages.getBeforeSubscriptionStart(() => {}, { limit: 50 });
+    } catch (e: unknown) {
+      // Expect an error to be thrown since no listener has been subscribed
+      caughtError = e as ErrorInfo;
+    }
+
+    // Assert that an error was caught
+    expect(caughtError).toBeDefined();
+    expect(caughtError?.message).toEqual('cannot query history; listener has not been subscribed yet');
+  });
+
+  it<TestContext>('should query listener history with the attachment serial after attaching', async (context) => {
+    const testAttachSerial = 'abcdefghij@1672531200000-123';
+    const testRoomId = 'roomId';
+    const testDirection = 'backwards';
+    const testLimit = 50;
+
+    // Mock the chat api call used by listener history query
+    const mockChatApi = {
+      getMessages: function (roomId: string, params: GetMessagesQueryParams): void {
+        expect(roomId).toEqual(testRoomId);
+        expect(params.direction).toEqual(testDirection);
+        expect(params.limit).toEqual(testLimit);
+        expect(params.fromSerial).toEqual(testAttachSerial);
+      },
+    } as unknown as ChatApi;
+
+    // Create a room with the mock chat api so we can check query params
+    const room = new DefaultRoom('roomId', context.realtime, mockChatApi, testClientOptions(), makeTestLogger());
+
+    // Force ts to recognize the channel properties
+    const channel = room.messages.channel as RealtimeChannel & {
+      properties: {
+        attachSerial: string | undefined;
+      };
+    };
+
+    // Set the timeserial of the channel attach
+    channel.properties.attachSerial = testAttachSerial;
+
+    vi.spyOn(channel, 'whenState').mockImplementation(async () => {
+      return Promise.resolve(null);
+    });
+
+    // Create a test listener
+    const listener1 = () => {};
+
+    // Subscribe to the messages
+    await room.messages.subscribe(listener1);
+
+    // Mock the channel state to be attached
+    vi.spyOn(channel, 'state', 'get').mockReturnValue('attached');
+
+    // Initiate an attach state change to resolve the listeners attach point
+    context.emulateBackendStateChange('attached', {
+      current: 'attached',
+      previous: 'detached',
+      resumed: false,
+    });
+
+    // Run a history query for the listener and check the chat api call is made with the channel attachment serial
+    await room.messages.getBeforeSubscriptionStart(listener1, { limit: 50 });
+  });
+
+  it<TestContext>('should query listener history with latest channel serial if already attached to the channel', async (context) => {
+    // We should use the latest channel serial if we are already attached to the channel
+    const latestChannelSerial = 'abcdefghij@1672531200000-123';
+
+    const testRoomId = 'roomId';
+    const testDirection = 'backwards';
+    const testLimit = 50;
+
+    // Mock the chat api call used by listener history query, using latest channel serial
+    const mockChatApi = {
+      getMessages: function (roomId: string, params: GetMessagesQueryParams): void {
+        expect(roomId).toEqual(testRoomId);
+        expect(params.direction).toEqual(testDirection);
+        expect(params.limit).toEqual(testLimit);
+        expect(params.fromSerial).toEqual(latestChannelSerial);
+      },
+    } as unknown as ChatApi;
+
+    // Create a room with the mock chat api
+    const room = new DefaultRoom('roomId', context.realtime, mockChatApi, testClientOptions(), makeTestLogger());
+
+    // Force ts to recognize the channel properties
+    const channel = room.messages.channel as RealtimeChannel & {
+      properties: {
+        channelSerial: string | undefined;
+      };
+      state: Ably.ChannelState;
+    };
+
+    // Mock the channel state to be attached so we should query with the channel serial
+    vi.spyOn(channel, 'state', 'get').mockReturnValue('attached');
+
+    // Set the timeserial of the channel (attachment serial)
+    channel.properties.channelSerial = latestChannelSerial;
+
+    // Create a test listener
+    const listener1 = () => {};
+
+    // Subscribe the listener to messages
+    await room.messages.subscribe(listener1);
+
+    // Run a history query for the listener and check the chat api call is made with the channel timeserial
+    await room.messages.getBeforeSubscriptionStart(listener1, { limit: 50 });
+  });
+
+  it<TestContext>('when attach occurs, should query with correct params if listener registered before attach', async (context) => {
+    const firstAttachmentSerial = '108uyDJAgBOihn12345678@1772531200000-1';
+
+    const testRoomId = 'roomId';
+    const testDirection = 'backwards';
+    const testLimit = 50;
+
+    let expectFunction: (roomId: string, params: GetMessagesQueryParams) => void = () => {};
+
+    // Mock the chat api call used by listener history query
+    const mockChatApi = {
+      getMessages: function (roomId: string, params: GetMessagesQueryParams): void {
+        expectFunction(roomId, params);
+      },
+    } as unknown as ChatApi;
+
+    // Create a room with the mock chat api
+    const room = new DefaultRoom('roomId', context.realtime, mockChatApi, testClientOptions(), makeTestLogger());
+
+    const channel = room.messages.channel as RealtimeChannel & {
+      properties: {
+        attachSerial: string | undefined;
+        fromSerial: string | undefined;
+      };
+    };
+
+    // Set the timeserials for before attachment testing
+    channel.properties.attachSerial = firstAttachmentSerial;
+
+    // Create a test listener
+    const listenerBeforeAttach = () => {};
+
+    // Subscribe to the messages, should receive the attachSerial
+    await room.messages.subscribe(listenerBeforeAttach);
+
+    // Mock the channel state to be attached
+    vi.spyOn(channel, 'state', 'get').mockReturnValue('attached');
+
+    // Initiate an attach state change to resolve the listeners attach point
+    context.emulateBackendStateChange('attached', {
+      current: 'attached',
+      previous: 'detached',
+      resumed: false,
+    });
+
+    // Check we are using the attachSerial
+    expectFunction = (roomId: string, params: GetMessagesQueryParams) => {
+      expect(roomId).toEqual(testRoomId);
+      expect(params.direction).toEqual(testDirection);
+      expect(params.limit).toEqual(testLimit);
+      expect(params.fromSerial).toEqual(firstAttachmentSerial);
+    };
+
+    // Run a history query for the listener and check the chat api call is made with the channel attachment serial
+    await room.messages.getBeforeSubscriptionStart(listenerBeforeAttach, { limit: 50 });
+
+    // Now update the attach serial
+    const secondAttachmentserial = '108hhDJ2dBOihn12345678@1992531200000-1';
+    channel.properties.attachSerial = secondAttachmentserial;
+
+    // Initiate a re-attach without resume, should cause all listener points to reset to new attach serial
+    context.emulateBackendStateChange('attached', {
+      current: 'detached',
+      previous: 'attached',
+      resumed: false,
+    });
+
+    // Check we are now using the new attachSerial
+    expectFunction = (_: string, params: GetMessagesQueryParams) => {
+      expect(params.fromSerial).toEqual(secondAttachmentserial);
+    };
+
+    // Run a history query for the listener and check the chat api call is made with the new attach serial
+    await room.messages.getBeforeSubscriptionStart(listenerBeforeAttach, { limit: 50 });
+
+    // Test the case where we receive an attached state change with resume.
+
+    // Change attach serial again
+    channel.properties.attachSerial = '108hhDJ2dBOihn12345678@1122531200000-1';
+
+    // Initiate a re-attach this time with resume, should not cause listener points to reset to new attach serial
+    context.emulateBackendStateChange('attached', {
+      current: 'detached',
+      previous: 'attached',
+      resumed: true,
+    });
+
+    // Check we are using the previous attachSerial
+    expectFunction = (_: string, params: GetMessagesQueryParams) => {
+      expect(params.fromSerial).toEqual(secondAttachmentserial);
+    };
+
+    // Run a history query for the listener and check the chat api call is made with the previous attach serial
+    await room.messages.getBeforeSubscriptionStart(listenerBeforeAttach, { limit: 50 });
+  });
+
+  it<TestContext>('when attach occurs, should query with correct params if listener register after attach', async (context) => {
+    // Testing the case where the channel is already attached and we have a channel serial set
+    const firstChannelSerial = 'abghhDJ2dBOihn12345678@1992531200000-1';
+    const firstAttachSerial = 'ackhhDJ2dBOihn12345678@1992531200000-1';
+
+    const testRoomId = 'roomId';
+    const testDirection = 'backwards';
+    const testLimit = 50;
+
+    let expectFunction: (roomId: string, params: GetMessagesQueryParams) => void = () => {};
+
+    // Mock the chat api call used by listener history query
+    const mockChatApi = {
+      getMessages: function (roomId: string, params: GetMessagesQueryParams): void {
+        expectFunction(roomId, params);
+      },
+    } as unknown as ChatApi;
+
+    // Create a room with the mock chat api
+    const room = new DefaultRoom('roomId', context.realtime, mockChatApi, testClientOptions(), makeTestLogger());
+
+    const channel = room.messages.channel as RealtimeChannel & {
+      properties: {
+        attachSerial: string | undefined;
+        channelSerial: string | undefined;
+      };
+    };
+
+    vi.spyOn(channel, 'whenState').mockImplementation(async () => {
+      return Promise.resolve(null);
+    });
+
+    // Set the timeserials for the channel
+    channel.properties.channelSerial = firstChannelSerial;
+    channel.properties.attachSerial = firstAttachSerial;
+
+    // Mock the channel state to be attached
+    vi.spyOn(channel, 'state', 'get').mockReturnValue('attached');
+
+    // Create a test listener
+    const listenerAfterAttach = () => {};
+
+    // Subscribe the listener to messages
+    await room.messages.subscribe(listenerAfterAttach);
+
+    // Check we are using the channel serial
+    expectFunction = (roomId: string, params: GetMessagesQueryParams) => {
+      expect(roomId).toEqual(testRoomId);
+      expect(params.direction).toEqual(testDirection);
+      expect(params.limit).toEqual(testLimit);
+      expect(params.fromSerial).toEqual(firstChannelSerial);
+    };
+
+    // Run a history query for the listener and check the chat api call is made with the channel serial
+    await room.messages.getBeforeSubscriptionStart(listenerAfterAttach, { limit: 50 });
+
+    // Change the attach and channel serials
+    const secondChannelSerial = '108hhDJ2hpOihn12345678@1992531200000-1';
+    const secondAttachSerial = '108hGGJ2hpOill12345678@1992531200000-1';
+    channel.properties.channelSerial = secondChannelSerial;
+    channel.properties.attachSerial = secondAttachSerial;
+
+    // Initiate a re-attach this time with resume, should not cause listener points to reset to new attach serial
+    context.emulateBackendStateChange('attached', {
+      current: 'attached',
+      previous: 'attached',
+      resumed: true,
+    });
+
+    // Check we are using the previous channel serial
+    expectFunction = (_: string, params: GetMessagesQueryParams) => {
+      expect(params.fromSerial).toEqual(firstChannelSerial);
+    };
+
+    // Run a history query for the listener and check the chat api call is made with the first channel serial
+    await room.messages.getBeforeSubscriptionStart(listenerAfterAttach, { limit: 50 });
+
+    // Initiate a re-attach this time without resume, should cause listener points to reset to new attach serial
+    context.emulateBackendStateChange('attached', {
+      current: 'attached',
+      previous: 'attached',
+      resumed: false,
+    });
+
+    // Check we are using the new attach serial
+    expectFunction = (_: string, params: GetMessagesQueryParams) => {
+      expect(params.fromSerial).toEqual(secondAttachSerial);
+    };
+
+    // Run a history query for the listener and check the chat api call is made with the attach serial
+    await room.messages.getBeforeSubscriptionStart(listenerAfterAttach, { limit: 50 });
+  });
+
+  it<TestContext>('when update occurs, should query with correct params', async (context) => {
+    // We have tested most of the state change handling logic in previous tests, this test is to ensure that the correct
+    // update state change logic is followed when the current and previous states are 'attached'
+
+    const firstChannelSerial = '108hhDJ2hpInKn12345678@1992531200000-1';
+    const firstAttachSerial = '108hhDJBiKOihn12345678@1992531200000-1';
+
+    const testRoomId = 'roomId';
+    const testDirection = 'backwards';
+    const testLimit = 50;
+
+    let expectFunction: (roomId: string, params: GetMessagesQueryParams) => void = () => {};
+
+    // Mock the chat api call used by listener history query
+    const mockChatApi = {
+      getMessages: function (roomId: string, params: GetMessagesQueryParams): void {
+        expectFunction(roomId, params);
+      },
+    } as unknown as ChatApi;
+
+    // Create a room with the mock chat api
+    const room = new DefaultRoom('roomId', context.realtime, mockChatApi, testClientOptions(), makeTestLogger());
+
+    const channel = room.messages.channel as RealtimeChannel & {
+      properties: {
+        attachSerial: string | undefined;
+        channelSerial: string | undefined;
+      };
+    };
+
+    // Mock the whenState to resolve immediately
+    vi.spyOn(channel, 'whenState').mockImplementation(async () => {
+      return Promise.resolve(null);
+    });
+
+    // Set the timeserials for the channel
+    channel.properties.channelSerial = firstChannelSerial;
+    channel.properties.attachSerial = firstAttachSerial;
+
+    // Mock the channel state to be attached
+    vi.spyOn(channel, 'state', 'get').mockReturnValue('attached');
+
+    // Create a test listener
+    const listenerAfterAttach = () => {};
+
+    // Subscribe the listener to messages
+    await room.messages.subscribe(listenerAfterAttach);
+
+    // Check we are using the channel serial
+    expectFunction = (roomId: string, params: GetMessagesQueryParams) => {
+      expect(roomId).toEqual(testRoomId);
+      expect(params.direction).toEqual(testDirection);
+      expect(params.limit).toEqual(testLimit);
+      expect(params.fromSerial).toEqual(firstChannelSerial);
+    };
+
+    // Run a history query for the listener and check the chat api call is made with the channel serial
+    await room.messages.getBeforeSubscriptionStart(listenerAfterAttach, { limit: 50 });
+
+    // Change the attach and channel serials
+    const secondChannelSerial = '108StIJ2hpOihn12345678@1992531200000-1';
+    const secondAttachSerial = '108DrInOhpOihn12345678@1992531200000-1';
+    channel.properties.channelSerial = secondChannelSerial;
+    channel.properties.attachSerial = secondAttachSerial;
+
+    // Initiate a re-attach this time with resume, should not cause listener points to reset to new attach serial
+    context.emulateBackendStateChange('update', {
+      current: 'attached',
+      previous: 'attached',
+      resumed: true,
+    });
+
+    // Check we are using the previous channel serial
+    expectFunction = (_: string, params: GetMessagesQueryParams) => {
+      expect(params.fromSerial).toEqual(firstChannelSerial);
+    };
+
+    // Run a history query for the listener and check the chat api call is made with the previous channel serial
+    await room.messages.getBeforeSubscriptionStart(listenerAfterAttach, { limit: 50 });
+
+    // Initiate a re-attach this time without resume, should cause listener points to reset to new attach serial
+    context.emulateBackendStateChange('update', {
+      current: 'attached',
+      previous: 'attached',
+      resumed: false,
+    });
+
+    // Check we are using the new attach serial
+    expectFunction = (_: string, params: GetMessagesQueryParams) => {
+      expect(params.fromSerial).toEqual(secondAttachSerial);
+    };
+
+    // Run a history query for the listener and check the chat api call is made with the new attach serial
+    await room.messages.getBeforeSubscriptionStart(listenerAfterAttach, { limit: 50 });
+
+    // Change the attach serial again
+    channel.properties.attachSerial = '108DrInRiKGihn12345678@1992531200000-1';
+
+    // Initiate a update this time without matching previous and current states, should not trigger
+    // listener points to reset to new attach serial
+    context.emulateBackendStateChange('update', {
+      current: 'detaching',
+      previous: 'attached',
+      resumed: false,
+    });
+
+    // Check we are using the new attach serial
+    expectFunction = (_: string, params: GetMessagesQueryParams) => {
+      expect(params.fromSerial).toEqual(secondAttachSerial);
+    };
+
+    // Run a history query for the listener and check the chat api call is made with the previous attach serial
+    await room.messages.getBeforeSubscriptionStart(listenerAfterAttach, { limit: 50 });
+  });
+
+  it<TestContext>('should throw an error if listener query end time is later than query timeserial', async (context) => {
+    // Create a room instance
+    const room = makeRoom(context);
+
+    let caughtError: ErrorInfo | undefined;
+
+    const channel = room.messages.channel as RealtimeChannel & {
+      properties: {
+        attachSerial: string | undefined;
+        channelSerial: string | undefined;
+      };
+    };
+
+    // Set the timeserials for the channel
+    channel.properties.channelSerial = '108uyDJAgBOihn12345678@1772531200000-1';
+    channel.properties.attachSerial = '108uyDJAgBOihn12345678@1772531200000-1';
+
+    // Mock the channel state to be attached
+    vi.spyOn(channel, 'state', 'get').mockReturnValue('attached');
+
+    // Create a test listener
+    const listener1 = () => {};
+
+    // Subscribe to the messages
+    await room.messages.subscribe(listener1);
+
+    try {
+      // Attempt to query message history before subscribing a listener
+      await room.messages.getBeforeSubscriptionStart(listener1, { limit: 50, end: 1992531200000 });
+    } catch (e: unknown) {
+      // Expect an error to be thrown since no listener has been subscribed
+      caughtError = e as ErrorInfo;
+    }
+
+    // Assert that an error was caught
+    expect(caughtError).toBeDefined();
+    expect(caughtError?.message).toEqual(
+      'cannot query history; end time is after the subscription point of the listener',
+    );
+  });
 });

--- a/test/timeserial.test.ts
+++ b/test/timeserial.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { DefaultTimeserial } from '../src/Timeserial.js';
+
+describe('calculateTimeserial', () => {
+  it('parses a valid timeserial', () => {
+    const timeserial = 'abcdefghij@1672531200000-123:1';
+    const result = DefaultTimeserial.calculateTimeserial(timeserial);
+    expect(result).toEqual({
+      seriesId: 'abcdefghij',
+      timestamp: 1672531200000,
+      counter: 123,
+      index: 1,
+    });
+  });
+
+  it.each([
+    ['abcdefghij@1672531200000'], // No counter
+    ['abcdefghij@'], // No timestamp
+    ['abcdefghij'], // No series id
+  ])('throws an error with an invalid timeserial %s', (timeserial) => {
+    expect(() => DefaultTimeserial.calculateTimeserial(timeserial)).toThrow(new Error('Invalid timeserial'));
+  });
+
+  it('should be equal to the same timeserial', () => {
+    const timeserial = 'abcdefghij@1672531200000-123:1';
+    const result = DefaultTimeserial.calculateTimeserial(timeserial);
+    expect(result.equal(timeserial)).toBe(true);
+  });
+
+  it.each([
+    ['abcdefghij@1672531200000-123:1', 'abcdefghij@1672531200000-124:2', true], // Earlier index
+    ['abcdefghij@1672531200000-124:2', 'abcdefghij@1672531200000-123:1', false], // Later index
+    ['abcdefghij@1672531200000-123:1', 'abcdefghij@1672531200000-123:1', false], // Same index
+    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-124', true], // Earlier counter
+    ['abcdefghij@1672531200000-124', 'abcdefghij@1672531200000-123', false], // Later counter
+    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-123', false], // Same counter
+    ['abcdefghi@1672531200000-123', 'abcdefghij@1672531200000-123', true], // Earlier series id
+    ['abcdefghij@1672531200000-123', 'abcdefghi@1672531200000-123', false], // Later series id
+    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-123', false], // Same series id
+    ['abcdefghi@1672531200000-123', 'abcdefghij@1672531200001-123', true], // Earlier timestamp
+    ['abcdefghij@1672531200001-123', 'abcdefghij@1672531200000-123', false], // Later timestamp
+    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-123', false], // Same timestamp]
+  ])(`is before another timeserial %s, %s -> %o`, (firstTimeserialString, secondTimeserialString, expected) => {
+    const firstTimeserial = DefaultTimeserial.calculateTimeserial(firstTimeserialString);
+    const secondTimeserial = DefaultTimeserial.calculateTimeserial(secondTimeserialString);
+
+    expect(firstTimeserial.before(secondTimeserial)).toBe(expected);
+  });
+
+  it.each([
+    ['abcdefghij@1672531200000-123:1', 'abcdefghij@1672531200000-124:2', false], // Earlier index
+    ['abcdefghij@1672531200000-124:2', 'abcdefghij@1672531200000-123:1', true], // Later index
+    ['abcdefghij@1672531200000-123:1', 'abcdefghij@1672531200000-123:1', false], // Same index
+    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-124', false], // Earlier counter
+    ['abcdefghij@1672531200000-124', 'abcdefghij@1672531200000-123', true], // Later counter
+    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-123', false], // Same counter
+    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-124', false], // Earlier series id
+    ['abcdefghij@1672531200000-124', 'abcdefghij@1672531200000-123', true], // Later series id
+    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-123', false], // Same series id
+    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200001-123', false], // Earlier timestamp
+    ['abcdefghij@1672531200001-123', 'abcdefghij@1672531200000-123', true], // Later timestamp
+    ['abcdefghij@1672531200000-123', 'abcdefghij@1672531200000-123', false], // Same timestamp
+  ])('is after another timeserial %s, %s -> %o', (firstTimeserialString, secondTimeserialString, expected) => {
+    const firstTimeserial = DefaultTimeserial.calculateTimeserial(firstTimeserialString);
+    const secondTimeserial = DefaultTimeserial.calculateTimeserial(secondTimeserialString);
+    expect(firstTimeserial.after(secondTimeserial)).toBe(expected);
+  });
+
+  it('should return the original timeserial as a string', () => {
+    const timeserial = 'abcdefghij@1672531200000-123:1';
+    const result = DefaultTimeserial.calculateTimeserial(timeserial);
+    expect(result.toString()).toBe(timeserial);
+  });
+});


### PR DESCRIPTION
### Context

* [CHA-280]
* This work related to [CHADR-28]

### Description

* This PR adds a method to handle history queries for listeners that have been subscribed to chat messages, based on either the channel attachment serial or the latest message time serial (if we have received any messages).


### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.


[CHA-280]: https://ably.atlassian.net/browse/CHA-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ