### PR TITLE
release: fix cdn deploy script

### DIFF
--- a/scripts/cdn_deploy.js
+++ b/scripts/cdn_deploy.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
-const AWS = require('aws-sdk');
-const fs = require('fs');
-const path = require('path');
-const { exec } = require('child_process');
-const argv = require('minimist')(process.argv.slice(2));
+import AWS from 'aws-sdk';
+import fs from 'fs';
+import path from 'path';
+import { exec } from 'child_process';
+import minimist from 'minimist';
+const argv = minimist(process.argv.slice(2));
 const S3_DEFAULT_BUCKET = 'prod-cdn.ably.com';
 const S3_DEFAULT_ROOT = 'lib';
 


### PR DESCRIPTION
### Context

[CHA-220]

### Description

- Fix the CDN deploy script to run when the repo is a module.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

### Testing Instructions (Optional)

Run `node scripts/cdn_deploy.js --skipCheckout --tag=0.1.0` - it won't work locally but it at least won't error because of imports.


[CHA-220]: https://ably.atlassian.net/browse/CHA-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ