### PR TITLE
test: enable coverage reports by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "format": "prettier --write src test __mocks__ demo/src",
     "format:check": "prettier --check src test __mocks__ demo/src",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
     "test:chat": "vitest run --project chat",
     "test:react": "vitest run --project react-hooks",
     "test:watch": "vitest watch",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,9 +19,4 @@ export default defineConfig({
     },
     sourcemap: true,
   },
-  test: {
-    coverage: {
-      include: ['src/**/*.ts'],
-    },
-  },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      enabled: true,
+      include: ['src/**/*'],
+      reporter: ['text', 'html', 'json-summary', 'json'],
+      reportOnFailure: true,
+      thresholds: {
+        statements: 93,
+        branches: 92,
+        functions: 92,
+        lines: 93,
+      },
+    },
+  },
+});


### PR DESCRIPTION
### Context

[CHA-220]

### Description

- generate test coverage reports by default on every test run
- require tests to pass the coverage thresholds

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

### Testing Instructions (Optional)

N/A

[CHA-220]: https://ably.atlassian.net/browse/CHA-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ