### PR TITLE
Make demo app multi-room by accepting a `room` query parameter.

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -3,13 +3,25 @@ import { ChatClient as ChatSdk } from '@ably-labs/chat';
 import { RoomProvider } from './containers/RoomContext';
 import { Chat } from './containers/Chat';
 
+let roomId: string;
+(function () {
+  const params = new URLSearchParams(window.location.search);
+  if (!params.has('room')) {
+    roomId = 'abcd';
+    params.set('room', roomId);
+    history.replaceState(null, '', '?' + params.toString());
+  } else {
+    roomId = params.get('room')!;
+  }
+})();
+
 interface AppProps {
   client: ChatSdk;
 }
 const App: FC<AppProps> = ({ client }) => (
   <RoomProvider
     client={client}
-    roomId="abcd"
+    roomId={roomId}
   >
     <Chat />
   </RoomProvider>


### PR DESCRIPTION
On load the page changes history to the default "abcd" room if no other room is set. If you change the URL you use a different room.

Useul for demos where you don't want the history of your own testing to leak, and also useful if you want to demo to sub-groups of people.
