### PR TITLE
react-hooks: add useChatClient hook, related context and provider

### DIFF
--- a/__mocks__/ably/index.ts
+++ b/__mocks__/ably/index.ts
@@ -170,6 +170,9 @@ class MockRealtime {
     requestToken(): void;
   };
   public connection: ReturnType<typeof createMockConnection>;
+  private options: {
+    agents?: Record<string, string | undefined>;
+  };
 
   public time() {}
 
@@ -197,6 +200,11 @@ class MockRealtime {
       clientId: client_id,
       requestToken: () => {},
     };
+
+    this.options = {
+      agents: {},
+    };
+
     this.connection = createMockConnection();
   }
 

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -34,7 +34,7 @@
     },
     "..": {
       "name": "@ably/chat",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "async-mutex": "^0.5.0",

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,5 +1,4 @@
 import { FC } from 'react';
-import { ChatClient as ChatSdk } from '@ably/chat';
 import { RoomProvider } from './containers/RoomContext';
 import { Chat } from './containers/Chat';
 import { OccupancyComponent } from './components/OccupancyComponent';
@@ -21,19 +20,14 @@ let roomId: string;
   }
 })();
 
-interface AppProps {
-  client: ChatSdk;
-}
+interface AppProps {}
 
-const App: FC<AppProps> = ({ client }) => (
-  <RoomProvider
-    client={client}
-    roomId={roomId}
-  >
-    <div style={{ display: 'flex', justifyContent: 'space-between', width: '800px' }}>
+const App: FC<AppProps> = () => (
+  <RoomProvider roomId={roomId}>
+    <div style={{ display: 'flex', justifyContent: 'space-between', width: '800px', height: '800px' }}>
       <Chat />
       <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <UserPresenceComponent clientId={client.clientId} />
+        <UserPresenceComponent />
         <OccupancyComponent />
       </div>
     </div>

--- a/demo/src/components/UserPresenceComponent/UserPresenceComponent.tsx
+++ b/demo/src/components/UserPresenceComponent/UserPresenceComponent.tsx
@@ -3,14 +3,14 @@ import { usePresence } from '../../hooks/usePresence';
 import '../../../styles/global.css';
 import './UserPresenceComponent.css';
 import { PresenceMember } from '@ably/chat';
+import { useChatClient } from '@ably/chat/react';
 
-interface UserListComponentProps {
-  clientId: string;
-}
+interface UserListComponentProps {}
 
-export const UserPresenceComponent: FC<UserListComponentProps> = ({ clientId }) => {
+export const UserPresenceComponent: FC<UserListComponentProps> = () => {
   const [isPanelOpen, setIsPanelOpen] = useState(true);
   const { loading, presenceMembers, enterPresence, updatePresence, leavePresence } = usePresence();
+  const clientId = useChatClient().clientId;
 
   const onEnterPresence = useCallback(() => {
     enterPresence({ status: 'online' })

--- a/demo/src/containers/RoomContext/RoomProvider.tsx
+++ b/demo/src/containers/RoomContext/RoomProvider.tsx
@@ -1,13 +1,15 @@
 import { FC, ReactNode, useMemo } from 'react';
-import { ChatClient, RoomOptionsDefaults } from '@ably/chat';
+import { RoomOptionsDefaults } from '@ably/chat';
 import { RoomContext } from './RoomContext';
+import { useChatClient } from '@ably/chat/react';
 
 interface RoomProviderProps {
-  client: ChatClient;
   roomId: string;
   children: ReactNode;
 }
-export const RoomProvider: FC<RoomProviderProps> = ({ client, roomId: roomId, children }) => {
+
+export const RoomProvider: FC<RoomProviderProps> = ({ roomId: roomId, children }) => {
+  const client = useChatClient();
   const value = useMemo(
     () => ({
       client,

--- a/demo/src/main.tsx
+++ b/demo/src/main.tsx
@@ -5,6 +5,8 @@ import { ChatClient, LogLevel } from '@ably/chat';
 import { nanoid } from 'nanoid';
 import App from './App.tsx';
 import './index.css';
+import { ChatClientProvider } from '@ably/chat/react';
+import { AblyProvider } from 'ably/react';
 
 // Generate a random clientId and remember it for the length of the session, so
 // if refreshing the page you still see your own messages as yours.
@@ -31,17 +33,21 @@ const clientId = (function () {
 //   clientId,
 // });
 
-const ablyClient = new Ably.Realtime({
+const realtimeClient = new Ably.Realtime({
   authUrl: `/api/ably-token-request?clientId=${clientId}`,
   restHost: import.meta?.env?.VITE_ABLY_HOST ? import.meta.env.VITE_ABLY_HOST : undefined,
   realtimeHost: import.meta?.env?.VITE_ABLY_HOST ? import.meta.env.VITE_ABLY_HOST : undefined,
   clientId,
 });
 
-const chatClient = new ChatClient(ablyClient, { logLevel: LogLevel.Debug });
+const chatClient = new ChatClient(realtimeClient, { logLevel: LogLevel.Debug });
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App client={chatClient} />
+    <AblyProvider client={realtimeClient}>
+      <ChatClientProvider client={chatClient}>
+        <App />
+      </ChatClientProvider>
+    </AblyProvider>
   </React.StrictMode>,
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ably/chat",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ably/chat",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "async-mutex": "^0.5.0",

--- a/src/core/chat.ts
+++ b/src/core/chat.ts
@@ -42,9 +42,8 @@ export class ChatClient {
     this._clientOptions = normalizeClientOptions(clientOptions);
     const logger = makeLogger(this._clientOptions);
     this._connection = new DefaultConnection(new DefaultConnectionStatus(realtime, logger));
-
     this._rooms = new DefaultRooms(realtime, this._clientOptions, logger);
-    this._setAgent();
+    this._addAgent('chat-js');
     logger.trace(`ably chat client version ${VERSION}; initialized`);
   }
 
@@ -93,12 +92,22 @@ export class ChatClient {
   }
 
   /**
-   * Sets the agent string for the client.
+   * Adds additional agent information to the client.
+   * Used internally to add React-specific agent information.
+   * @param agent - The agent to add.
    * @internal
    */
-  private _setAgent(): void {
+  public addReactAgent(): void {
+    this._addAgent('chat-react');
+  }
+
+  /**
+   * Sets the agent string for the client.
+   * @param agent - The agent to add.
+   * @internal
+   */
+  private _addAgent(agent: string): void {
     const realtime = this._realtime as RealtimeWithOptions;
-    const agent = { 'chat-js': VERSION };
-    realtime.options.agents = { ...(realtime.options.agents ?? realtime.options.agents), ...agent };
+    realtime.options.agents = { ...(realtime.options.agents ?? realtime.options.agents), [agent]: VERSION };
   }
 }

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -1,0 +1,47 @@
+# Chat React Usage Guide
+
+This document provides a brief guide on how to use custom chat components and hooks provided by the Ably Chat SDK.
+
+## ChatClientProvider
+
+This provider is used to provide the `ChatClient` instance to all child components in your React component tree.
+
+To use it, wrap your component tree with the `ChatClientProvider` and pass in the `ChatClient` instance you wish to
+use.
+
+```tsx
+import { ChatClientProvider } from '@ably/chat/react';
+import * as Ably from 'ably';
+import { LogLevel } from '@ably/chat';
+
+const realtimeClient = new Ably.Realtime({ key: 'api-key', clientId: 'clientId' });
+const chatClient = new ChatClient(realtimeClient);
+
+const App = () => {
+  return (
+    <ChatClientProvider client={chatClient}>
+      <RestOfYourApp />
+    </ChatClientProvider>
+  );
+};
+```
+
+The `ChatClient` instance will now be available to all child components in your React component tree.
+
+### useChatClient
+
+This hook allows you to access the `ChatClient` instance from your React components from the context provided by the
+`ChatClientProvider`.
+
+To use it, call the hook in your component, this will retrieve the `ChatClient` instance from the nearest
+`ChatClientProvider` in the component tree.
+
+```tsx
+import { useChatClient } from '@ably/chat/react';
+
+const MyComponent = () => {
+  const chatClient = useChatClient();
+  const clientId = chatClient.clientId;
+  return <div>Client id is: {clientId}</div>;
+};
+```

--- a/src/react/contexts/chat-client-context.tsx
+++ b/src/react/contexts/chat-client-context.tsx
@@ -1,0 +1,69 @@
+import { ChatClient } from '@ably/chat';
+import React from 'react';
+
+/**
+ * Context key to handle global context for Ably Chat Client.
+ * Only a single instance of Ably Chat context should exist to avoid issues resulted from multiple identical contexts,
+ * e.g., a Chat Client instance added in one context, and then attempted to retrieve it from a different context.
+ *
+ */
+const contextKey = Symbol.for('__ABLY_CHAT_CLIENT_CONTEXT__');
+
+/**
+ * Extends GlobalThis interface with chat context.
+ * The chat context is created once and stored in the global state to ensure a single context instance.
+ *
+ * @property {React.Context<ChatClientContextValue> | undefined} contextKey Ably Chat client context.
+ */
+interface GlobalThis {
+  [contextKey]?: React.Context<ChatClientContextValue>;
+}
+
+/**
+ * Object to encapsulate global context. Uses `globalThis` if defined.
+ * Protects against creating multiple instances of the context due to misconfigurations
+ * in module bundler or package manager configurations.
+ *
+ */
+const globalObjectForContext: GlobalThis = typeof globalThis === 'undefined' ? {} : (globalThis as GlobalThis);
+
+/**
+ * Props for a chat client context provider.
+ */
+export interface ChatClientContextProviderProps {
+  /**
+   Instance of the {@link ChatClient}
+   */
+  client: ChatClient;
+}
+
+/**
+ * Record of provider props for each chat client context provider, indexed by provider id.
+ *
+ */
+export type ChatClientContextValue = Record<string, ChatClientContextProviderProps>;
+
+/**
+ * Returns a chat client context.
+ * Retrieve the context from the global object if initialized,
+ * else, initialize and store the context in the global object.
+ *
+ * @return {React.Context<ChatClientContextValue>} Global context for ChatClient.
+ *
+ */
+function getChatContext(): React.Context<ChatClientContextValue> {
+  let context = globalObjectForContext[contextKey];
+  if (!context) {
+    context = globalObjectForContext[contextKey] = React.createContext<ChatClientContextValue>({});
+  }
+
+  return context;
+}
+
+/**
+ * Global context for ChatClientProvider.
+ * Access point for ChatClient context in the application.
+ *
+ * @type {React.Context<ChatClientContextValue>}
+ */
+export const ChatClientContext: React.Context<ChatClientContextValue> = getChatContext();

--- a/src/react/hooks/use-chat-client.ts
+++ b/src/react/hooks/use-chat-client.ts
@@ -1,0 +1,23 @@
+import { ChatClient } from '@ably/chat';
+import * as Ably from 'ably';
+import React from 'react';
+
+import { ChatClientContext } from '../contexts/chat-client-context.js';
+import { DEFAULT_CHAT_CLIENT_ID } from '../providers/chat-client-provider.js';
+
+/**
+ * Hook to access the chat client provided by `ChatClientContext`.
+ * This hook must be used within a `ChatClientProvider`.
+ *
+ * @throws {ErrorInfo} When the hook is not used within a `ChatClientProvider`.
+ *
+ * @returns {ChatClient} The chat client instance provided by the context.
+ *
+ */
+export const useChatClient = (): ChatClient => {
+  const context = React.useContext(ChatClientContext)[DEFAULT_CHAT_CLIENT_ID];
+  if (!context) {
+    throw new Ably.ErrorInfo('useChatClient hook must be used within a chat client provider', 40000, 400);
+  }
+  return context.client;
+};

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -2,4 +2,7 @@
  * @module chat-react
  */
 
+export { type ChatClientContextProviderProps } from './contexts/chat-client-context.js';
+export { useChatClient } from './hooks/use-chat-client.js';
 export { type TestHookReturnType, useCounter } from './hooks/use-counter.js';
+export { ChatClientProvider, type ChatClientProviderProps } from './providers/chat-client-provider.js';

--- a/src/react/providers/chat-client-provider.tsx
+++ b/src/react/providers/chat-client-provider.tsx
@@ -1,0 +1,44 @@
+import { ChatClient } from '@ably/chat';
+import * as React from 'react';
+import { ReactNode } from 'react';
+
+import { ChatClientContext, ChatClientContextValue } from '../contexts/chat-client-context.js';
+
+/**
+ * The default identifier for the chat client context.
+ */
+export const DEFAULT_CHAT_CLIENT_ID = 'default';
+
+/**
+ * Props for the ChatClientProvider component.
+ */
+export interface ChatClientProviderProps {
+  /**
+   * The child components to be rendered within this provider.
+   */
+  children?: ReactNode | ReactNode[] | null;
+
+  /**
+   * An instance of the chat client to be used in the provider.
+   */
+  client: ChatClient;
+}
+
+/**
+ * Returns a React component that provides a `ChatClient` in a React context to the component subtree.
+ * Updates the context value when the `ChatClient` prop changes.
+ *
+ * @param {ChatClientProviderProps} props - The props for the ChatClientProvider component.
+ *
+ * @returns {ChatClientProvider} component.
+ */
+export const ChatClientProvider = ({ children, client }: ChatClientProviderProps) => {
+  const context = React.useContext(ChatClientContext);
+  const value: ChatClientContextValue = React.useMemo(() => {
+    // Set the internal useReact option to true to enable React-specific agent.
+    client.addReactAgent();
+    return { ...context, [DEFAULT_CHAT_CLIENT_ID]: { client: client } };
+  }, [client, context]);
+
+  return <ChatClientContext.Provider value={value}>{children}</ChatClientContext.Provider>;
+};

--- a/src/react/tsconfig.json
+++ b/src/react/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["./hooks/**/*.ts", "index.ts"],
+  "include": ["./hooks/**/*.{ts,tsx}", "index.ts", "./contexts/**/*.{ts,tsx}", "./providers/**/*.{ts,tsx}"],
   "compilerOptions": {
     "rootDir": ".",
     "target": "es6",

--- a/test/core/chat.integration.test.ts
+++ b/test/core/chat.integration.test.ts
@@ -28,9 +28,18 @@ const waitForConnectionLifecycle = (chat: ChatClient, state: ConnectionLifecycle
 };
 
 describe('Chat', () => {
-  it('should set the agent string', () => {
+  it('should set the agent string on client instantiation', () => {
     const chat = newChatClient(testClientOptions());
     expect((chat.realtime as RealtimeWithOptions).options.agents).toEqual({ 'chat-js': VERSION });
+  });
+
+  it('should add a new agent string', () => {
+    const chat = newChatClient(testClientOptions());
+    chat.addReactAgent();
+    expect((chat.realtime as RealtimeWithOptions).options.agents).toEqual({
+      'chat-js': VERSION,
+      'chat-react': VERSION,
+    });
   });
 
   it('should mix in the client options', () => {

--- a/test/react/hooks/use-chat-client.test.tsx
+++ b/test/react/hooks/use-chat-client.test.tsx
@@ -1,0 +1,159 @@
+import { ChatClient } from '@ably/chat';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RealtimeWithOptions } from '../../../src/core/realtime-extensions.ts';
+import { VERSION } from '../../../src/core/version.ts';
+import { useChatClient } from '../../../src/react/hooks/use-chat-client.ts';
+import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
+import { newChatClient } from '../../helper/chat.ts';
+
+const TestComponent: React.FC<{ callback: (client: ChatClient) => void }> = ({ callback }) => {
+  const chatClient = useChatClient();
+  callback(chatClient);
+  return <div />;
+};
+
+vi.mock('ably');
+
+describe('useChatClient', () => {
+  it('it should throw an error if used outside of ChatClientProvider', () => {
+    expect(() => render(<TestComponent callback={() => {}} />)).toThrowErrorInfo({
+      code: 40000,
+      message: 'useChatClient hook must be used within a chat client provider',
+    });
+  });
+
+  it('it should get the chat client from the context without error and with the correct agent', () => {
+    const chatClient = newChatClient() as unknown as ChatClient;
+    const TestProvider = () => (
+      <ChatClientProvider client={chatClient}>
+        <TestComponent
+          callback={(client) => {
+            expect(client).toBe(chatClient);
+            const agents = (client.realtime as RealtimeWithOptions).options.agents;
+            expect(agents).toEqual({ 'chat-js': VERSION, 'chat-react': VERSION });
+          }}
+        />
+      </ChatClientProvider>
+    );
+    render(<TestProvider />);
+  });
+
+  it('it should provide the same chat client to nested components', () => {
+    let client1: ChatClient | undefined;
+    let client2: ChatClient | undefined;
+    const TestComponentInner = () => {
+      client1 = useChatClient();
+      return <div />;
+    };
+
+    const TestComponentOuter = () => {
+      client2 = useChatClient();
+      return <TestComponentInner />;
+    };
+
+    const chatClient = newChatClient() as unknown as ChatClient;
+    render(
+      <ChatClientProvider client={chatClient}>
+        <TestComponentOuter />
+      </ChatClientProvider>,
+    );
+
+    if (!client1 || !client2) {
+      expect.fail('client1 or client2 is undefined');
+    }
+
+    expect(client1).toEqual(client2);
+  });
+  it('it should handle context updates correctly', () => {
+    const client1 = newChatClient() as unknown as ChatClient;
+    const client2 = newChatClient() as unknown as ChatClient;
+    const { rerender } = render(
+      <ChatClientProvider client={client1}>
+        <TestComponent
+          callback={(client) => {
+            expect(client).toBe(client1);
+          }}
+        />
+      </ChatClientProvider>,
+    );
+
+    rerender(
+      <ChatClientProvider client={client2}>
+        <TestComponent
+          callback={(client) => {
+            expect(client).toBe(client2);
+          }}
+        />
+      </ChatClientProvider>,
+    );
+  });
+
+  it('it should provide same context across disconnected components', () => {
+    let client1: ChatClient | undefined;
+    let client2: ChatClient | undefined;
+    const TestComponentInner = () => {
+      client2 = useChatClient();
+      return <div />;
+    };
+
+    const TestComponentOuter = () => {
+      client1 = useChatClient();
+      return <TestComponentInner />;
+    };
+
+    const chatClient = newChatClient() as unknown as ChatClient;
+    render(
+      <ChatClientProvider client={chatClient}>
+        <div>
+          <TestComponentOuter />
+          <TestComponentOuter />
+        </div>
+      </ChatClientProvider>,
+    );
+
+    if (!client1 || !client2) {
+      expect.fail('client1 or client2 is undefined');
+    }
+
+    // Check if the context value from the two independent components is the same (global context)
+    expect(client1).toBe(client2);
+  });
+
+  it('it should handle multiple providers correctly', () => {
+    let innerClient: ChatClient | undefined;
+    let outerClient: ChatClient | undefined;
+
+    const TestComponentInner = () => {
+      innerClient = useChatClient();
+      return <div />;
+    };
+
+    const TestComponentOuter = () => {
+      outerClient = useChatClient();
+      return <div />;
+    };
+
+    const chatClientInner = newChatClient() as unknown as ChatClient;
+    const chatClientOuter = newChatClient() as unknown as ChatClient;
+
+    render(
+      <ChatClientProvider client={chatClientOuter}>
+        <TestComponentOuter />
+        <ChatClientProvider client={chatClientInner}>
+          <TestComponentInner />
+        </ChatClientProvider>
+      </ChatClientProvider>,
+    );
+
+    if (!innerClient || !outerClient) {
+      expect.fail('innerClient or outerClient is undefined');
+    }
+
+    // Check if the correct client was used in the correct component (inner component uses inner client and vice versa)
+    expect(innerClient).toBe(chatClientInner);
+    expect(outerClient).toBe(chatClientOuter);
+  });
+});

--- a/test/react/providers/chat-client-provider.test.tsx
+++ b/test/react/providers/chat-client-provider.test.tsx
@@ -1,0 +1,24 @@
+import { ChatClient } from '@ably/chat';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { describe, it, vi } from 'vitest';
+
+import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
+import { newChatClient } from '../../helper/chat.ts';
+
+vi.mock('ably');
+
+describe('useChatClient', () => {
+  it('it should create a provider without error', () => {
+    const chatClient = newChatClient() as unknown as ChatClient;
+    const TestComponent = () => {
+      return <div />;
+    };
+    const TestProvider = () => (
+      <ChatClientProvider client={chatClient}>
+        <TestComponent />
+      </ChatClientProvider>
+    );
+    render(<TestProvider />);
+  });
+});

--- a/typedoc.json
+++ b/typedoc.json
@@ -10,6 +10,13 @@
   "visibilityFilters": {
     "external": true
   },
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@ably/chat": ["./src/core"],
+      "@ably/chat/react": ["./src/react"]
+    }
+  },
   "requiredToBeDocumented": [
     "Accessor",
     "Class",


### PR DESCRIPTION
### Context

* Provide name of JIRA ticket that this PR is related to (if applicable).
    * e.g. [CHA-101] - this will automatically link the PR to the JIRA ticket.
* Provide names of any related DRs (if applicable).
* Provide links to any related PRs

### Description

* Added `useChatClient` custom hook that allows the user to retrieve the current chat client from the nearest context.
* Added `ChatClientContext` and `ChatClientProvider`, which are necessary for using the new hook.
  * These components ensure that there is only a single instance of the chat context at any given level in the component tree. 
* Updated tsconfig to recognise the new context and provider files.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

* Start the demo app, check you can send reaction, messages and enter presence.


[CHA-101]: https://ably.atlassian.net/browse/CHA-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ