### PR TITLE
docs: clarify the boundaries of before and after on messages

### DIFF
--- a/src/Message.ts
+++ b/src/Message.ts
@@ -71,7 +71,9 @@ export interface Message {
   readonly headers: MessageHeaders;
 
   /**
-   * Determines if this message was created before the given message.
+   * Determines if this message was created before the given message. This comparison is based on
+   * global order, so does not necessarily represent the order that messages are received in realtime
+   * from the backend.
    * @param message The message to compare against.
    * @returns true if this message was created before the given message, in global order.
    * @throws {@link ErrorInfo} if timeserial of either message is invalid.
@@ -79,7 +81,9 @@ export interface Message {
   before(message: Message): boolean;
 
   /**
-   * Determines if this message was created after the given message.
+   * Determines if this message was created after the given message. This comparison is based on
+   * global order, so does not necessarily represent the order that messages are received in realtime
+   * from the backend.
    * @param message The message to compare against.
    * @returns true if this message was created after the given message, in global order.
    * @throws {@link ErrorInfo} if timeserial of either message is invalid.


### PR DESCRIPTION
### Description

Clarifies that before and after on messages compare them in the global non-realtime order.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

### Testing Instructions (Optional)

N/A
