### PR TITLE
feature: Added Public Ably Message Parsers 

### DIFF
--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -1,0 +1,130 @@
+import * as Ably from 'ably';
+
+import { MessageEvents, RoomReactionEvents } from './events.js';
+import { Message } from './message.js';
+import { parseMessage } from './message-parser.js';
+import { Reaction } from './reaction.js';
+import { parseReaction } from './reaction-parser.js';
+
+/**
+ * Enum for chat entity types. This is used to determine the type of entity encoded in an inboundMessage-like object, and
+ * subsequently which method should be used to parse the entity.
+ */
+export enum ChatEntityType {
+  /**
+   * Represents a chat message type.
+   */
+  ChatMessage = 'chatMessage',
+  /**
+   * Represents a reaction type.
+   */
+  Reaction = 'reaction',
+}
+
+/**
+ * Helper function to validate the encoded object.
+ *
+ * @param encoded - The object to validate.
+ * @throws {@link ErrorInfo} - If the encoded object is invalid.
+ */
+function validateEncoded(encoded: unknown): void {
+  if (typeof encoded !== 'object' || encoded === null) {
+    throw new Ably.ErrorInfo('invalid encoded type; encoded is not type object or is null', 40000, 400);
+  }
+
+  if (!('name' in encoded) || typeof encoded.name !== 'string') {
+    throw new Ably.ErrorInfo('invalid encoded inbound message; message does not have a valid name field', 40000, 400);
+  }
+}
+
+/**
+ * A method to determine the type of entity encoded in an inboundMessage-like object.
+ *
+ * @param encoded - The deserialized inboundMessage-like object.
+ * @returns {'chatMessage' | 'reaction'} The type of entity encoded in the message.
+ * @throws {@link ErrorInfo} - If there is an error extracting the entity type from the message
+ */
+export function getEntityTypeFromEncoded(encoded: unknown): 'chatMessage' | 'reaction' {
+  validateEncoded(encoded);
+  // At this point, we know that the encoded object is an InboundMessage-like object
+  return getEntityTypeFromAblyMessage(encoded as Ably.InboundMessage);
+}
+
+/**
+ * A method to create a chat message from a deserialized inboundMessage-like object encoded by Ably.
+ *
+ * @param {unknown} encoded - The deserialized inboundMessage-like object.
+ * encryption options if you have chosen to encrypt the messages sent to your integration.
+ * @returns {Promise<Message>} A promise that resolves with a chat message.
+ * @throws {@link ErrorInfo} - If there is an error parsing the message.
+ */
+export async function chatMessageFromEncoded(encoded: unknown): Promise<Message> {
+  validateEncoded(encoded);
+
+  const message = await Ably.Realtime.Message.fromEncoded(encoded);
+
+  return chatMessageFromAblyMessage(message);
+}
+
+/**
+ * A method to create a reaction from a deserialized inboundMessage-like object encoded by Ably.
+ *
+ * @param {unknown} encoded - The deserialized inboundMessage-like object.
+ * encryption options if you have chosen to encrypt the messages sent to your integration.
+ * @returns {Promise<Reaction>} A promise that resolves with a reaction.
+ * @throws {@link ErrorInfo} - If there is an error parsing the message.
+ */
+export async function reactionFromEncoded(encoded: unknown): Promise<Reaction> {
+  validateEncoded(encoded);
+  const message = await Ably.Realtime.Message.fromEncoded(encoded);
+  return reactionFromAblyMessage(message);
+}
+
+/**
+ * A method to determine the type of entity in an inboundMessage object.
+ *
+ * @param message - The Ably inboundMessage object.
+ * @returns {ChatEntityType} The type of chat entity of the message.
+ * @throws {@link ErrorInfo} - If there is an error extracting the entity type from the message
+ */
+export function getEntityTypeFromAblyMessage(message: Ably.InboundMessage): ChatEntityType {
+  switch (message.name) {
+    case MessageEvents.Created: {
+      return ChatEntityType.ChatMessage;
+    }
+    case RoomReactionEvents.Reaction: {
+      return ChatEntityType.Reaction;
+    }
+    case undefined: {
+      throw new Ably.ErrorInfo(`received incoming message without event name`, 40000, 400);
+    }
+    default: {
+      throw new Ably.ErrorInfo(`unknown message type: ${message.name}`, 40000, 400);
+    }
+  }
+}
+
+/**
+ * Converts an Ably inboundMessage to a reaction. You can use the `getEntityTypeFromAblyMessage` method to determine
+ * if the type of the entity is a reaction before calling this method.
+ *
+ * @param {Ably.InboundMessage} ablyMessage - The inbound Ably message to convert.
+ * @returns Reaction - The converted reaction.
+ * @throws {@link ErrorInfo} - If there is an error parsing the message.
+ */
+export function reactionFromAblyMessage(ablyMessage: Ably.InboundMessage): Reaction {
+  return parseReaction(ablyMessage);
+}
+
+/**
+ * Converts an Ably inboundMessage to a chat message. You can use the `getEntityTypeFromAblyMessage` method to determine
+ * if the type of the entity is a chat message before calling this method.
+ *
+ * @param {Ably.InboundMessage} ablyMessage - The inbound Ably message to convert.
+ * @returns Message - The converted chat message.
+ * @throws {@link ErrorInfo} - If there is an error parsing the message.
+ */
+export function chatMessageFromAblyMessage(ablyMessage: Ably.InboundMessage): Message {
+  const roomId = ablyMessage.id.split(':')[2];
+  return parseMessage(roomId, ablyMessage);
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -16,6 +16,15 @@ export type { DiscontinuityListener, OnDiscontinuitySubscriptionResponse } from 
 export type { ErrorCodes } from './errors.js';
 export { MessageEvents, PresenceEvents } from './events.js';
 export type { Headers } from './headers.js';
+export {
+  ChatEntityType,
+  chatMessageFromAblyMessage,
+  chatMessageFromEncoded,
+  getEntityTypeFromAblyMessage,
+  getEntityTypeFromEncoded,
+  reactionFromAblyMessage,
+  reactionFromEncoded,
+} from './helpers.js';
 export type { LogContext, LogHandler } from './logger.js';
 export { LogLevel } from './logger.js';
 export type { Message, MessageHeaders, MessageMetadata } from './message.js';

--- a/src/core/message-parser.ts
+++ b/src/core/message-parser.ts
@@ -1,0 +1,57 @@
+import * as Ably from 'ably';
+
+import { DefaultMessage, Message, MessageHeaders, MessageMetadata } from './message.js';
+
+interface MessagePayload {
+  data?: {
+    text?: string;
+    metadata?: MessageMetadata;
+  };
+  clientId?: string;
+  timestamp: number;
+  extras?: {
+    timeserial?: string;
+    headers?: MessageHeaders;
+  };
+}
+
+export function parseMessage(roomId: string | undefined, message: Ably.InboundMessage): Message {
+  const messageCreatedMessage = message as MessagePayload;
+  if (!roomId) {
+    throw new Ably.ErrorInfo(`received incoming message without roomId`, 50000, 500);
+  }
+
+  if (!messageCreatedMessage.data) {
+    throw new Ably.ErrorInfo(`received incoming message without data`, 50000, 500);
+  }
+
+  if (!messageCreatedMessage.clientId) {
+    throw new Ably.ErrorInfo(`received incoming message without clientId`, 50000, 500);
+  }
+
+  if (!messageCreatedMessage.timestamp) {
+    throw new Ably.ErrorInfo(`received incoming message without timestamp`, 50000, 500);
+  }
+
+  if (messageCreatedMessage.data.text === undefined) {
+    throw new Ably.ErrorInfo(`received incoming message without text`, 50000, 500);
+  }
+
+  if (!messageCreatedMessage.extras) {
+    throw new Ably.ErrorInfo(`received incoming message without extras`, 50000, 500);
+  }
+
+  if (!messageCreatedMessage.extras.timeserial) {
+    throw new Ably.ErrorInfo(`received incoming message without timeserial`, 50000, 500);
+  }
+
+  return new DefaultMessage(
+    messageCreatedMessage.extras.timeserial,
+    messageCreatedMessage.clientId,
+    roomId,
+    messageCreatedMessage.data.text,
+    new Date(messageCreatedMessage.timestamp),
+    messageCreatedMessage.data.metadata ?? {},
+    messageCreatedMessage.extras.headers ?? {},
+  );
+}

--- a/src/core/reaction-parser.ts
+++ b/src/core/reaction-parser.ts
@@ -1,0 +1,43 @@
+import * as Ably from 'ably';
+
+import { DefaultReaction, Reaction, ReactionHeaders, ReactionMetadata } from './reaction.js';
+
+interface ReactionPayload {
+  data?: {
+    type: string;
+    metadata?: ReactionMetadata;
+  };
+  clientId?: string;
+  timestamp: number;
+  extras?: {
+    headers?: ReactionHeaders;
+  };
+}
+
+export function parseReaction(message: Ably.InboundMessage, clientId?: string): Reaction {
+  const reactionCreatedMessage = message as ReactionPayload;
+  if (!reactionCreatedMessage.data) {
+    throw new Ably.ErrorInfo(`received incoming message without data`, 50000, 500);
+  }
+
+  if (!reactionCreatedMessage.data.type || typeof reactionCreatedMessage.data.type !== 'string') {
+    throw new Ably.ErrorInfo('invalid reaction message with no type', 50000, 500);
+  }
+
+  if (!reactionCreatedMessage.clientId) {
+    throw new Ably.ErrorInfo(`received incoming message without clientId`, 50000, 500);
+  }
+
+  if (!reactionCreatedMessage.timestamp) {
+    throw new Ably.ErrorInfo(`received incoming message without timestamp`, 50000, 500);
+  }
+
+  return new DefaultReaction(
+    reactionCreatedMessage.data.type,
+    reactionCreatedMessage.clientId,
+    new Date(reactionCreatedMessage.timestamp),
+    clientId ? clientId === reactionCreatedMessage.clientId : false,
+    reactionCreatedMessage.data.metadata ?? {},
+    reactionCreatedMessage.extras?.headers ?? {},
+  );
+}

--- a/test/core/helpers.test.ts
+++ b/test/core/helpers.test.ts
@@ -1,0 +1,143 @@
+import * as Ably from 'ably';
+import { describe, expect, it } from 'vitest';
+
+import { MessageEvents } from '../../src/core/events.js';
+import { RoomReactionEvents } from '../../src/core/events.ts';
+import { chatMessageFromEncoded, getEntityTypeFromEncoded, reactionFromEncoded } from '../../src/core/helpers.js';
+import { DefaultMessage } from '../../src/core/message.js';
+import { DefaultReaction } from '../../src/core/reaction.js';
+
+const TEST_ENVELOPED_MESSAGE = {
+  id: 'chat:6TP2sA:some-room:219f7afc614af7b:0',
+  clientId: 'user1',
+  timestamp: 1719948956834,
+  encoding: 'json',
+  extras: {
+    timeserial: '108TeGZDQBderu97202638@1719948956834-0',
+    headers: {},
+  },
+  data: '{"text":"I have the high ground now","metadata":{}}',
+  name: 'message.created',
+};
+
+const TEST_ENVELOPED_ROOM_REACTION = {
+  id: 'NtORcEMDdH:0:0',
+  clientId: 'user1',
+  connectionId: 'NtORcEMDdH',
+  timestamp: 1719948877991,
+  encoding: 'json',
+  data: '{"type":"like"}',
+  name: 'roomReaction',
+};
+
+describe('helpers', () => {
+  describe('fromEncodedChatMessage', () => {
+    it('should return a chat message', async () => {
+      const result = await chatMessageFromEncoded(TEST_ENVELOPED_MESSAGE);
+      expect(result).toEqual(
+        new DefaultMessage(
+          '108TeGZDQBderu97202638@1719948956834-0',
+          'user1',
+          'some-room',
+          'I have the high ground now',
+          new Date(1719948956834),
+          {},
+          {},
+        ),
+      );
+    });
+
+    it('should throw an error if message does not match a chat message type', async () => {
+      await expect(async () => {
+        await chatMessageFromEncoded({
+          id: 'chat:6TP2sA:some-room:219f7afc614af7b:0',
+          clientId: 'user1',
+          timestamp: 1719948956834,
+          encoding: 'json',
+          extras: {
+            timeserial: '108TeGZDQBderu97202638@1719948956834-0',
+            headers: {},
+          },
+          name: 'message.created',
+        });
+      }).rejects.toBeErrorInfo({
+        code: 50000,
+        message: 'received incoming message without data',
+      });
+    });
+  });
+
+  describe('fromEncodedRoomReaction', () => {
+    it('should return a room reaction', async () => {
+      const result = await reactionFromEncoded(TEST_ENVELOPED_ROOM_REACTION);
+      expect(result).toEqual(new DefaultReaction('like', 'user1', new Date(1719948877991), false, {}, {}));
+    });
+
+    it('should throw an error if message does not match a room reaction type', async () => {
+      await expect(async () => {
+        await reactionFromEncoded({
+          id: 'NtORcEMDdH:0:0',
+          clientId: 'user1',
+          connectionId: 'NtORcEMDdH',
+          timestamp: 1719948877991,
+          encoding: 'json',
+          name: 'message.created',
+        });
+      }).rejects.toBeErrorInfo({
+        code: 50000,
+        message: 'received incoming message without data',
+      });
+    });
+  });
+
+  describe('getEntityTypeFromEncoded', () => {
+    describe.each([
+      {
+        description: 'encoded is undefined',
+        encoded: undefined,
+        expectedError: 'invalid encoded type; encoded is not type object or is null',
+      },
+      {
+        description: 'encoded is null',
+        encoded: null,
+        expectedError: 'invalid encoded type; encoded is not type object or is null',
+      },
+      {
+        description: 'encoded does not have a name property',
+        encoded: { notName: 'notName' },
+        expectedError: 'invalid encoded inbound message; message does not have a valid name field',
+      },
+      {
+        description: 'name property is undefined',
+        encoded: { name: undefined },
+        expectedError: 'invalid encoded inbound message; message does not have a valid name field',
+      },
+      {
+        description: 'name property is unknown',
+        encoded: { name: 'unknownEvent' },
+        expectedError: 'unknown message type: unknownEvent',
+      },
+    ])('should throw an error', ({ description, encoded, expectedError }) => {
+      it(`should throw an error is ${description}`, () => {
+        expect(() => {
+          getEntityTypeFromEncoded(encoded);
+        }).toThrowErrorInfo({
+          code: 40000,
+          message: expectedError,
+        });
+      });
+    });
+
+    it('should return "chatMessage" for MessageEvents.created', () => {
+      const message = { name: MessageEvents.Created as string } as Ably.InboundMessage;
+      const result = getEntityTypeFromEncoded(message);
+      expect(result).toBe('chatMessage');
+    });
+
+    it('should return "roomReaction" for RoomReactionEvents.reaction', () => {
+      const message = { name: RoomReactionEvents.Reaction as string } as Ably.InboundMessage;
+      const result = getEntityTypeFromEncoded(message);
+      expect(result).toBe('reaction');
+    });
+  });
+});

--- a/test/core/message-parser.test.ts
+++ b/test/core/message-parser.test.ts
@@ -1,0 +1,94 @@
+import * as Ably from 'ably';
+import { describe, expect, it } from 'vitest';
+
+import { DefaultMessage } from '../../src/core/message.js';
+import { parseMessage } from '../../src/core/message-parser.js';
+
+describe('parseMessage', () => {
+  describe.each([
+    {
+      description: 'roomId is undefined',
+      roomId: undefined,
+      message: {},
+      expectedError: 'received incoming message without roomId',
+    },
+    {
+      description: 'message.data is undefined',
+      roomId: 'room1',
+      message: { clientId: 'client1', timestamp: 1234567890, extras: { timeserial: 'abcdefghij@1672531200000-123' } },
+      expectedError: 'received incoming message without data',
+    },
+    {
+      description: 'message.clientId is undefined',
+      roomId: 'room1',
+      message: {
+        data: { text: 'hello' },
+        timestamp: 1234567890,
+        extras: { timeserial: 'abcdefghij@1672531200000-123' },
+      },
+      expectedError: 'received incoming message without clientId',
+    },
+    {
+      description: 'message.timestamp is undefined',
+      roomId: 'room1',
+      message: {
+        data: { text: 'hello' },
+        clientId: 'client1',
+        extras: { timeserial: 'abcdefghij@1672531200000-123' },
+      },
+      expectedError: 'received incoming message without timestamp',
+    },
+    {
+      description: 'message.data.text is undefined',
+      roomId: 'room1',
+      message: {
+        data: {},
+        clientId: 'client1',
+        timestamp: 1234567890,
+        extras: { timeserial: 'abcdefghij@1672531200000-123' },
+      },
+      expectedError: 'received incoming message without text',
+    },
+    {
+      description: 'message.extras is undefined',
+      roomId: 'room1',
+      message: { data: { text: 'hello' }, clientId: 'client1', timestamp: 1234567890 },
+      expectedError: 'received incoming message without extras',
+    },
+    {
+      description: 'message.extras.timeserial is undefined',
+      roomId: 'room1',
+      message: { data: { text: 'hello' }, clientId: 'client1', timestamp: 1234567890, extras: {} },
+      expectedError: 'received incoming message without timeserial',
+    },
+  ])('should throw an error ', ({ description, roomId, message, expectedError }) => {
+    it(`should throw an error if ${description}`, () => {
+      expect(() => {
+        parseMessage(roomId, message as Ably.InboundMessage);
+      }).toThrowErrorInfo({
+        code: 50000,
+        message: expectedError,
+      });
+    });
+  });
+
+  it('should return a DefaultMessage instance for a valid message', () => {
+    const message = {
+      data: { text: 'hello', metadata: { key: 'value' } },
+      clientId: 'client1',
+      timestamp: 1234567890,
+      extras: { timeserial: 'abcdefghij@1672531200000-123', headers: { headerKey: 'headerValue' } },
+    } as Ably.InboundMessage;
+
+    const result = parseMessage('room1', message);
+
+    expect(result).toBeInstanceOf(DefaultMessage);
+    expect(result.timeserial).toBe('abcdefghij@1672531200000-123');
+    expect(result.clientId).toBe('client1');
+    expect(result.roomId).toBe('room1');
+    expect(result.text).toBe('hello');
+    expect(result.createdAt).toEqual(new Date(1234567890));
+    expect(result.metadata).toEqual({ key: 'value' });
+    expect(result.headers).toEqual({ headerKey: 'headerValue' });
+  });
+});

--- a/test/core/reaction-parser.test.ts
+++ b/test/core/reaction-parser.test.ts
@@ -1,0 +1,75 @@
+import * as Ably from 'ably';
+import { describe, expect, it } from 'vitest';
+
+import { DefaultReaction } from '../../src/core/reaction.js';
+import { parseReaction } from '../../src/core/reaction-parser.js';
+
+describe('parseReaction', () => {
+  describe.each([
+    {
+      description: 'message.data is undefined',
+      message: {} as Ably.InboundMessage,
+      expectedError: 'received incoming message without data',
+    },
+    {
+      description: 'message.data.type is undefined',
+      message: { data: {}, clientId: 'client1', timestamp: 1234567890 },
+      expectedError: 'invalid reaction message with no type',
+    },
+    {
+      description: 'message.data.type is not a string',
+      message: { data: { type: 123 }, clientId: 'client1', timestamp: 1234567890 },
+      expectedError: 'invalid reaction message with no type',
+    },
+    {
+      description: 'message.clientId is undefined',
+      message: { data: { type: 'like' }, timestamp: 1234567890 },
+      expectedError: 'received incoming message without clientId',
+    },
+    {
+      description: 'message.timestamp is undefined',
+      message: { data: { type: 'like' }, clientId: 'client1' },
+      expectedError: 'received incoming message without timestamp',
+    },
+  ])('should throw an error', ({ description, message, expectedError }) => {
+    it(`should throw the error if ${description}`, () => {
+      expect(() => {
+        parseReaction(message as Ably.InboundMessage);
+      }).toThrowErrorInfo({
+        code: 50000,
+        message: expectedError,
+      });
+    });
+  });
+
+  it('should return a DefaultReaction instance for a valid message', () => {
+    const message = {
+      data: { type: 'like', metadata: { key: 'value' } },
+      clientId: 'client1',
+      timestamp: 1234567890,
+      extras: { headers: { headerKey: 'headerValue' } },
+    } as Ably.InboundMessage;
+
+    const result = parseReaction(message);
+
+    expect(result).toBeInstanceOf(DefaultReaction);
+    expect(result.type).toBe('like');
+    expect(result.clientId).toBe('client1');
+    expect(result.createdAt).toEqual(new Date(1234567890));
+    expect(result.isSelf).toBe(false);
+    expect(result.metadata).toEqual({ key: 'value' });
+    expect(result.headers).toEqual({ headerKey: 'headerValue' });
+  });
+
+  it('should set isFromCurrentUser to true if clientId matches', () => {
+    const message = {
+      data: { type: 'like' },
+      clientId: 'client1',
+      timestamp: 1234567890,
+    } as Ably.InboundMessage;
+
+    const result = parseReaction(message, 'client1');
+
+    expect(result.isSelf).toBe(true);
+  });
+});


### PR DESCRIPTION
### Context

* [CHA-337]
* Users may wish to make use of ably's integration offerings, such as webhooks/AWS lambdas, where messages/reactions etc. sent to the room can be filtered and sent to an integration. It would be useful to have some functions set up that users can pass an encoded inbound message-like object and decode them straight into a chat type like a message or reaction.

### Description

- Added two functions that take an encoded ably message, such as those sent via integration rules, and try to convert them into chat types. 
  - Added fromEncodedChatMessage function that will try and convert the message into a chat message. 
  - Added fromEncodedReaction function that will try and convert the message into a reaction.

- Added getEntityTypeFromEncoded function that will also take an encoded message, and attempt to resolve the chat entity type, currently either a chat message or reaction. This can then be used to inform the user which of the two fromEncoded function you need to use.

- Added two functions that take an ably inbound message, and try to convert them into chat types. 
  - Added fromAblyMessageToReaction function that will take an ably inboundMessage and try to convert it to a reaction
  - Added fromAblyMessageToChatMessage function that will take an ably inboundMessage and try to convert it to a chat message.

- Added getEntityTypeFromAblyMessage function that will take inboundMessage, and attempt to resolve the chat entity type, currently either a chat message or reaction. This can then be used to inform the user which of the two fromAblyMessage functions you need to use.

- Moved message and reaction parsing to internal folders for reuse outside their previous classes. Added testing for message and reaction parsing since it wasn't covered comprehensively.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.


[CHA-337]: https://ably.atlassian.net/browse/CHA-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ