### PR TITLE
demo app: call stop typing if the input text becomes empty so the there's no delay if you delete what you're typing

### DIFF
--- a/demo/src/components/MessageInput/MessageInput.tsx
+++ b/demo/src/components/MessageInput/MessageInput.tsx
@@ -23,7 +23,11 @@ export const MessageInput: FC<MessageInputProps> = ({
 }) => {
   const handleValueChange: ChangeEventHandler<HTMLInputElement> = ({ target }) => {
     onValueChange(target.value);
-    onStartTyping();
+    if (target.value && target.value.length > 0) {
+      onStartTyping();
+    } else {
+      onStopTyping();
+    }
   };
 
   const handleFormSubmit: FormEventHandler<HTMLFormElement> = (event) => {


### PR DESCRIPTION
What the title says.

It feels snappier when we call `stop()` when playing with two browser tabs side by side (which is likely the main use case of the demo)