### PR TITLE
react-hooks: add useChatConnection hook

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -34,7 +34,7 @@
     },
     "..": {
       "name": "@ably/chat",
-      "version": "0.2.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "async-mutex": "^0.5.0",

--- a/demo/src/components/ConnectionStatusComponent/ConnectionStatusComponent.tsx
+++ b/demo/src/components/ConnectionStatusComponent/ConnectionStatusComponent.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useChatConnection } from '@ably/chat/react';
+import { ConnectionLifecycle } from '@ably/chat';
+
+export const ConnectionStatusComponent: React.FC = () => {
+  const { currentStatus } = useChatConnection();
+
+  switch (currentStatus) {
+    case ConnectionLifecycle.Connecting: {
+      return <div className="text-blue-800 bg-blue-50">Connecting...</div>;
+    }
+    case ConnectionLifecycle.Disconnected: {
+      return <div className="text-yellow-800 bg-yellow-50">Disconnected - will retry to connect automatically</div>;
+    }
+    case ConnectionLifecycle.Suspended: {
+      return (
+        <div className="text-yellow-800 bg-yellow-50">Connection suspended - will retry to connect automatically</div>
+      );
+    }
+    case ConnectionLifecycle.Failed: {
+      return <div className="text-red-800 bg-red-50">Connection failed. Refresh the page to try again.</div>;
+    }
+  }
+
+  // initialized and connected are not shown since they are
+  // not warnings for the user
+  return <></>;
+};

--- a/demo/src/components/ConnectionStatusComponent/index.ts
+++ b/demo/src/components/ConnectionStatusComponent/index.ts
@@ -1,0 +1,1 @@
+export { ConnectionStatusComponent } from './ConnectionStatusComponent';

--- a/demo/src/components/MessageInput/MessageInput.tsx
+++ b/demo/src/components/MessageInput/MessageInput.tsx
@@ -62,7 +62,7 @@ export const MessageInput: FC<MessageInputProps> = ({ disabled, onSend, onStartT
         <button
           disabled={disabled}
           type="submit"
-          className="inline-flex items-center justify-center rounded-r-md px-3 py-1 transition duration-500 ease-in-out text-white bg-blue-500 hover:bg-blue-400 focus:outline-none"
+          className="inline-flex items-center justify-center rounded-r-md px-3 py-1 transition duration-500 ease-in-out text-white bg-blue-500 hover:bg-blue-400 focus:outline-none disabled:bg-gray-400 disabled:cursor-not-allowed"
         >
           Send
           <svg

--- a/demo/src/components/OccupancyComponent/OccupancyComponent.tsx
+++ b/demo/src/components/OccupancyComponent/OccupancyComponent.tsx
@@ -1,19 +1,12 @@
 import { FC } from 'react';
 import { useOccupancy } from '../../hooks/useOccupancy.ts';
 import './OccupancyComponent.css';
-import { useChatConnection } from '@ably/chat/react';
-import { ConnectionLifecycle } from '@ably/chat';
 
 /**
  * Displays the occupancy metrics of the current room.
  */
 export const OccupancyComponent: FC = () => {
   const { occupancyMetrics } = useOccupancy();
-  const { currentStatus } = useChatConnection();
-
-  if (currentStatus !== ConnectionLifecycle.Connected) {
-    return <div>Connecting...</div>;
-  }
 
   return (
     <div className="container p-5 sm:p-12 w-full ">

--- a/demo/src/components/OccupancyComponent/OccupancyComponent.tsx
+++ b/demo/src/components/OccupancyComponent/OccupancyComponent.tsx
@@ -1,12 +1,19 @@
 import { FC } from 'react';
 import { useOccupancy } from '../../hooks/useOccupancy.ts';
 import './OccupancyComponent.css';
+import { useChatConnection } from '@ably/chat/react';
 
 /**
  * Displays the occupancy metrics of the current room.
  */
 export const OccupancyComponent: FC = () => {
   const { occupancyMetrics } = useOccupancy();
+  const { currentStatus } = useChatConnection();
+
+  if (currentStatus !== 'connected') {
+    return <div>Connecting...</div>;
+  }
+
   return (
     <div className="container p-5 sm:p-12 w-full ">
       <div className="occupancy-counts w-full flex flex-col items-center ">

--- a/demo/src/components/OccupancyComponent/OccupancyComponent.tsx
+++ b/demo/src/components/OccupancyComponent/OccupancyComponent.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { useOccupancy } from '../../hooks/useOccupancy.ts';
 import './OccupancyComponent.css';
 import { useChatConnection } from '@ably/chat/react';
+import { ConnectionLifecycle } from '@ably/chat';
 
 /**
  * Displays the occupancy metrics of the current room.
@@ -10,7 +11,7 @@ export const OccupancyComponent: FC = () => {
   const { occupancyMetrics } = useOccupancy();
   const { currentStatus } = useChatConnection();
 
-  if (currentStatus !== 'connected') {
+  if (currentStatus !== ConnectionLifecycle.Connected) {
     return <div>Connecting...</div>;
   }
 

--- a/demo/src/components/ReactionInput/ReactionInput.tsx
+++ b/demo/src/components/ReactionInput/ReactionInput.tsx
@@ -3,9 +3,10 @@ import { FC } from 'react';
 interface ReactionInputProps {
   reactions: string[];
   onSend(reaction: string): void;
+  disabled: boolean;
 }
 
-export const ReactionInput: FC<ReactionInputProps> = ({ reactions, onSend }) => {
+export const ReactionInput: FC<ReactionInputProps> = ({ reactions, onSend, disabled = false }) => {
   // set default reactions if empty or not set
   if (!reactions || reactions.length === 0) {
     reactions = ['👍', '❤️', '💥', '🚀', '👎', '💔'];
@@ -16,9 +17,12 @@ export const ReactionInput: FC<ReactionInputProps> = ({ reactions, onSend }) => 
       key={reaction}
       onClick={(e) => {
         e.preventDefault();
-        onSend(reaction);
+        if (!disabled) {
+          onSend(reaction);
+        }
       }}
       href="#"
+      className={disabled ? 'cursor-not-allowed' : ''}
     >
       {reaction}
     </a>

--- a/demo/src/components/UserPresenceComponent/UserPresenceComponent.tsx
+++ b/demo/src/components/UserPresenceComponent/UserPresenceComponent.tsx
@@ -2,7 +2,7 @@ import { FC, useCallback, useState } from 'react';
 import { usePresence } from '../../hooks/usePresence';
 import '../../../styles/global.css';
 import './UserPresenceComponent.css';
-import { PresenceMember } from '@ably/chat';
+import { ConnectionLifecycle, PresenceMember } from '@ably/chat';
 import { useChatClient, useChatConnection } from '@ably/chat/react';
 
 interface UserListComponentProps {}
@@ -43,7 +43,7 @@ export const UserPresenceComponent: FC<UserListComponentProps> = () => {
     return <li key={index}>{`${presentMember.clientId} - ${status.toUpperCase()}`}</li>;
   };
 
-  if (currentStatus !== 'connected') {
+  if (currentStatus !== ConnectionLifecycle.Connected) {
     return <div>Connecting...</div>;
   }
 

--- a/demo/src/components/UserPresenceComponent/UserPresenceComponent.tsx
+++ b/demo/src/components/UserPresenceComponent/UserPresenceComponent.tsx
@@ -12,6 +12,7 @@ export const UserPresenceComponent: FC<UserListComponentProps> = () => {
   const { loading, presenceMembers, enterPresence, updatePresence, leavePresence } = usePresence();
   const clientId = useChatClient().clientId;
   const { currentStatus } = useChatConnection();
+  const isConnected = currentStatus === ConnectionLifecycle.Connected;
 
   const onEnterPresence = useCallback(() => {
     enterPresence({ status: 'online' })
@@ -43,10 +44,6 @@ export const UserPresenceComponent: FC<UserListComponentProps> = () => {
     return <li key={index}>{`${presentMember.clientId} - ${status.toUpperCase()}`}</li>;
   };
 
-  if (currentStatus !== ConnectionLifecycle.Connected) {
-    return <div>Connecting...</div>;
-  }
-
   if (loading) {
     return <div className="loading">loading...</div>;
   }
@@ -69,19 +66,22 @@ export const UserPresenceComponent: FC<UserListComponentProps> = () => {
           <div className="actions">
             <button
               onClick={() => onEnterPresence()}
-              className="btn enter"
+              disabled={!isConnected}
+              className="btn enter disabled:bg-gray-300 disabled:cursor-not-allowed"
             >
               👤 Join
             </button>
             <button
               onClick={() => onUpdatePresence()}
-              className="btn update"
+              disabled={!isConnected}
+              className="btn update disabled:bg-gray-300 disabled:cursor-not-allowed"
             >
               🔄 Appear Away
             </button>
             <button
               onClick={() => onLeavePresence()}
-              className="btn leave"
+              disabled={!isConnected}
+              className="btn leave disabled:bg-gray-300 disabled:cursor-not-allowed"
             >
               🚪 Leave
             </button>

--- a/demo/src/components/UserPresenceComponent/UserPresenceComponent.tsx
+++ b/demo/src/components/UserPresenceComponent/UserPresenceComponent.tsx
@@ -3,7 +3,7 @@ import { usePresence } from '../../hooks/usePresence';
 import '../../../styles/global.css';
 import './UserPresenceComponent.css';
 import { PresenceMember } from '@ably/chat';
-import { useChatClient } from '@ably/chat/react';
+import { useChatClient, useChatConnection } from '@ably/chat/react';
 
 interface UserListComponentProps {}
 
@@ -11,6 +11,7 @@ export const UserPresenceComponent: FC<UserListComponentProps> = () => {
   const [isPanelOpen, setIsPanelOpen] = useState(true);
   const { loading, presenceMembers, enterPresence, updatePresence, leavePresence } = usePresence();
   const clientId = useChatClient().clientId;
+  const { currentStatus } = useChatConnection();
 
   const onEnterPresence = useCallback(() => {
     enterPresence({ status: 'online' })
@@ -41,6 +42,10 @@ export const UserPresenceComponent: FC<UserListComponentProps> = () => {
     }
     return <li key={index}>{`${presentMember.clientId} - ${status.toUpperCase()}`}</li>;
   };
+
+  if (currentStatus !== 'connected') {
+    return <div>Connecting...</div>;
+  }
 
   if (loading) {
     return <div className="loading">loading...</div>;

--- a/demo/src/containers/Chat/Chat.tsx
+++ b/demo/src/containers/Chat/Chat.tsx
@@ -6,6 +6,7 @@ import { useTypingIndicators } from '../../hooks/useTypingIndicators.ts';
 import { useReactions } from '../../hooks/useReactions';
 import { ReactionInput } from '../../components/ReactionInput';
 import { useChatConnection } from '@ably/chat/react';
+import { ConnectionLifecycle } from '@ably/chat';
 
 export const Chat = () => {
   const { loading, clientId, messages, sendMessage } = useMessages();
@@ -69,7 +70,7 @@ export const Chat = () => {
     }
   }, [messages, loading]);
 
-  if (currentStatus !== 'connected') {
+  if (currentStatus !== ConnectionLifecycle.Connected) {
     return <div>Connecting...</div>;
   }
 

--- a/demo/src/containers/Chat/Chat.tsx
+++ b/demo/src/containers/Chat/Chat.tsx
@@ -5,11 +5,13 @@ import { useMessages } from '../../hooks/useMessages';
 import { useTypingIndicators } from '../../hooks/useTypingIndicators.ts';
 import { useReactions } from '../../hooks/useReactions';
 import { ReactionInput } from '../../components/ReactionInput';
+import { useChatConnection } from '@ably/chat/react';
 
 export const Chat = () => {
   const { loading, clientId, messages, sendMessage } = useMessages();
   const { startTyping, stopTyping, typers } = useTypingIndicators();
   const { reactions, sendReaction } = useReactions();
+  const { currentStatus } = useChatConnection();
 
   // Used to anchor the scroll to the bottom of the chat
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
@@ -66,6 +68,10 @@ export const Chat = () => {
       scrollToBottom();
     }
   }, [messages, loading]);
+
+  if (currentStatus !== 'connected') {
+    return <div>Connecting...</div>;
+  }
 
   return (
     <div className="flex-1 p:2 sm:p-12 justify-between flex flex-col h-screen">

--- a/demo/src/containers/Chat/Chat.tsx
+++ b/demo/src/containers/Chat/Chat.tsx
@@ -5,6 +5,7 @@ import { useMessages } from '../../hooks/useMessages';
 import { useTypingIndicators } from '../../hooks/useTypingIndicators.ts';
 import { useReactions } from '../../hooks/useReactions';
 import { ReactionInput } from '../../components/ReactionInput';
+import { ConnectionStatusComponent } from '../../components/ConnectionStatusComponent/ConnectionStatusComponent.tsx';
 import { useChatConnection } from '@ably/chat/react';
 import { ConnectionLifecycle } from '@ably/chat';
 
@@ -13,6 +14,8 @@ export const Chat = () => {
   const { startTyping, stopTyping, typers } = useTypingIndicators();
   const { reactions, sendReaction } = useReactions();
   const { currentStatus } = useChatConnection();
+
+  const isConnected: boolean = currentStatus === ConnectionLifecycle.Connected;
 
   // Used to anchor the scroll to the bottom of the chat
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
@@ -70,12 +73,9 @@ export const Chat = () => {
     }
   }, [messages, loading]);
 
-  if (currentStatus !== ConnectionLifecycle.Connected) {
-    return <div>Connecting...</div>;
-  }
-
   return (
     <div className="flex-1 p:2 sm:p-12 justify-between flex flex-col h-screen">
+      <ConnectionStatusComponent />
       <div
         className="text-xs p-3"
         style={{ backgroundColor: '#333' }}
@@ -114,7 +114,7 @@ export const Chat = () => {
       </div>
       <div className="border-t-2 border-gray-200 px-4 pt-4 mb-2 sm:mb-0">
         <MessageInput
-          disabled={loading}
+          disabled={loading || !isConnected}
           onSend={handleMessageSend}
           onStartTyping={startTyping}
           onStopTyping={stopTyping}
@@ -124,6 +124,7 @@ export const Chat = () => {
         <ReactionInput
           reactions={[]}
           onSend={sendReaction}
+          disabled={loading || !isConnected}
         ></ReactionInput>
       </div>
       <div>

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,12 +6,12 @@ export { ChatClient } from './chat.js';
 export type { ClientOptions } from './config.js';
 export type { Connection } from './connection.js';
 export type {
-  ConnectionLifecycle,
   ConnectionStatus,
   ConnectionStatusChange,
   ConnectionStatusListener,
   OnConnectionStatusChangeResponse,
 } from './connection-status.js';
+export { ConnectionLifecycle } from './connection-status.js';
 export type { DiscontinuityListener, OnDiscontinuitySubscriptionResponse } from './discontinuity.js';
 export type { ErrorCodes } from './errors.js';
 export { MessageEvents, PresenceEvents } from './events.js';

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -45,3 +45,25 @@ const MyComponent = () => {
   return <div>Client id is: {clientId}</div>;
 };
 ```
+
+## useChatConnection
+
+This hook allows you to access the connection status of the `ChatClient` instance from your React components.
+
+To use it, call the hook in your component, this will retrieve the connection state from the `ChatClient` of the
+nearest `ChatClientProvider`.
+
+It can also be supplied with an optional listener that will receive the underlying connection status changes.
+
+```tsx
+import { useChatConnection } from '@ably/chat/react';
+
+const MyComponent = () => {
+  const { currentStatus } = useChatConnection({
+    onStatusChange: (statusChange) => {
+      console.log('Connection status changed to: ', statusChange.current);
+    },
+  });
+  return <div>Connection status is: {currentStatus}</div>;
+};
+```

--- a/src/react/hooks/use-chat-connection.ts
+++ b/src/react/hooks/use-chat-connection.ts
@@ -1,0 +1,87 @@
+import { Connection, ConnectionLifecycle, ConnectionStatusChange, ConnectionStatusListener } from '@ably/chat';
+import { ErrorInfo } from 'ably';
+import { useEffect, useState } from 'react';
+
+import { useChatClient } from './use-chat-client.js';
+
+/**
+ * The options for the useChatConnection hook.
+ */
+export interface UseChatConnectionOptions {
+  /**
+   * A callback that will be called whenever the connection status changes.
+   */
+  onStatusChange?: ConnectionStatusListener;
+}
+
+/**
+ * The response from the useChatConnection hook.
+ */
+export interface UseChatConnectionResponse {
+  /**
+   * The current status of the connection.
+   */
+  currentStatus: ConnectionLifecycle;
+
+  /**
+   * An error that provides a reason why the connection has entered the new status, if applicable.
+   */
+  error?: ErrorInfo;
+
+  /**
+   * The current Ably connection instance.
+   */
+  connection: Connection;
+}
+
+/**
+ * A hook that provides the current connection status and error, and allows the user to listen to connection status changes.
+ *
+ * @param options - The options for the hook
+ * @returns The current connection status and error, as well as the connection instance.
+ */
+export const useChatConnection = (options?: UseChatConnectionOptions): UseChatConnectionResponse => {
+  const chatClient = useChatClient();
+
+  // Initialize states with the current values from chatClient
+  const [currentStatus, setCurrentStatus] = useState<ConnectionLifecycle>(chatClient.connection.status.current);
+  const [error, setError] = useState<ErrorInfo | undefined>(chatClient.connection.status.error);
+  const [connection, setConnection] = useState<Connection>(chatClient.connection);
+
+  // Update the states when the chatClient changes
+  useEffect(() => {
+    setConnection(chatClient.connection);
+    setError(chatClient.connection.status.error);
+    setCurrentStatus(chatClient.connection.status.current);
+  }, [chatClient]);
+
+  // Apply the listener to the chatClient's connection status changes to keep the state update across re-renders
+  useEffect(() => {
+    const { off } = chatClient.connection.status.onChange((change: ConnectionStatusChange) => {
+      // Update states with new values
+      setCurrentStatus(change.current);
+      setError(change.error);
+    });
+    // Cleanup listener on un-mount
+    return () => {
+      off();
+    };
+  }, [chatClient.connection.status]);
+
+  // Register the listener for the user-provided onStatusChange callback
+  useEffect(() => {
+    if (!options?.onStatusChange) return;
+    const { onStatusChange } = options;
+    const { off } = chatClient.connection.status.onChange(onStatusChange);
+
+    return () => {
+      off();
+    };
+  }, [chatClient.connection.status, options]);
+
+  return {
+    currentStatus,
+    error,
+    connection,
+  };
+};

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -5,5 +5,10 @@
 export { type ChatStatusResponse } from './chat-status-response.js';
 export { type ChatClientContextProviderProps } from './contexts/chat-client-context.js';
 export { useChatClient } from './hooks/use-chat-client.js';
+export {
+  useChatConnection,
+  type UseChatConnectionOptions,
+  type UseChatConnectionResponse,
+} from './hooks/use-chat-connection.js';
 export { ChatClientProvider, type ChatClientProviderProps } from './providers/chat-client-provider.js';
 export { type StatusParams } from './status-params.js';

--- a/test/react/hooks/use-chat-connection.test.tsx
+++ b/test/react/hooks/use-chat-connection.test.tsx
@@ -1,0 +1,149 @@
+import { act, renderHook } from '@testing-library/react';
+import * as Ably from 'ably';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ConnectionLifecycle,
+  ConnectionStatusChange,
+  ConnectionStatusListener,
+} from '../../../src/core/connection-status.ts';
+import { useChatConnection } from '../../../src/react/hooks/use-chat-connection.ts';
+
+let mockCallbacks: ConnectionStatusListener[] = [];
+
+const createMockChatClient = (currentStatus: ConnectionLifecycle, error?: Ably.ErrorInfo) => {
+  return {
+    connection: {
+      status: {
+        current: currentStatus,
+        error: error,
+        onChange: (callback: ConnectionStatusListener) => {
+          mockCallbacks.push(callback);
+          return {
+            off: () => {
+              mockCallbacks = mockCallbacks.filter((cb) => cb !== callback);
+            },
+          };
+        },
+      },
+    },
+  };
+};
+
+let mockChatClient = createMockChatClient(ConnectionLifecycle.Initialized);
+
+const publishStatusChange = (statusChange: ConnectionStatusChange) => {
+  for (const callback of mockCallbacks) {
+    callback(statusChange);
+  }
+};
+
+// Mock the useChatClient hook
+vi.mock('../../../src/react/hooks/use-chat-client.ts', () => {
+  return {
+    useChatClient: () => mockChatClient,
+  };
+});
+
+describe('useChatConnection', () => {
+  beforeEach(() => {
+    mockCallbacks = [];
+    mockChatClient = createMockChatClient(ConnectionLifecycle.Initialized);
+  });
+
+  it('it should provide the initial state of the connection on render', () => {
+    const { result } = renderHook(() => useChatConnection());
+    expect(result.current.currentStatus).toBe(ConnectionLifecycle.Initialized);
+    expect(result.current.error).toEqual(undefined);
+  });
+
+  it('it should update the status correctly on status change', () => {
+    const { result } = renderHook(() => useChatConnection());
+    // check the initial state
+    expect(result.current.currentStatus).toBe(ConnectionLifecycle.Initialized);
+    expect(result.current.error).toEqual(undefined);
+
+    // re-render the component, emitting a status change
+    act(() => {
+      publishStatusChange({
+        current: ConnectionLifecycle.Connected,
+        previous: ConnectionLifecycle.Connecting,
+        error: undefined,
+      });
+    });
+
+    // check the updated state
+    expect(result.current.currentStatus).toBe(ConnectionLifecycle.Connected);
+    expect(result.current.error).toEqual(undefined);
+  });
+
+  it('it should update the error correctly on status change', () => {
+    const { result } = renderHook(() => useChatConnection());
+    // check the initial state
+    expect(result.current.currentStatus).toBe(ConnectionLifecycle.Initialized);
+    expect(result.current.error).toEqual(undefined);
+
+    const testError = new Ably.ErrorInfo('error', 500, 50000);
+    // re-render the component, emitting a status change
+    act(() => {
+      publishStatusChange({
+        current: ConnectionLifecycle.Disconnected,
+        previous: ConnectionLifecycle.Initialized,
+        error: testError,
+        retryIn: 100,
+      });
+    });
+
+    // check the updated state
+    expect(result.current.currentStatus).toBe(ConnectionLifecycle.Disconnected);
+    expect(result.current.error).toEqual(testError);
+  });
+
+  it('it should call the user supplied listener with the status change ', () => {
+    const listener = (statusChange: ConnectionStatusChange) => {
+      expect(statusChange.current).toBe(ConnectionLifecycle.Connected);
+      expect(statusChange.previous).toBe(ConnectionLifecycle.Connecting);
+      expect(statusChange.error).toEqual(undefined);
+      expect(statusChange.retryIn).toEqual(undefined);
+    };
+
+    renderHook(() => useChatConnection({ onStatusChange: listener }));
+
+    // re-render the component, emitting a status change
+    act(() => {
+      publishStatusChange({
+        current: ConnectionLifecycle.Connected,
+        previous: ConnectionLifecycle.Connecting,
+        error: undefined,
+      });
+    });
+  });
+
+  it('it should handle rerender if the chat client instance changes', () => {
+    const { result, rerender } = renderHook(() => useChatConnection());
+    // check the initial state
+    expect(result.current.currentStatus).toBe(ConnectionLifecycle.Initialized);
+    expect(result.current.error).toEqual(undefined);
+
+    // change the chat client instance
+    mockChatClient = createMockChatClient(ConnectionLifecycle.Connected);
+
+    // re-render the component, use effect should run and update the state
+    rerender();
+
+    // check the updated state
+    expect(result.current.currentStatus).toBe(ConnectionLifecycle.Connected);
+    expect(result.current.error).toEqual(undefined);
+  });
+
+  it('it should call the off functions for registered listeners on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useChatConnection({
+        onStatusChange: () => {},
+      }),
+    );
+    expect(mockCallbacks.length).toBe(2);
+    unmount();
+    expect(mockCallbacks.length).toBe(0);
+  });
+});


### PR DESCRIPTION
### Context

* [CHA-381]

### Description

* Introduced useChatConnection to allow users to subscribe to connection status changes.
* A listener can also be supplied to the hook if the user wants the underlying status changes.
* Added some basic usage to the demo app.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).



[CHA-381]: https://ably.atlassian.net/browse/CHA-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ