### PR TITLE
build: enable npm publish provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: 'write'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -22,4 +23,4 @@ jobs:
         run: |
           npm ci
           npm run build
-          npm publish --access=public
+          npm publish --provenance --access public


### PR DESCRIPTION
### Context

[CHA-220]

### Description

This change adds npm publish provenance, which provides a clear link between our npm publish and where that publish came from. We therefore improve our transparency and supply-chain security.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

### Testing Instructions (Optional)

We need to create our first release before we can test this.

[CHA-220]: https://ably.atlassian.net/browse/CHA-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ