### PR TITLE
react-hooks: Update ChatStatusResponse attributes

### DIFF
--- a/src/react/chat-status-response.ts
+++ b/src/react/chat-status-response.ts
@@ -1,18 +1,18 @@
-import { ConnectionStatus, ErrorInfo, RoomStatus } from '@ably/chat';
+import { ConnectionLifecycle, ErrorInfo, RoomLifecycle } from '@ably/chat';
 
 /**
  * Common status variables for chat features. Most hooks in this library
  * implement this interface.
  */
 export interface ChatStatusResponse {
-  /** Provides access to get or listen to the connection to Ably. */
-  readonly connectionStatus: ConnectionStatus;
+  /** Provides the connection status of the Ably connection. */
+  readonly connectionStatus: ConnectionLifecycle;
 
   /** If there's a connection error it will be available here.  */
   readonly connectionError?: ErrorInfo;
 
-  /** Provides access to get or listen to the room status. */
-  readonly roomStatus: RoomStatus;
+  /** Provides the status of the room. */
+  readonly roomStatus: RoomLifecycle;
 
   /** If there's an error with the room it will be available here. */
   readonly roomError?: ErrorInfo;


### PR DESCRIPTION
### Context

* Currently, the `ChatStatusReponse` exposes the room status and connection status objects. This isn't really needed by the other react hooks, the current state and error is sufficient. 

### Description

* Updated the `ChatStatusReponse` interface so it now returns the `ConnectionLifecycle` and `RoomLifecycle` types in place of their respective status objects.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [ ] (Optional) Update documentation for new features.
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).
