### PR TITLE
Style - Homogenise Subscription Response Off/Unsubscribe Conventions

### DIFF
--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -136,7 +136,7 @@ export interface MessageSubscriptionResponse {
   /**
    * Unsubscribe the listener registered with {@link Messages.subscribe} from message events.
    */
-  unsubscribe(): void;
+  unsubscribe: () => void;
 
   /**
    * Get the previous messages that were sent to the room before the listener was subscribed.

--- a/src/discontinuity.ts
+++ b/src/discontinuity.ts
@@ -25,7 +25,7 @@ export interface OnDiscontinuitySubscriptionResponse {
   /**
    * Unsubscribe from discontinuity events.
    */
-  off(): void;
+  off: () => void;
 }
 
 /**


### PR DESCRIPTION
### Context

* MessageSubscriptionResponse and the OnDiscontinuitySubscriptionResponse had unsubscribe/off defined as a method where all others had it defined as a property.

### Description

*  Updated it to a property so we follow the same pattern everywhere.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [ ] (Optional) Update documentation for new features.
