### PR TITLE
CHA:351:  Rename of Messages Class Query Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,12 @@ so you must pass in the same reference that you subscribed.
 
 ### Query message history
 
-The messages object also exposes the `query` method which can be used to return historical messages in the chat room, according
+The messages object also exposes the `get` method which can be used to return historical messages in the chat room,
+according
 to the given criteria. It returns a paginated response that can be used to query for more messages.
 
 ```typescript
-const historicalMessages = await room.messages.query({ direction: 'backwards', limit: 50 });
+const historicalMessages = await room.messages.get({ direction: 'backwards', limit: 50 });
 console.log(historicalMessages.items);
 if (historicalMessages.hasNext()) {
   const next = await historicalMessages.next();

--- a/demo/src/hooks/useMessages.ts
+++ b/demo/src/hooks/useMessages.ts
@@ -34,7 +34,7 @@ export const useMessages = () => {
 
     const mounted = true;
     const initMessages = async () => {
-      const lastMessages = await room.messages.query({ limit: 100 });
+      const lastMessages = await room.messages.get({ limit: 100 });
       if (mounted) {
         setMessages((prevMessages) => combineMessages(prevMessages, lastMessages.items).reverse());
         setLoading(false);

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -154,7 +154,7 @@ export interface Messages {
    * @returns A promise that resolves with the paginated result of messages. This paginated result can
    * be used to fetch more messages if available.
    */
-  query(options: QueryOptions): Promise<PaginatedResult<Message>>;
+  get(options: QueryOptions): Promise<PaginatedResult<Message>>;
 
   /**
    * Send a message in the chat room.
@@ -212,7 +212,7 @@ export class DefaultMessages extends EventEmitter<MessageEventsMap> implements M
   /**
    * @inheritdoc Messages
    */
-  async query(options: QueryOptions): Promise<PaginatedResult<Message>> {
+  async get(options: QueryOptions): Promise<PaginatedResult<Message>> {
     this._logger.trace('Messages.query();');
     return this._chatApi.getMessages(this._roomId, options);
   }

--- a/test/Chat.integration.test.ts
+++ b/test/Chat.integration.test.ts
@@ -28,7 +28,7 @@ describe('Chat', () => {
     expect(occupancy).toEqual(expect.objectContaining({ connections: 0, presenceMembers: 0 }));
 
     // Request history, and expect it to succeed
-    const history = (await chat.rooms.get('test').messages.query({ limit: 1 })).items;
+    const history = (await chat.rooms.get('test').messages.get({ limit: 1 })).items;
     expect(history).toEqual(
       expect.arrayContaining([expect.objectContaining({ text: 'my message', clientId: chat.clientId })]),
     );
@@ -46,7 +46,7 @@ describe('Chat', () => {
     expect(occupancy).toEqual(expect.objectContaining({ connections: 0, presenceMembers: 0 }));
 
     // Request history, and expect it to succeed
-    const history = (await chat.rooms.get('test').messages.query({ limit: 1 })).items;
+    const history = (await chat.rooms.get('test').messages.get({ limit: 1 })).items;
     expect(history).toEqual(
       expect.arrayContaining([expect.objectContaining({ text: 'my message', clientId: chat.clientId })]),
     );

--- a/test/Messages.integration.test.ts
+++ b/test/Messages.integration.test.ts
@@ -84,7 +84,7 @@ describe('messages integration', () => {
     const message3 = await room.messages.send({ text: 'You underestimate my power!' });
 
     // Do a history request to get all 3 messages
-    const history = await room.messages.query({ limit: 3, direction: 'forwards' });
+    const history = await room.messages.get({ limit: 3, direction: 'forwards' });
 
     expect(history.items).toEqual([
       expect.objectContaining({
@@ -120,7 +120,7 @@ describe('messages integration', () => {
     const message4 = await room.messages.send({ text: "Don't try it!" });
 
     // Do a history request to get the first 3 messages
-    const history1 = await room.messages.query({ limit: 3, direction: 'forwards' });
+    const history1 = await room.messages.get({ limit: 3, direction: 'forwards' });
 
     expect(history1.items).toEqual([
       expect.objectContaining({
@@ -170,7 +170,7 @@ describe('messages integration', () => {
     const message4 = await room.messages.send({ text: "Don't try it!" });
 
     // Do a history request to get the last 3 messages
-    const history1 = await room.messages.query({ limit: 3, direction: 'backwards' });
+    const history1 = await room.messages.get({ limit: 3, direction: 'backwards' });
 
     expect(history1.items).toEqual([
       expect.objectContaining({
@@ -256,7 +256,7 @@ describe('messages integration', () => {
       expect.objectContaining(expectedMessages[1]),
     ]);
 
-    const history = await room.messages.query({ limit: 2, direction: 'forwards' });
+    const history = await room.messages.get({ limit: 2, direction: 'forwards' });
 
     expect(history.items.length).toEqual(2);
     expect(history.items, 'history messages to match').toEqual([


### PR DESCRIPTION
Renamed messages class function from 'query' to 'get' as per API design review.

[CHA-351]

[CHA-351]: https://ably.atlassian.net/browse/CHA-351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ