### PR TITLE
CHA:352 Rename Presence Function Per API Review

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ const presentMembers = await room.presence.get();
 const presentMember = await room.presence.get({ clientId: 'client-id' });
 
 // You can call this to get a simple boolean value of whether a member is present or not
-const isPresent = await room.presence.userIsPresent('client-id');
+const isPresent = await room.presence.isUserPresent('client-id');
 ```
 
 Calls to `presence.get()` will return an array of the presence messages. Where each message contains the most recent

--- a/src/Presence.ts
+++ b/src/Presence.ts
@@ -115,7 +115,7 @@ export interface Presence {
    * @param {string} clientId - The client ID to check if it is present in the room.
    * @returns {Promise<{boolean}>} or upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
    */
-  userIsPresent(clientId: string): Promise<boolean>;
+  isUserPresent(clientId: string): Promise<boolean>;
 
   /**
    * Method to join room presence, will emit an enter event to all subscribers. Repeat calls will trigger more enter events.
@@ -225,7 +225,7 @@ export class DefaultPresence extends EventEmitter<PresenceEventsMap> implements 
   /**
    * @inheritDoc
    */
-  async userIsPresent(clientId: string): Promise<boolean> {
+  async isUserPresent(clientId: string): Promise<boolean> {
     const presenceSet = await this.subscriptionManager.channel.presence.get({ clientId: clientId });
     return presenceSet.length > 0;
   }

--- a/test/Presence.integration.test.ts
+++ b/test/Presence.integration.test.ts
@@ -194,10 +194,10 @@ describe('UserPresence', { timeout: 10000 }, () => {
     // Enter presence for a client
     await context.chatRoom.presence.enter();
     // Fetch the presence list and check if the client is present
-    const userIsPresent = await context.chatRoom.presence.userIsPresent(context.defaultTestClientId);
+    const userIsPresent = await context.chatRoom.presence.isUserPresent(context.defaultTestClientId);
     expect(userIsPresent, 'user with clientId should be present').toEqual(true);
     // Ensure that a user that has not entered presence is not present
-    const userIsNotPresent = await context.chatRoom.presence.userIsPresent('clientId2');
+    const userIsNotPresent = await context.chatRoom.presence.isUserPresent('clientId2');
     expect(userIsNotPresent, 'user with clientId1 should not be present').toEqual(false);
   });
 


### PR DESCRIPTION
Renamed presence function from userIsPresent to isUserPresent inline with the API design review.
[CHA-352]


[CHA-352]: https://ably.atlassian.net/browse/CHA-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ