### PR TITLE
dev: add eslint plugin for browser compatibility

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,14 +10,15 @@ module.exports = {
     sourceType: 'module',
     project: ['./tsconfig.json', './tsconfig.test.json', './src/react/tsconfig.json', './src/react/tsconfig.test.json'],
   },
-  plugins: ['@typescript-eslint', 'security', 'jsdoc', 'import', 'simple-import-sort'],
+  plugins: ['@typescript-eslint', 'security', 'jsdoc', 'import', 'simple-import-sort', 'compat'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended-type-checked',
     'plugin:@typescript-eslint/strict-type-checked',
     'plugin:@typescript-eslint/stylistic-type-checked',
     'plugin:security/recommended-legacy',
-    'plugin:import/recommended'
+    'plugin:import/recommended',
+    'plugin:compat/recommended'
   ],
   rules: {
     'eol-last': 'error',
@@ -117,7 +118,8 @@ module.exports = {
     'vite.config.ts',
     'vitest.workspace.ts',
     'test/helper/testSetup.ts',
-    '__mocks__'
+    '__mocks__',
+    'coverage/'
   ],
   settings: {
     jsdoc: {

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -51,6 +51,7 @@
         "aws-sdk": "^2.1656.0",
         "cspell": "^8.10.1",
         "eslint": "^8.57.0",
+        "eslint-plugin-compat": "^5.0.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jsdoc": "^48.5.0",
         "eslint-plugin-react": "^7.34.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "aws-sdk": "^2.1656.0",
         "cspell": "^8.10.1",
         "eslint": "^8.57.0",
+        "eslint-plugin-compat": "^5.0.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jsdoc": "^48.5.0",
         "eslint-plugin-react": "^7.34.3",
@@ -1262,6 +1263,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mdn/browser-compat-data": {
+      "version": "5.5.38",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.5.38.tgz",
+      "integrity": "sha512-rwwTAkFM5CRuECirmKB/OoG1MXW9v8LAWv8u4NBu8cghRf6zNIKVJ9s+7TT5tXwLRlfbTR2sb7V0rWcD68eXhg==",
+      "dev": true
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.43.0",
@@ -2771,6 +2778,15 @@
         "node": "*"
       }
     },
+    "node_modules/ast-metadata-inferer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.8.0.tgz",
+      "integrity": "sha512-jOMKcHht9LxYIEQu+RVd22vtgrPaVCtDRQ/16IGmurdzxvYbDd5ynxjnyrzLnieG96eTcAyaoj/wN/4/1FyyeA==",
+      "dev": true,
+      "dependencies": {
+        "@mdn/browser-compat-data": "^5.2.34"
+      }
+    },
     "node_modules/async-mutex": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
@@ -4119,6 +4135,28 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-compat": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-5.0.0.tgz",
+      "integrity": "sha512-29KNWyFkUbNVf6TIKVe9SVCGCtHjML3HnUg9C8LG2GsXf7miAeBOgdMc1n2B5n0sHUzg1/A4IFly7Jyf1gSbgQ==",
+      "dev": true,
+      "dependencies": {
+        "@mdn/browser-compat-data": "^5.5.19",
+        "ast-metadata-inferer": "^0.8.0",
+        "browserslist": "^4.23.0",
+        "caniuse-lite": "^1.0.30001605",
+        "find-up": "^5.0.0",
+        "globals": "^13.24.0",
+        "lodash.memoize": "^4.1.2",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=14.x"
+      },
+      "peerDependencies": {
+        "eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -6086,6 +6124,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true
     },
     "node_modules/lodash.merge": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "aws-sdk": "^2.1656.0",
     "cspell": "^8.10.1",
     "eslint": "^8.57.0",
+    "eslint-plugin-compat": "^5.0.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsdoc": "^48.5.0",
     "eslint-plugin-react": "^7.34.3",
@@ -97,5 +98,9 @@
   "optionalDependencies": {
     "@rollup/rollup-darwin-arm64": "^4.18",
     "@rollup/rollup-linux-x64-gnu": "^4.18"
-  }
+  },
+  "browserslist": [
+    "defaults",
+    "not op_mini all"
+  ]
 }


### PR DESCRIPTION
[CHA-396]

### Description

Adds the eslint-plugin-compat plugin to our eslint config that checks browser conformance.

The settings are for all "modern" browsers, except opera mini, as that doesn't support promises.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.

### Testing Instructions (Optional)

To prove plugin is doing as intended - remove the "not op_mini all" from package.json and run lint, it should fail.


[CHA-396]: https://ably.atlassian.net/browse/CHA-396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ