### PR TITLE
Update reaction send signature and add headers and metadata

### DIFF
--- a/demo/src/hooks/useReactions.ts
+++ b/demo/src/hooks/useReactions.ts
@@ -7,7 +7,7 @@ export const useReactions = () => {
 
   const sendReaction = useCallback(
     (reaction: string) => {
-      room.reactions.send(reaction);
+      room.reactions.send({ type: reaction });
     },
     [room],
   );

--- a/src/Reaction.ts
+++ b/src/Reaction.ts
@@ -1,3 +1,16 @@
+import { Headers } from './Headers.js';
+import { Metadata } from './Metadata.js';
+
+/**
+ * {@link Headers} type for chat messages.
+ */
+export type ReactionHeaders = Headers;
+
+/**
+ * {@link Metadata} type for chat messages.
+ */
+export type ReactionMetadata = Metadata;
+
 /**
  * Represents a room-level reaction.
  */
@@ -8,9 +21,14 @@ export interface Reaction {
   readonly type: string;
 
   /**
-   * metadata of the reaction, if any was set
+   * Metadata of the reaction. If no metadata was set this is an empty object.
    */
-  readonly metadata?: unknown;
+  readonly metadata: ReactionMetadata;
+
+  /**
+   * Headers of the reaction. If no headers were set this is an empty object.
+   */
+  readonly headers: ReactionHeaders;
 
   /**
    * The timestamp at which the reaction was sent.
@@ -37,7 +55,8 @@ export class DefaultReaction implements Reaction {
     public readonly clientId: string,
     public readonly createdAt: Date,
     public readonly isSelf: boolean,
-    public readonly metadata: unknown,
+    public readonly metadata: ReactionMetadata,
+    public readonly headers: ReactionHeaders,
   ) {
     // The object is frozen after constructing to enforce readonly at runtime too
     Object.freeze(this);

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export type { Presence, PresenceData, PresenceEvent, PresenceListener, PresenceM
 export type { PaginatedResult } from './query.js';
 export type { Reaction } from './Reaction.js';
 export type { Room } from './Room.js';
-export type { RoomReactionListener, RoomReactions } from './RoomReactions.js';
+export type { RoomReactionListener, RoomReactions, SendReactionParams } from './RoomReactions.js';
 export type { Rooms } from './Rooms.js';
 export type { Typing, TypingEvent, TypingListener } from './Typing.js';
 export type { ChannelStateChange, ErrorInfo, RealtimePresenceParams } from 'ably';

--- a/test/RoomReactions.integration.test.ts
+++ b/test/RoomReactions.integration.test.ts
@@ -66,8 +66,8 @@ describe('room-level reactions integration test', () => {
     };
     await room.reactions.subscribe(subscriber);
 
-    for (const reactionType of expectedReactions) {
-      await room.reactions.send(reactionType);
+    for (const type of expectedReactions) {
+      await room.reactions.send({ type });
     }
 
     await waitForReactions(reactions, expectedReactions);


### PR DESCRIPTION
This makes reactions and messages consistent in how you send them.

It makes things simple as both headers and metadata work exactly the same for both.

### Context

- [CHA-360]
- [CHA-350] was the ticket for messages

Another small change is adding a check for the reactions.send() to make sure the type is set.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

[CHA-360]: https://ably.atlassian.net/browse/CHA-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CHA-350]: https://ably.atlassian.net/browse/CHA-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ