### PR TITLE
dev: fix tsconfig paths

### DIFF
--- a/src/react/tsconfig.json
+++ b/src/react/tsconfig.json
@@ -1,5 +1,13 @@
 {
-  "include": ["./hooks/**/*.{ts,tsx}", "index.ts", "./contexts/**/*.{ts,tsx}", "./providers/**/*.{ts,tsx}"],
+  "include": [
+    "./hooks/**/*.ts",
+    "./hooks/**/*.tsx",
+    "index.ts",
+    "./contexts/**/*.ts",
+    "./contexts/**/*.tsx",
+    "./providers/**/*.ts",
+    "./providers/**/*.tsx"
+  ],
   "compilerOptions": {
     "rootDir": ".",
     "target": "es6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "include": [
     "./src/**/*.ts",
+    "./src/**/*.tsx",
     "./test/**/*.ts",
     "./test/**/*.tsx",
     "./test/**/*.d.ts",


### PR DESCRIPTION
### Description

We need to specify the extensions separately as globs don't do regular expressions. This change ensures that we specify paths properly so that ESLint picks them up.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A