### PR TITLE
CHA-330: Update Presence Member Type

### DIFF
--- a/src/Presence.ts
+++ b/src/Presence.ts
@@ -80,14 +80,9 @@ export interface PresenceMember {
   extras: any;
 
   /**
-   * The Ably message id of the associated presence message.
+   * The timestamp of when the last change in state occurred for this presence member.
    */
-  id: string;
-
-  /**
-   * The timestamp of the presence message.
-   */
-  timestamp: number;
+  updatedAt: number;
 }
 
 /**
@@ -215,10 +210,9 @@ export class DefaultPresence extends EventEmitter<PresenceEventsMap> implements 
       action: user.action as PresenceEvents,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       data: user.data?.userCustomData as PresenceData,
-      timestamp: user.timestamp,
+      updatedAt: user.timestamp,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       extras: user.extras,
-      id: user.id,
     }));
   }
 


### PR DESCRIPTION
Removed the use of the 'id' field on the presence member type, it relates to the id of the underlying Ably message, and so isn't really useful here.
Update the timestamp field of the presence member type to 'updatedAt' for clarity.

[CHA-330]

[CHA-330]: https://ably.atlassian.net/browse/CHA-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ