### PR TITLE
react hooks: add base interfaces Listenable, StatusParmas and ChatStatusResponse

### DIFF
--- a/src/react/chat-status-response.ts
+++ b/src/react/chat-status-response.ts
@@ -1,8 +1,19 @@
 import { ConnectionStatus, ErrorInfo, RoomStatus } from '@ably/chat';
 
+/**
+ * Common status variables for chat features. Most hooks in this library
+ * implement this interface.
+ */
 export interface ChatStatusResponse {
+  /** Provides access to get or listen to the connection to Ably. */
   readonly connectionStatus: ConnectionStatus;
+
+  /** If there's a connection error it will be available here.  */
   readonly connectionError?: ErrorInfo;
+
+  /** Provides access to get or listen to the room status. */
   readonly roomStatus: RoomStatus;
+
+  /** If there's an error with the room it will be available here. */
   readonly roomError?: ErrorInfo;
 }

--- a/src/react/chat-status-response.ts
+++ b/src/react/chat-status-response.ts
@@ -1,0 +1,8 @@
+import { ConnectionStatus, ErrorInfo, RoomStatus } from '@ably/chat';
+
+export interface ChatStatusResponse {
+  readonly connectionStatus: ConnectionStatus;
+  readonly connectionError?: ErrorInfo;
+  readonly roomStatus: RoomStatus;
+  readonly roomError?: ErrorInfo;
+}

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -2,6 +2,8 @@
  * @module chat-react
  */
 
+export { type ChatStatusResponse } from './chat-status-response.js';
 export { type ChatClientContextProviderProps } from './contexts/chat-client-context.js';
 export { useChatClient } from './hooks/use-chat-client.js';
 export { ChatClientProvider, type ChatClientProviderProps } from './providers/chat-client-provider.js';
+export { type StatusParams } from './status-params.js';

--- a/src/react/listenable.ts
+++ b/src/react/listenable.ts
@@ -1,3 +1,7 @@
+/**
+ * Hooks that provide events that can be listened to implement this interface
+ * to allow passing a listener when using the hook.
+ */
 export interface Listenable<T> {
   listener?: T;
 }

--- a/src/react/listenable.ts
+++ b/src/react/listenable.ts
@@ -1,0 +1,3 @@
+export interface Listenable<T> {
+  listener?: T;
+}

--- a/src/react/status-params.ts
+++ b/src/react/status-params.ts
@@ -1,8 +1,33 @@
 import { ConnectionStatusChange, RoomStatusChange } from '@ably/chat';
 import * as Ably from 'ably';
 
+/**
+ * Parameters for registering callbacks to receive status changes from
+ * different chat features.
+ *
+ * Most hooks provided in this library accept this parameter to allow you to
+ * listen to status changes.
+ *
+ * It's an alternative to {@link ChatStatusResponse} which provide this
+ * information via a callback.
+ */
 export interface StatusParams {
+  /**
+   * Register a callback for when the room status changes.
+   * @param change Object representing the change in room status.
+   */
   onRoomStatusChange?: (change: RoomStatusChange) => void;
+
+  /**
+   * Register a callback for when the connection status to Ably changes.
+   * @param change Object representing the change in connection status.
+   */
   onConnectionStatusChange?: (change: ConnectionStatusChange) => void;
+
+  /**
+   * Register a callback to detect and respond to discontinuities. For example,
+   * you might choose to fetch missing messages.
+   * @param error The error that caused the discontinuity.
+   */
   onDiscontinuity?: (error?: Ably.ErrorInfo) => void;
 }

--- a/src/react/status-params.ts
+++ b/src/react/status-params.ts
@@ -1,0 +1,8 @@
+import { ConnectionStatusChange, RoomStatusChange } from '@ably/chat';
+import * as Ably from 'ably';
+
+export interface StatusParams {
+  onRoomStatusChange?: (change: RoomStatusChange) => void;
+  onConnectionStatusChange?: (change: ConnectionStatusChange) => void;
+  onDiscontinuity?: (error?: Ably.ErrorInfo) => void;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       thresholds: {
         statements: 92,
         branches: 93,
-        functions: 95,
+        functions: 93,
         lines: 92,
       },
       provider: 'v8',


### PR DESCRIPTION
### Context

Adds interfaces as they are defined in CHADR-030. Closes [CHA-383]. They will be used for future hooks.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] (Optional) Update documentation for new features.
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

n/a

[CHA-383]: https://ably.atlassian.net/browse/CHA-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ