### PR TITLE
Async room initialisation

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -17,5 +17,8 @@
     "livestreams",
     "livestream"
   ],
-  "ignoreRegExpList": ["/.*@\\d{13}-/"]
+  "ignoreRegExpList": ["/.*@\\d{13}-/"],
+  "flagWords": [
+    "cancelled"
+  ]
 }

--- a/demo/src/components/MessageInput/MessageInput.tsx
+++ b/demo/src/components/MessageInput/MessageInput.tsx
@@ -15,7 +15,7 @@ export const MessageInput: FC<MessageInputProps> = ({ disabled, onSend, onStartT
     // Typing indicators start method should be called with every keystroke since
     // they automatically stop if the user stops typing for a certain amount of time.
     //
-    // The timeout duration can be configured when initialising the room.
+    // The timeout duration can be configured when initializing the room.
     if (target.value && target.value.length > 0) {
       onStartTyping();
     } else {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     }
   },
   "scripts": {
-    "lint": "eslint . && cspell '{src,test}/**' './*.md'",
+    "lint": "eslint . && npm run cspell",
     "lint:fix": "eslint --fix .",
     "format": "prettier --write src test __mocks__ demo/src",
     "format:check": "prettier --check src test __mocks__ demo/src",
@@ -34,7 +34,8 @@
     "test:typescript": "tsc",
     "demo:reload": "npm run build && cd demo && npm i file:../",
     "docs": "typedoc",
-    "modulereport": "tsc --noEmit --esModuleInterop scripts/moduleReport.ts && esr scripts/moduleReport.ts"
+    "modulereport": "tsc --noEmit --esModuleInterop scripts/moduleReport.ts && esr scripts/moduleReport.ts",
+    "cspell": "cspell '{src,test}/**' './*.md'"
   },
   "files": [
     "dist/**",

--- a/src/core/discontinuity.ts
+++ b/src/core/discontinuity.ts
@@ -7,6 +7,11 @@ import EventEmitter from './utils/event-emitter.js';
  */
 export interface HandlesDiscontinuity {
   /**
+   * The channel that this object is associated with.
+   */
+  get channel(): Promise<Ably.RealtimeChannel>;
+
+  /**
    * Called when a discontinuity is detected on the channel.
    * @param reason The error that caused the discontinuity.
    */

--- a/src/core/discontinuity.ts
+++ b/src/core/discontinuity.ts
@@ -7,11 +7,6 @@ import EventEmitter from './utils/event-emitter.js';
  */
 export interface HandlesDiscontinuity {
   /**
-   * The channel that this object is associated with.
-   */
-  get channel(): Ably.RealtimeChannel;
-
-  /**
    * Called when a discontinuity is detected on the channel.
    * @param reason The error that caused the discontinuity.
    */

--- a/src/core/discontinuity.ts
+++ b/src/core/discontinuity.ts
@@ -7,7 +7,8 @@ import EventEmitter from './utils/event-emitter.js';
  */
 export interface HandlesDiscontinuity {
   /**
-   * The channel that this object is associated with.
+   * A promise of the channel that this object is associated with. The promise
+   * is resolved when the feature has finished initializing.
    */
   get channel(): Promise<Ably.RealtimeChannel>;
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -63,13 +63,8 @@ export type {
   RoomReactionsSubscriptionResponse,
   SendReactionParams,
 } from './room-reactions.js';
-export type {
-  OnRoomStatusChangeResponse,
-  RoomLifecycle,
-  RoomStatus,
-  RoomStatusChange,
-  RoomStatusListener,
-} from './room-status.js';
+export type { OnRoomStatusChangeResponse, RoomStatus, RoomStatusChange, RoomStatusListener } from './room-status.js';
+export { RoomLifecycle } from './room-status.js';
 export type { Rooms } from './rooms.js';
 export type { Typing, TypingEvent, TypingListener, TypingSubscriptionResponse } from './typing.js';
 export type { ChannelStateChange, ErrorInfo, RealtimePresenceParams } from 'ably';

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -243,7 +243,9 @@ export class DefaultMessages
     this._channel = initAfter.then(() => this._makeChannel(roomId, realtime));
 
     // Catch this so it won't send unhandledrejection global event
-    this._channel.catch((error : unknown) => { logger.debug('Messages: channel initialization canceled', { roomId, error }); });
+    this._channel.catch((error: unknown) => {
+      logger.debug('Messages: channel initialization canceled', { roomId, error });
+    });
 
     this._chatApi = chatApi;
     this._clientId = clientId;

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -364,7 +364,6 @@ export class DefaultMessages
     }
   > {
     // Get the attachSerial from the channel properties
-    // const channel = await this._channelPromise;
     const channel = await this._channelPromise;
     return channel as Ably.RealtimeChannel & {
       properties: {

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -264,7 +264,7 @@ export class DefaultMessages
     });
 
     // catch this so it won't send unhandledrejection global event
-    this._channel.catch(() => {});
+    this._channel.catch(() => void 0);
 
     this._chatApi = chatApi;
     this._clientId = clientId;

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -197,7 +197,7 @@ export interface Messages extends EmitsDiscontinuities {
    *
    * @returns the realtime channel
    */
-  get channelPromise(): Promise<Ably.RealtimeChannel>;
+  get channel(): Promise<Ably.RealtimeChannel>;
 }
 
 /**
@@ -208,7 +208,7 @@ export class DefaultMessages
   implements Messages, HandlesDiscontinuity, ContributesToRoomLifecycle
 {
   private readonly _roomId: string;
-  private readonly _channelPromise: Promise<Ably.RealtimeChannel>;
+  private readonly _channel: Promise<Ably.RealtimeChannel>;
   private readonly _chatApi: ChatApi;
   private readonly _clientId: string;
   private readonly _listenerSubscriptionPoints: Map<
@@ -239,7 +239,7 @@ export class DefaultMessages
     super();
     this._roomId = roomId;
 
-    this._channelPromise = initAfter.then(() => {
+    this._channel = initAfter.then(() => {
       const channel = getChannel(messagesChannelName(roomId), realtime);
 
       addListenerToChannelWithoutAttach({
@@ -264,7 +264,7 @@ export class DefaultMessages
     });
 
     // catch this so it won't send unhandledrejection global event
-    this._channelPromise.catch(() => {});
+    this._channel.catch(() => {});
 
     this._chatApi = chatApi;
     this._clientId = clientId;
@@ -364,7 +364,7 @@ export class DefaultMessages
     }
   > {
     // Get the attachSerial from the channel properties
-    const channel = await this._channelPromise;
+    const channel = await this._channel;
     return channel as Ably.RealtimeChannel & {
       properties: {
         attachSerial: string | undefined;
@@ -414,8 +414,8 @@ export class DefaultMessages
   /**
    * @inheritdoc Messages
    */
-  get channelPromise(): Promise<Ably.RealtimeChannel> {
-    return this._channelPromise;
+  get channel(): Promise<Ably.RealtimeChannel> {
+    return this._channel;
   }
 
   /**

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -243,7 +243,7 @@ export class DefaultMessages
     this._channel = initAfter.then(() => this._makeChannel(roomId, realtime));
 
     // Catch this so it won't send unhandledrejection global event
-    this._channel.catch((error : unknown) => { logger.debug('Messages: channel initialization cancelled', { roomId, error }); });
+    this._channel.catch((error : unknown) => { logger.debug('Messages: channel initialization canceled', { roomId, error }); });
 
     this._chatApi = chatApi;
     this._clientId = clientId;

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -227,6 +227,7 @@ export class DefaultMessages
    * @param chatApi An instance of the ChatApi.
    * @param clientId The client ID of the user.
    * @param logger An instance of the Logger.
+   * @param initAfter A promise that is awaited before creating any channels.
    */
   constructor(
     roomId: string,

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -195,7 +195,7 @@ export interface Messages extends EmitsDiscontinuities {
   /**
    * Get the underlying Ably realtime channel used for the messages in this chat room.
    *
-   * @returns the realtime channel
+   * @returns A promise of the realtime channel.
    */
   get channel(): Promise<Ably.RealtimeChannel>;
 }

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -242,8 +242,8 @@ export class DefaultMessages
 
     this._channel = initAfter.then(() => this._makeChannel(roomId, realtime));
 
-    // catch this so it won't send unhandledrejection global event
-    this._channel.catch(() => void 0);
+    // Catch this so it won't send unhandledrejection global event
+    this._channel.catch((error : unknown) => { logger.debug('Messages: channel initialization cancelled', { roomId, error }); });
 
     this._chatApi = chatApi;
     this._clientId = clientId;

--- a/src/core/occupancy.ts
+++ b/src/core/occupancy.ts
@@ -109,6 +109,7 @@ export class DefaultOccupancy
    * @param realtime An instance of the Ably Realtime client.
    * @param chatApi An instance of the ChatApi.
    * @param logger An instance of the Logger.
+   * @param initAfter A promise that is awaited before creating any channels.
    */
   constructor(roomId: string, realtime: Ably.Realtime, chatApi: ChatApi, logger: Logger, initAfter: Promise<void>) {
     super();

--- a/src/core/occupancy.ts
+++ b/src/core/occupancy.ts
@@ -118,7 +118,9 @@ export class DefaultOccupancy
     this._channel = initAfter.then(() => this._makeChannel(roomId, realtime));
 
     // Catch this so it won't send unhandledrejection global event
-    this._channel.catch((error : unknown) => { logger.debug('Occupancy: channel initialization canceled', { roomId, error }); });
+    this._channel.catch((error: unknown) => {
+      logger.debug('Occupancy: channel initialization canceled', { roomId, error });
+    });
 
     this._chatApi = chatApi;
     this._logger = logger;

--- a/src/core/occupancy.ts
+++ b/src/core/occupancy.ts
@@ -46,7 +46,7 @@ export interface Occupancy extends EmitsDiscontinuities {
   /**
    * Get underlying Ably channel for occupancy events.
    *
-   * @returns The underlying Ably channel for occupancy events.
+   * @returns A promise of the underlying Ably channel for occupancy events.
    */
   get channel(): Promise<Ably.RealtimeChannel>;
 }

--- a/src/core/occupancy.ts
+++ b/src/core/occupancy.ts
@@ -125,7 +125,7 @@ export class DefaultOccupancy
     });
 
     // catch this so it won't send unhandledrejection global event
-    this._channel.catch(() => {});
+    this._channel.catch(() => void 0);
 
     this._chatApi = chatApi;
     this._logger = logger;

--- a/src/core/occupancy.ts
+++ b/src/core/occupancy.ts
@@ -118,7 +118,7 @@ export class DefaultOccupancy
     this._channel = initAfter.then(() => this._makeChannel(roomId, realtime));
 
     // Catch this so it won't send unhandledrejection global event
-    this._channel.catch((error : unknown) => { logger.debug('Occupancy: channel initialization cancelled', { roomId, error }); });
+    this._channel.catch((error : unknown) => { logger.debug('Occupancy: channel initialization canceled', { roomId, error }); });
 
     this._chatApi = chatApi;
     this._logger = logger;

--- a/src/core/occupancy.ts
+++ b/src/core/occupancy.ts
@@ -48,7 +48,7 @@ export interface Occupancy extends EmitsDiscontinuities {
    *
    * @returns The underlying Ably channel for occupancy events.
    */
-  get channel(): Ably.RealtimeChannel;
+  get channelPromise(): Promise<Ably.RealtimeChannel>;
 }
 
 /**
@@ -98,7 +98,7 @@ export class DefaultOccupancy
   implements Occupancy, HandlesDiscontinuity, ContributesToRoomLifecycle
 {
   private readonly _roomId: string;
-  private readonly _channel: Ably.RealtimeChannel;
+  private readonly _channelPromise: Promise<Ably.RealtimeChannel>;
   private readonly _chatApi: ChatApi;
   private _logger: Logger;
   private _discontinuityEmitter: DiscontinuityEmitter = newDiscontinuityEmitter();
@@ -110,15 +110,23 @@ export class DefaultOccupancy
    * @param chatApi An instance of the ChatApi.
    * @param logger An instance of the Logger.
    */
-  constructor(roomId: string, realtime: Ably.Realtime, chatApi: ChatApi, logger: Logger) {
+  constructor(roomId: string, realtime: Ably.Realtime, chatApi: ChatApi, logger: Logger, initAfter: Promise<void>) {
     super();
     this._roomId = roomId;
-    this._channel = getChannel(messagesChannelName(roomId), realtime, { params: { occupancy: 'metrics' } });
-    addListenerToChannelWithoutAttach({
-      listener: this._internalOccupancyListener.bind(this),
-      events: ['[meta]occupancy'],
-      channel: this._channel,
+
+    this._channelPromise = initAfter.then(() => {
+      const channel = getChannel(messagesChannelName(roomId), realtime, { params: { occupancy: 'metrics' } });
+      addListenerToChannelWithoutAttach({
+        listener: this._internalOccupancyListener.bind(this),
+        events: ['[meta]occupancy'],
+        channel: channel,
+      });
+      return channel;
     });
+
+    // catch this so it won't send unhandledrejection global event
+    this._channelPromise.catch(() => {});
+
     this._chatApi = chatApi;
     this._logger = logger;
   }
@@ -157,8 +165,8 @@ export class DefaultOccupancy
   /**
    * @inheritdoc Occupancy
    */
-  get channel(): Ably.RealtimeChannel {
-    return this._channel;
+  get channelPromise(): Promise<Ably.RealtimeChannel> {
+    return this._channelPromise;
   }
 
   /**

--- a/src/core/occupancy.ts
+++ b/src/core/occupancy.ts
@@ -117,8 +117,8 @@ export class DefaultOccupancy
 
     this._channel = initAfter.then(() => this._makeChannel(roomId, realtime));
 
-    // catch this so it won't send unhandledrejection global event
-    this._channel.catch(() => void 0);
+    // Catch this so it won't send unhandledrejection global event
+    this._channel.catch((error : unknown) => { logger.debug('Occupancy: channel initialization cancelled', { roomId, error }); });
 
     this._chatApi = chatApi;
     this._logger = logger;

--- a/src/core/occupancy.ts
+++ b/src/core/occupancy.ts
@@ -115,21 +115,26 @@ export class DefaultOccupancy
     super();
     this._roomId = roomId;
 
-    this._channel = initAfter.then(() => {
-      const channel = getChannel(messagesChannelName(roomId), realtime, { params: { occupancy: 'metrics' } });
-      addListenerToChannelWithoutAttach({
-        listener: this._internalOccupancyListener.bind(this),
-        events: ['[meta]occupancy'],
-        channel: channel,
-      });
-      return channel;
-    });
+    this._channel = initAfter.then(() => this._makeChannel(roomId, realtime));
 
     // catch this so it won't send unhandledrejection global event
     this._channel.catch(() => void 0);
 
     this._chatApi = chatApi;
     this._logger = logger;
+  }
+
+  /**
+   * Creates the realtime channel for occupancy. Called after initAfter is resolved.
+   */
+  private _makeChannel(roomId: string, realtime: Ably.Realtime): Ably.RealtimeChannel {
+    const channel = getChannel(messagesChannelName(roomId), realtime, { params: { occupancy: 'metrics' } });
+    addListenerToChannelWithoutAttach({
+      listener: this._internalOccupancyListener.bind(this),
+      events: ['[meta]occupancy'],
+      channel: channel,
+    });
+    return channel;
   }
 
   /**

--- a/src/core/occupancy.ts
+++ b/src/core/occupancy.ts
@@ -48,7 +48,7 @@ export interface Occupancy extends EmitsDiscontinuities {
    *
    * @returns The underlying Ably channel for occupancy events.
    */
-  get channelPromise(): Promise<Ably.RealtimeChannel>;
+  get channel(): Promise<Ably.RealtimeChannel>;
 }
 
 /**
@@ -98,7 +98,7 @@ export class DefaultOccupancy
   implements Occupancy, HandlesDiscontinuity, ContributesToRoomLifecycle
 {
   private readonly _roomId: string;
-  private readonly _channelPromise: Promise<Ably.RealtimeChannel>;
+  private readonly _channel: Promise<Ably.RealtimeChannel>;
   private readonly _chatApi: ChatApi;
   private _logger: Logger;
   private _discontinuityEmitter: DiscontinuityEmitter = newDiscontinuityEmitter();
@@ -114,7 +114,7 @@ export class DefaultOccupancy
     super();
     this._roomId = roomId;
 
-    this._channelPromise = initAfter.then(() => {
+    this._channel = initAfter.then(() => {
       const channel = getChannel(messagesChannelName(roomId), realtime, { params: { occupancy: 'metrics' } });
       addListenerToChannelWithoutAttach({
         listener: this._internalOccupancyListener.bind(this),
@@ -125,7 +125,7 @@ export class DefaultOccupancy
     });
 
     // catch this so it won't send unhandledrejection global event
-    this._channelPromise.catch(() => {});
+    this._channel.catch(() => {});
 
     this._chatApi = chatApi;
     this._logger = logger;
@@ -165,8 +165,8 @@ export class DefaultOccupancy
   /**
    * @inheritdoc Occupancy
    */
-  get channelPromise(): Promise<Ably.RealtimeChannel> {
-    return this._channelPromise;
+  get channel(): Promise<Ably.RealtimeChannel> {
+    return this._channel;
   }
 
   /**

--- a/src/core/presence.ts
+++ b/src/core/presence.ts
@@ -218,7 +218,7 @@ export class DefaultPresence
     this._channel = initAfter.then(() => this._makeChannel(roomId, roomOptions, realtime));
 
     // Catch this so it won't send unhandledrejection global event
-    this._channel.catch((error : unknown) => { logger.debug('Presence: channel initialization cancelled', { roomId, error }); });
+    this._channel.catch((error : unknown) => { logger.debug('Presence: channel initialization canceled', { roomId, error }); });
 
     this._clientId = clientId;
     this._logger = logger;

--- a/src/core/presence.ts
+++ b/src/core/presence.ts
@@ -217,8 +217,8 @@ export class DefaultPresence
 
     this._channel = initAfter.then(() => this._makeChannel(roomId, roomOptions, realtime));
 
-    // catch this so it won't send unhandledrejection global event
-    this._channel.catch(() => void 0);
+    // Catch this so it won't send unhandledrejection global event
+    this._channel.catch((error : unknown) => { logger.debug('Presence: channel initialization cancelled', { roomId, error }); });
 
     this._clientId = clientId;
     this._logger = logger;

--- a/src/core/presence.ts
+++ b/src/core/presence.ts
@@ -234,7 +234,7 @@ export class DefaultPresence
     });
 
     // catch this so it won't send unhandledrejection global event
-    this._channel.catch(() => {});
+    this._channel.catch(() => void 0);
 
     this._clientId = clientId;
     this._logger = logger;

--- a/src/core/presence.ts
+++ b/src/core/presence.ts
@@ -180,7 +180,7 @@ export interface Presence extends EmitsDiscontinuities {
    * Get the underlying Ably realtime channel used for presence in this chat room.
    * @returns The realtime channel.
    */
-  get channel(): Ably.RealtimeChannel;
+  get channelPromise(): Promise<Ably.RealtimeChannel>;
 }
 
 /**
@@ -190,7 +190,7 @@ export class DefaultPresence
   extends EventEmitter<PresenceEventsMap>
   implements Presence, HandlesDiscontinuity, ContributesToRoomLifecycle
 {
-  private readonly _channel: Ably.RealtimeChannel;
+  private readonly _channelPromise: Promise<Ably.RealtimeChannel>;
   private readonly _clientId: string;
   private readonly _logger: Logger;
   private readonly _discontinuityEmitter: DiscontinuityEmitter = newDiscontinuityEmitter();
@@ -204,7 +204,14 @@ export class DefaultPresence
    * A channel can have multiple connections using the same clientId.
    * @param logger An instance of the Logger.
    */
-  constructor(roomId: string, roomOptions: RoomOptions, realtime: Ably.Realtime, clientId: string, logger: Logger) {
+  constructor(
+    roomId: string,
+    roomOptions: RoomOptions,
+    realtime: Ably.Realtime,
+    clientId: string,
+    logger: Logger,
+    initAfter: Promise<void>,
+  ) {
     super();
 
     // Set our channel modes based on the room options
@@ -217,11 +224,18 @@ export class DefaultPresence
       channelModes.push('PRESENCE_SUBSCRIBE');
     }
 
-    this._channel = getChannel(messagesChannelName(roomId), realtime, { modes: channelModes });
-    addListenerToChannelPresenceWithoutAttach({
-      listener: this.subscribeToEvents.bind(this),
-      channel: this._channel,
+    this._channelPromise = initAfter.then(() => {
+      const channel = getChannel(messagesChannelName(roomId), realtime, { modes: channelModes });
+      addListenerToChannelPresenceWithoutAttach({
+        listener: this.subscribeToEvents.bind(this),
+        channel: channel,
+      });
+      return channel;
     });
+
+    // catch this so it won't send unhandledrejection global event
+    this._channelPromise.catch(() => {});
+
     this._clientId = clientId;
     this._logger = logger;
   }
@@ -230,8 +244,8 @@ export class DefaultPresence
    * Get the underlying Ably realtime channel used for presence in this chat room.
    * @returns The realtime channel.
    */
-  get channel(): Ably.RealtimeChannel {
-    return this._channel;
+  get channelPromise(): Promise<Ably.RealtimeChannel> {
+    return this._channelPromise;
   }
 
   /**
@@ -239,7 +253,8 @@ export class DefaultPresence
    */
   async get(params?: Ably.RealtimePresenceParams): Promise<PresenceMember[]> {
     this._logger.trace('Presence.get()', { params });
-    const userOnPresence = await this._channel.presence.get(params);
+    const channel = await this._channelPromise;
+    const userOnPresence = await channel.presence.get(params);
 
     // ably-js never emits the 'absent' event, so we can safely ignore it here.
     return userOnPresence.map((user) => ({
@@ -257,7 +272,8 @@ export class DefaultPresence
    * @inheritDoc
    */
   async isUserPresent(clientId: string): Promise<boolean> {
-    const presenceSet = await this._channel.presence.get({ clientId: clientId });
+    const channel = await this._channelPromise;
+    const presenceSet = await channel.presence.get({ clientId: clientId });
     return presenceSet.length > 0;
   }
 
@@ -271,8 +287,8 @@ export class DefaultPresence
     const presenceEventToSend: AblyPresenceData = {
       userCustomData: data,
     };
-
-    return this._channel.presence.enterClient(this._clientId, presenceEventToSend);
+    const channel = await this._channelPromise;
+    return channel.presence.enterClient(this._clientId, presenceEventToSend);
   }
 
   /**
@@ -285,8 +301,8 @@ export class DefaultPresence
     const presenceEventToSend: AblyPresenceData = {
       userCustomData: data,
     };
-
-    return this._channel.presence.updateClient(this._clientId, presenceEventToSend);
+    const channel = await this._channelPromise;
+    return channel.presence.updateClient(this._clientId, presenceEventToSend);
   }
 
   /**
@@ -299,8 +315,8 @@ export class DefaultPresence
     const presenceEventToSend: AblyPresenceData = {
       userCustomData: data,
     };
-
-    return this._channel.presence.leaveClient(this._clientId, presenceEventToSend);
+    const channel = await this._channelPromise;
+    return channel.presence.leaveClient(this._clientId, presenceEventToSend);
   }
 
   /**

--- a/src/core/presence.ts
+++ b/src/core/presence.ts
@@ -218,7 +218,9 @@ export class DefaultPresence
     this._channel = initAfter.then(() => this._makeChannel(roomId, roomOptions, realtime));
 
     // Catch this so it won't send unhandledrejection global event
-    this._channel.catch((error : unknown) => { logger.debug('Presence: channel initialization canceled', { roomId, error }); });
+    this._channel.catch((error: unknown) => {
+      logger.debug('Presence: channel initialization canceled', { roomId, error });
+    });
 
     this._clientId = clientId;
     this._logger = logger;

--- a/src/core/presence.ts
+++ b/src/core/presence.ts
@@ -203,6 +203,7 @@ export class DefaultPresence
    * @param clientId The client ID, attached to presences messages as an identifier of the sender.
    * A channel can have multiple connections using the same clientId.
    * @param logger An instance of the Logger.
+   * @param initAfter A promise that is awaited before creating any channels.
    */
   constructor(
     roomId: string,

--- a/src/core/presence.ts
+++ b/src/core/presence.ts
@@ -178,7 +178,7 @@ export interface Presence extends EmitsDiscontinuities {
 
   /**
    * Get the underlying Ably realtime channel used for presence in this chat room.
-   * @returns The realtime channel.
+   * @returns A promise of the realtime channel.
    */
   get channel(): Promise<Ably.RealtimeChannel>;
 }

--- a/src/core/room-lifecycle-manager.ts
+++ b/src/core/room-lifecycle-manager.ts
@@ -12,7 +12,7 @@ import { DefaultStatus, NewRoomStatus, RoomLifecycle, RoomStatusChange } from '.
 export interface ContributesToRoomLifecycle extends HandlesDiscontinuity {
   /**
    * Gets the channel on which the feature operates. This promise is never
-   * rejected except in the case where room initialization is cancelled.
+   * rejected except in the case where room initialization is canceled.
    */
   get channel(): Promise<Ably.RealtimeChannel>;
 

--- a/src/core/room-lifecycle-manager.ts
+++ b/src/core/room-lifecycle-manager.ts
@@ -33,7 +33,7 @@ export interface ContributesToRoomLifecycle extends HandlesDiscontinuity {
  * This interface represents a feature that contributes to the room lifecycle and
  * exposes its channel directly. Objects of this type are created by awaiting the
  * channel promises of all the {@link ContributesToRoomLifecycle} objects.
- * 
+ *
  * @internal
  */
 interface ResolvedContributor {

--- a/src/core/room-lifecycle-manager.ts
+++ b/src/core/room-lifecycle-manager.ts
@@ -12,7 +12,7 @@ import { DefaultStatus, NewRoomStatus, RoomLifecycle, RoomStatusChange } from '.
 export interface ContributesToRoomLifecycle extends HandlesDiscontinuity {
   /**
    * Gets the channel on which the feature operates. This promise is never
-   * rejected exept in the case where room initialisation is cancelled.
+   * rejected except in the case where room initialization is cancelled.
    */
   get channel(): Promise<Ably.RealtimeChannel>;
 

--- a/src/core/room-lifecycle-manager.ts
+++ b/src/core/room-lifecycle-manager.ts
@@ -14,7 +14,7 @@ export interface ContributesToRoomLifecycle extends HandlesDiscontinuity {
    * Gets the channel on which the feature operates. This promise is never
    * rejected exept in the case where room initialisation is cancelled.
    */
-  get channelPromise(): Promise<Ably.RealtimeChannel>;
+  get channel(): Promise<Ably.RealtimeChannel>;
 
   /**
    * Gets the ErrorInfo code that should be used when the feature fails to attach.

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -157,7 +157,9 @@ export class DefaultRoomReactions
     this._channel = initAfter.then(() => this._makeChannel(roomId, realtime));
 
     // Catch this so it won't send unhandledrejection global event
-    this._channel.catch((error : unknown) => { logger.debug('RoomReactions: channel initialization canceled', { roomId, error }); });
+    this._channel.catch((error: unknown) => {
+      logger.debug('RoomReactions: channel initialization canceled', { roomId, error });
+    });
 
     this._clientId = clientId;
     this._logger = logger;

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -108,7 +108,7 @@ export interface RoomReactions extends EmitsDiscontinuities {
    * Returns an instance of the Ably realtime channel used for room-level reactions.
    * Avoid using this directly unless special features that cannot otherwise be implemented are needed.
    *
-   * @returns The Ably realtime channel instance.
+   * @returns A promise of the Ably realtime channel.
    */
   get channel(): Promise<Ably.RealtimeChannel>;
 }

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -157,7 +157,7 @@ export class DefaultRoomReactions
     this._channel = initAfter.then(() => this._makeChannel(roomId, realtime));
 
     // Catch this so it won't send unhandledrejection global event
-    this._channel.catch((error : unknown) => { logger.debug('RoomReactions: channel initialization cancelled', { roomId, error }); });
+    this._channel.catch((error : unknown) => { logger.debug('RoomReactions: channel initialization canceled', { roomId, error }); });
 
     this._clientId = clientId;
     this._logger = logger;

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -110,7 +110,7 @@ export interface RoomReactions extends EmitsDiscontinuities {
    *
    * @returns The Ably realtime channel instance.
    */
-  get channel(): Ably.RealtimeChannel;
+  get channelPromise(): Promise<Ably.RealtimeChannel>;
 }
 
 interface RoomReactionEventsMap {
@@ -139,7 +139,7 @@ export class DefaultRoomReactions
   extends EventEmitter<RoomReactionEventsMap>
   implements RoomReactions, HandlesDiscontinuity, ContributesToRoomLifecycle
 {
-  private readonly _channel: Ably.RealtimeChannel;
+  private readonly _channelPromise: Promise<Ably.RealtimeChannel>;
   private readonly _clientId: string;
   private readonly _logger: Logger;
   private readonly _discontinuityEmitter: DiscontinuityEmitter = newDiscontinuityEmitter();
@@ -151,14 +151,20 @@ export class DefaultRoomReactions
    * @param clientId The client ID of the user.
    * @param logger An instance of the Logger.
    */
-  constructor(roomId: string, realtime: Ably.Realtime, clientId: string, logger: Logger) {
+  constructor(roomId: string, realtime: Ably.Realtime, clientId: string, logger: Logger, initAfter: Promise<void>) {
     super();
-    this._channel = getChannel(`${roomId}::$chat::$reactions`, realtime);
-    addListenerToChannelWithoutAttach({
-      listener: this._forwarder.bind(this),
-      events: [RoomReactionEvents.Reaction],
-      channel: this._channel,
+    this._channelPromise = initAfter.then(() => {
+      const channel = getChannel(`${roomId}::$chat::$reactions`, realtime);
+      addListenerToChannelWithoutAttach({
+        listener: this._forwarder.bind(this),
+        events: [RoomReactionEvents.Reaction],
+        channel: channel,
+      });
+      return channel;
     });
+
+    // catch this so it won't send unhandledrejection global event
+    this._channelPromise.catch(() => {});
 
     this._clientId = clientId;
     this._logger = logger;
@@ -209,7 +215,9 @@ export class DefaultRoomReactions
       },
     };
 
-    return this._channel.publish(realtimeMessage);
+    return this._channelPromise.then((channel) => {
+      return channel.publish(realtimeMessage);
+    });
   }
 
   /**
@@ -245,8 +253,8 @@ export class DefaultRoomReactions
     this.emit(RoomReactionEvents.Reaction, reaction);
   };
 
-  get channel(): Ably.RealtimeChannel {
-    return this._channel;
+  get channelPromise(): Promise<Ably.RealtimeChannel> {
+    return this._channelPromise;
   }
 
   private _parseNewReaction(inbound: Ably.InboundMessage, clientId: string): Reaction | undefined {

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -164,7 +164,7 @@ export class DefaultRoomReactions
     });
 
     // catch this so it won't send unhandledrejection global event
-    this._channel.catch(() => {});
+    this._channel.catch(() => void 0);
 
     this._clientId = clientId;
     this._logger = logger;

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -156,8 +156,8 @@ export class DefaultRoomReactions
     super();
     this._channel = initAfter.then(() => this._makeChannel(roomId, realtime));
 
-    // catch this so it won't send unhandledrejection global event
-    this._channel.catch(() => void 0);
+    // Catch this so it won't send unhandledrejection global event
+    this._channel.catch((error : unknown) => { logger.debug('RoomReactions: channel initialization cancelled', { roomId, error }); });
 
     this._clientId = clientId;
     this._logger = logger;

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -154,21 +154,26 @@ export class DefaultRoomReactions
    */
   constructor(roomId: string, realtime: Ably.Realtime, clientId: string, logger: Logger, initAfter: Promise<void>) {
     super();
-    this._channel = initAfter.then(() => {
-      const channel = getChannel(`${roomId}::$chat::$reactions`, realtime);
-      addListenerToChannelWithoutAttach({
-        listener: this._forwarder.bind(this),
-        events: [RoomReactionEvents.Reaction],
-        channel: channel,
-      });
-      return channel;
-    });
+    this._channel = initAfter.then(() => this._makeChannel(roomId, realtime));
 
     // catch this so it won't send unhandledrejection global event
     this._channel.catch(() => void 0);
 
     this._clientId = clientId;
     this._logger = logger;
+  }
+
+  /**
+   * Creates the realtime channel for room reactions. Called after initAfter is resolved.
+   */
+  private _makeChannel(roomId: string, realtime: Ably.Realtime): Ably.RealtimeChannel {
+    const channel = getChannel(`${roomId}::$chat::$reactions`, realtime);
+    addListenerToChannelWithoutAttach({
+      listener: this._forwarder.bind(this),
+      events: [RoomReactionEvents.Reaction],
+      channel: channel,
+    });
+    return channel;
   }
 
   /**

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -150,6 +150,7 @@ export class DefaultRoomReactions
    * @param realtime An instance of the Ably Realtime client.
    * @param clientId The client ID of the user.
    * @param logger An instance of the Logger.
+   * @param initAfter A promise that is awaited before creating any channels.
    */
   constructor(roomId: string, realtime: Ably.Realtime, clientId: string, logger: Logger, initAfter: Promise<void>) {
     super();

--- a/src/core/room-status.ts
+++ b/src/core/room-status.ts
@@ -8,6 +8,11 @@ import EventEmitter from './utils/event-emitter.js';
  */
 export enum RoomLifecycle {
   /**
+   * The library is currently initializing the room.
+   */
+  Initializing = 'initializing',
+
+  /**
    * A temporary state for when the library is first initialized.
    */
   Initialized = 'initialized',
@@ -162,7 +167,7 @@ type RoomStatusEventsMap = {
  * @internal
  */
 export class DefaultStatus extends EventEmitter<RoomStatusEventsMap> implements InternalRoomStatus {
-  private _state: RoomLifecycle = RoomLifecycle.Initialized;
+  private _state: RoomLifecycle = RoomLifecycle.Initializing;
   private _error?: Ably.ErrorInfo;
   private readonly _logger: Logger;
   private readonly _internalEmitter = new EventEmitter<RoomStatusEventsMap>();
@@ -174,7 +179,7 @@ export class DefaultStatus extends EventEmitter<RoomStatusEventsMap> implements 
   constructor(logger: Logger) {
     super();
     this._logger = logger;
-    this._state = RoomLifecycle.Initialized;
+    this._state = RoomLifecycle.Initializing;
     this._error = undefined;
   }
 

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -175,7 +175,7 @@ export class DefaultRoom implements Room {
 
     // At this stage finalizer (release) only needs to cancel the pending
     // initialization.
-    this._finalizer = async () => {
+    this._finalizer = () => {
       if (stopInitializingFeatures) {
         stopInitializingFeatures();
       }

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -261,7 +261,7 @@ export class DefaultRoom implements Room {
         contributor: ContributesToRoomLifecycle;
       }
       const promises = features.map((feature) => {
-        return feature.channelPromise.then((channel): ContributorWithChannel => {
+        return feature.channel.then((channel): ContributorWithChannel => {
           return {
             channel: channel,
             contributor: feature,
@@ -302,7 +302,7 @@ export class DefaultRoom implements Room {
             status: RoomLifecycle.Failed,
             error: new Ably.ErrorInfo('Room features initialization failed.', 40000, 400, error as Error),
           });
-          return Promise.reject(error);
+          throw error;
         });
     });
 

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -100,7 +100,7 @@ export class DefaultRoom implements Room {
   private readonly _roomId: string;
   private readonly _options: RoomOptions;
   private readonly _chatApi: ChatApi;
-  private readonly _messages?: DefaultMessages;
+  private readonly _messages: DefaultMessages;
   private readonly _typing?: DefaultTyping;
   private readonly _presence?: DefaultPresence;
   private readonly _reactions?: DefaultRoomReactions;
@@ -139,7 +139,7 @@ export class DefaultRoom implements Room {
     this._status = new DefaultStatus(logger);
 
     // This function gets called if release() is called before initialization
-    // starts. It allows for the room to not be initialised at all since it
+    // starts. It allows for the room to not be initialized at all since it
     // won't be needed.
     let stopInitializingFeatures: (() => void) | undefined;
 
@@ -162,8 +162,8 @@ export class DefaultRoom implements Room {
         reject(err);
       };
       initAfter
-        .then(() => {})
-        .catch(() => {})
+        .then(() => void 0)
+        .catch(() => void 0)
         .finally(() => {
           stopInitializingFeatures = undefined;
           if (rejected) {
@@ -307,7 +307,7 @@ export class DefaultRoom implements Room {
     });
 
     // Catch errors from asyncOpsAfter to prevent unhandled promise rejection error
-    this._asyncOpsAfter.catch(() => {});
+    this._asyncOpsAfter.catch(() => void 0);
   }
 
   /**
@@ -328,7 +328,7 @@ export class DefaultRoom implements Room {
    * @inheritdoc Room
    */
   get messages(): Messages {
-    return this._messages!;
+    return this._messages;
   }
 
   /**

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -154,7 +154,7 @@ export class DefaultRoom implements Room {
   private readonly _status: DefaultStatus;
   private _lifecycleManager?: RoomLifecycleManager;
   private _finalizer: () => Promise<void>;
-  private _asyncOpsAfter: Promise<void>;
+  private readonly _asyncOpsAfter: Promise<void>;
 
   /**
    * Constructs a new Room instance.

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -143,8 +143,8 @@ export class DefaultRoom implements Room {
     // won't be needed.
     let stopInitializingFeatures: (() => void) | undefined;
 
-    // This promise is the same as initAfter but it gets rejected if release()
-    // is called before initialization starts. This make sure that room
+    // This promise is the same as initAfter, but it gets rejected if release()
+    // is called before initialization starts. This makes sure that room
     // features will not permanently hang waiting for this promise to resolve.
     //
     // This promise is passed down to all features to wait before starting to

--- a/src/core/rooms.ts
+++ b/src/core/rooms.ts
@@ -139,10 +139,6 @@ export class DefaultRooms implements Rooms {
       // are made in quick succession. We only want to remove the
       // room from the releasing map if the last ongoing release
       // finished.
-      //
-      // The release callbacks are actually happening in the order
-      // in which release() methods are called due to passing
-      // waitForMe in rooms.get().
       const releasing = this._releasing.get(roomId);
       if (releasing && releasing.count < count) {
         this._releasing.delete(roomId);

--- a/src/core/rooms.ts
+++ b/src/core/rooms.ts
@@ -109,22 +109,22 @@ export class DefaultRooms implements Rooms {
     const room = this._rooms.get(roomId);
     const releasing = this._releasing.get(roomId);
 
-    // if we don't have the room
+    // If the room doesn't currently exist
     if (!room) {
-      // ... and it's currently releasing wait for the same promise
+      // If the room is being released, forward the releasing promise
       if (releasing) {
         return releasing.promise;
       }
 
-      // if not releasing, nothing else to do
+      // If the room is not releasing, there is nothing else to do
       return Promise.resolve();
     }
 
-    // make sure we no longer keep this room in the map
+    // Make sure we no longer keep this room in the map
     this._rooms.delete(roomId);
 
-    // we have a room and an ongoing release, we keep the count
-    // of the latest release call.
+    // We have a room and an ongoing release, we keep the count of the latest
+    // release call.
     let count = 0;
     if (releasing) {
       count = releasing.count + 1;

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -68,8 +68,8 @@ export interface Typing extends EmitsDiscontinuities {
   stop(): Promise<void>;
 
   /**
-   * Get the name of the realtime channel underpinning typing events.
-   * @returns The name of the realtime channel.
+   * Get the Ably realtime channel underpinning typing events.
+   * @returns A promise of the Ably realtime channel.
    */
   channel: Promise<Ably.RealtimeChannel>;
 }

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -136,6 +136,7 @@ export class DefaultTyping
    * @param realtime An instance of the Ably Realtime client.
    * @param clientId The client ID of the user.
    * @param logger An instance of the Logger.
+   * @param initAfter A promise that is awaited before creating any channels.
    */
   constructor(
     roomId: string,

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -151,7 +151,7 @@ export class DefaultTyping
     this._channel = initAfter.then(() => this._makeChannel(roomId, realtime));
 
     // Catch this so it won't send unhandledrejection global event
-    this._channel.catch((error : unknown) => { logger.debug('Typing: channel initialization cancelled', { roomId, error }); });
+    this._channel.catch((error : unknown) => { logger.debug('Typing: channel initialization canceled', { roomId, error }); });
 
     // Timeout for typing
     this._typingTimeoutMs = options.timeoutMs;

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -157,7 +157,7 @@ export class DefaultTyping
     });
 
     // catch this so it won't send unhandledrejection global event
-    this._channel.catch(() => {});
+    this._channel.catch(() => void 0);
 
     // Timeout for typing
     this._typingTimeoutMs = options.timeoutMs;

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -151,7 +151,9 @@ export class DefaultTyping
     this._channel = initAfter.then(() => this._makeChannel(roomId, realtime));
 
     // Catch this so it won't send unhandledrejection global event
-    this._channel.catch((error : unknown) => { logger.debug('Typing: channel initialization canceled', { roomId, error }); });
+    this._channel.catch((error: unknown) => {
+      logger.debug('Typing: channel initialization canceled', { roomId, error });
+    });
 
     // Timeout for typing
     this._typingTimeoutMs = options.timeoutMs;

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -148,14 +148,7 @@ export class DefaultTyping
   ) {
     super();
     this._clientId = clientId;
-    this._channel = initAfter.then(() => {
-      const channel = getChannel(`${roomId}::$chat::$typingIndicators`, realtime);
-      addListenerToChannelPresenceWithoutAttach({
-        listener: this._internalSubscribeToEvents.bind(this),
-        channel: channel,
-      });
-      return channel;
-    });
+    this._channel = initAfter.then(() => this._makeChannel(roomId, realtime));
 
     // catch this so it won't send unhandledrejection global event
     this._channel.catch(() => void 0);
@@ -163,6 +156,18 @@ export class DefaultTyping
     // Timeout for typing
     this._typingTimeoutMs = options.timeoutMs;
     this._logger = logger;
+  }
+
+  /**
+   * Creates the realtime channel for typing indicators. Called after initAfter is resolved.
+   */
+  private _makeChannel(roomId: string, realtime: Ably.Realtime): Ably.RealtimeChannel {
+    const channel = getChannel(`${roomId}::$chat::$typingIndicators`, realtime);
+    addListenerToChannelPresenceWithoutAttach({
+      listener: this._internalSubscribeToEvents.bind(this),
+      channel: channel,
+    });
+    return channel;
   }
 
   /**

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -150,8 +150,8 @@ export class DefaultTyping
     this._clientId = clientId;
     this._channel = initAfter.then(() => this._makeChannel(roomId, realtime));
 
-    // catch this so it won't send unhandledrejection global event
-    this._channel.catch(() => void 0);
+    // Catch this so it won't send unhandledrejection global event
+    this._channel.catch((error : unknown) => { logger.debug('Typing: channel initialization cancelled', { roomId, error }); });
 
     // Timeout for typing
     this._typingTimeoutMs = options.timeoutMs;

--- a/test/core/messages.integration.test.ts
+++ b/test/core/messages.integration.test.ts
@@ -33,11 +33,11 @@ describe('messages integration', () => {
     context.chat = newChatClient();
   });
 
-  it<TestContext>('sets the agent version on the channel', (context) => {
+  it<TestContext>('sets the agent version on the channel', async (context) => {
     const { chat } = context;
 
     const room = getRandomRoom(chat);
-    const channel = room.messages.channel as RealtimeChannelWithOptions;
+    const channel = (await room.messages.channelPromise) as RealtimeChannelWithOptions;
 
     expect(channel.channelOptions.params).toEqual(expect.objectContaining({ agent: CHANNEL_OPTIONS_AGENT_STRING }));
   });
@@ -407,7 +407,7 @@ describe('messages integration', () => {
       discontinuityErrors.push(error);
     });
 
-    const channelSuspendable = room.messages.channel as Ably.RealtimeChannel & {
+    const channelSuspendable = (await room.messages.channelPromise) as Ably.RealtimeChannel & {
       notifyState(state: 'suspended' | 'attached'): void;
     };
 

--- a/test/core/messages.integration.test.ts
+++ b/test/core/messages.integration.test.ts
@@ -37,7 +37,7 @@ describe('messages integration', () => {
     const { chat } = context;
 
     const room = getRandomRoom(chat);
-    const channel = (await room.messages.channelPromise) as RealtimeChannelWithOptions;
+    const channel = (await room.messages.channel) as RealtimeChannelWithOptions;
 
     expect(channel.channelOptions.params).toEqual(expect.objectContaining({ agent: CHANNEL_OPTIONS_AGENT_STRING }));
   });
@@ -407,7 +407,7 @@ describe('messages integration', () => {
       discontinuityErrors.push(error);
     });
 
-    const channelSuspendable = (await room.messages.channelPromise) as Ably.RealtimeChannel & {
+    const channelSuspendable = (await room.messages.channel) as Ably.RealtimeChannel & {
       notifyState(state: 'suspended' | 'attached'): void;
     };
 

--- a/test/core/messages.test.ts
+++ b/test/core/messages.test.ts
@@ -50,7 +50,7 @@ describe('Messages', () => {
     context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
     context.chatApi = new ChatApi(context.realtime, makeTestLogger());
     context.room = makeRandomRoom({ chatApi: context.chatApi, realtime: context.realtime });
-    const channel = await context.room.messages.channelPromise;
+    const channel = await context.room.messages.channel;
     context.emulateBackendPublish = channelEventEmitter(channel);
     context.emulateBackendStateChange = channelStateEventEmitter(channel);
   });
@@ -449,7 +449,7 @@ describe('Messages', () => {
       return Promise.resolve(mockPaginatedResultWithItems([]));
     });
 
-    const msgChannel = await room.messages.channelPromise;
+    const msgChannel = await room.messages.channel;
 
     // Force ts to recognize the channel properties
     const channel = msgChannel as RealtimeChannel & {
@@ -471,9 +471,13 @@ describe('Messages', () => {
     // This test was failing because now we wait for the channel promise inside
     // DefaultMessages._resolveSubscriptionStart. That got resolved a tick after
     // we changed the channel state below. To address this issue we wait an
-    // insignificant amount of time here to ensure the channel promise inside 
+    // insignificant amount of time here to ensure the channel promise inside
     // DefaultMessages resolves BEFORE we change the channel state here.
-    await new Promise<void>(resolve => setTimeout(() => { resolve();}, 10));
+    await new Promise<void>((resolve) =>
+      setTimeout(() => {
+        resolve();
+      }, 10),
+    );
 
     // Mock the channel state to be attached
     vi.spyOn(channel, 'state', 'get').mockReturnValue('attached');
@@ -505,7 +509,7 @@ describe('Messages', () => {
       return Promise.resolve(mockPaginatedResultWithItems([]));
     });
 
-    const msgChannel = await room.messages.channelPromise;
+    const msgChannel = await room.messages.channel;
 
     // Force ts to recognize the channel properties
     const channel = msgChannel as RealtimeChannel & {
@@ -542,7 +546,7 @@ describe('Messages', () => {
       return Promise.resolve(mockPaginatedResultWithItems([]));
     });
 
-    const msgChannel = await room.messages.channelPromise;
+    const msgChannel = await room.messages.channel;
     const channel = msgChannel as RealtimeChannel & {
       properties: {
         attachSerial: string | undefined;
@@ -556,7 +560,11 @@ describe('Messages', () => {
     const { getPreviousMessages } = room.messages.subscribe(() => {});
 
     // wait
-    await new Promise<void>(resolve => setTimeout(() => { resolve();}, 10));
+    await new Promise<void>((resolve) =>
+      setTimeout(() => {
+        resolve();
+      }, 10),
+    );
 
     // Mock the channel state to be attached
     vi.spyOn(channel, 'state', 'get').mockReturnValue('attached');
@@ -635,7 +643,7 @@ describe('Messages', () => {
       return Promise.resolve(mockPaginatedResultWithItems([]));
     });
 
-    const msgChannel = await room.messages.channelPromise;
+    const msgChannel = await room.messages.channel;
     const channel = msgChannel as RealtimeChannel & {
       properties: {
         attachSerial: string | undefined;
@@ -723,7 +731,7 @@ describe('Messages', () => {
       return Promise.resolve(mockPaginatedResultWithItems([]));
     });
 
-    const msgChannel = await room.messages.channelPromise;
+    const msgChannel = await room.messages.channel;
     const channel = msgChannel as RealtimeChannel & {
       properties: {
         attachSerial: string | undefined;
@@ -826,7 +834,7 @@ describe('Messages', () => {
     // Create a room instance
     const { room } = context;
 
-    const msgChannel = await room.messages.channelPromise;
+    const msgChannel = await room.messages.channel;
     const channel = msgChannel as RealtimeChannel & {
       properties: {
         attachSerial: string | undefined;

--- a/test/core/messages.test.ts
+++ b/test/core/messages.test.ts
@@ -46,12 +46,13 @@ const mockPaginatedResultWithItems = (items: Message[]): MockPaginatedResult => 
 vi.mock('ably');
 
 describe('Messages', () => {
-  beforeEach<TestContext>((context) => {
+  beforeEach<TestContext>(async (context) => {
     context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
     context.chatApi = new ChatApi(context.realtime, makeTestLogger());
     context.room = makeRandomRoom({ chatApi: context.chatApi, realtime: context.realtime });
-    context.emulateBackendPublish = channelEventEmitter(context.room.messages.channel);
-    context.emulateBackendStateChange = channelStateEventEmitter(context.room.messages.channel);
+    const channel = await context.room.messages.channelPromise;
+    context.emulateBackendPublish = channelEventEmitter(channel);
+    context.emulateBackendStateChange = channelStateEventEmitter(channel);
   });
 
   describe('sending message', () => {
@@ -448,8 +449,10 @@ describe('Messages', () => {
       return Promise.resolve(mockPaginatedResultWithItems([]));
     });
 
+    const msgChannel = await room.messages.channelPromise;
+
     // Force ts to recognize the channel properties
-    const channel = room.messages.channel as RealtimeChannel & {
+    const channel = msgChannel as RealtimeChannel & {
       properties: {
         attachSerial: string | undefined;
       };
@@ -458,12 +461,19 @@ describe('Messages', () => {
     // Set the timeserial of the channel attach
     channel.properties.attachSerial = testAttachSerial;
 
-    vi.spyOn(channel, 'whenState').mockImplementation(() => {
+    vi.spyOn(channel, 'whenState').mockImplementation(function () {
       return Promise.resolve(null);
     });
 
     // Subscribe to the messages
     const { getPreviousMessages } = room.messages.subscribe(() => {});
+
+    // This test was failing because now we wait for the channel promise inside
+    // DefaultMessages._resolveSubscriptionStart. That got resolved a tick after
+    // we changed the channel state below. To address this issue we wait an
+    // insignificant amount of time here to ensure the channel promise inside 
+    // DefaultMessages resolves BEFORE we change the channel state here.
+    await new Promise<void>(resolve => setTimeout(() => { resolve();}, 10));
 
     // Mock the channel state to be attached
     vi.spyOn(channel, 'state', 'get').mockReturnValue('attached');
@@ -495,8 +505,10 @@ describe('Messages', () => {
       return Promise.resolve(mockPaginatedResultWithItems([]));
     });
 
+    const msgChannel = await room.messages.channelPromise;
+
     // Force ts to recognize the channel properties
-    const channel = room.messages.channel as RealtimeChannel & {
+    const channel = msgChannel as RealtimeChannel & {
       properties: {
         channelSerial: string | undefined;
       };
@@ -530,7 +542,8 @@ describe('Messages', () => {
       return Promise.resolve(mockPaginatedResultWithItems([]));
     });
 
-    const channel = room.messages.channel as RealtimeChannel & {
+    const msgChannel = await room.messages.channelPromise;
+    const channel = msgChannel as RealtimeChannel & {
       properties: {
         attachSerial: string | undefined;
         fromSerial: string | undefined;
@@ -541,6 +554,9 @@ describe('Messages', () => {
     channel.properties.attachSerial = firstAttachmentSerial;
 
     const { getPreviousMessages } = room.messages.subscribe(() => {});
+
+    // wait
+    await new Promise<void>(resolve => setTimeout(() => { resolve();}, 10));
 
     // Mock the channel state to be attached
     vi.spyOn(channel, 'state', 'get').mockReturnValue('attached');
@@ -619,7 +635,8 @@ describe('Messages', () => {
       return Promise.resolve(mockPaginatedResultWithItems([]));
     });
 
-    const channel = room.messages.channel as RealtimeChannel & {
+    const msgChannel = await room.messages.channelPromise;
+    const channel = msgChannel as RealtimeChannel & {
       properties: {
         attachSerial: string | undefined;
         channelSerial: string | undefined;
@@ -706,7 +723,8 @@ describe('Messages', () => {
       return Promise.resolve(mockPaginatedResultWithItems([]));
     });
 
-    const channel = room.messages.channel as RealtimeChannel & {
+    const msgChannel = await room.messages.channelPromise;
+    const channel = msgChannel as RealtimeChannel & {
       properties: {
         attachSerial: string | undefined;
         channelSerial: string | undefined;
@@ -808,7 +826,8 @@ describe('Messages', () => {
     // Create a room instance
     const { room } = context;
 
-    const channel = room.messages.channel as RealtimeChannel & {
+    const msgChannel = await room.messages.channelPromise;
+    const channel = msgChannel as RealtimeChannel & {
       properties: {
         attachSerial: string | undefined;
         channelSerial: string | undefined;

--- a/test/core/occupancy.integration.test.ts
+++ b/test/core/occupancy.integration.test.ts
@@ -84,9 +84,11 @@ describe('occupancy', () => {
       presenceMembers: 0,
     });
 
+    const channelName = (await room.messages.channelPromise).name;
+
     // In a separate realtime client, attach to the same room
     const realtimeClient = ablyRealtimeClientWithToken();
-    const realtimeChannel = realtimeClient.channels.get(room.messages.channel.name);
+    const realtimeChannel = realtimeClient.channels.get(channelName);
     await realtimeChannel.attach();
 
     // Wait for the occupancy to reach the expected occupancy
@@ -100,7 +102,7 @@ describe('occupancy', () => {
     // Make another realtime client and attach to the same room, but only as a subscriber
     // Also have them enter and subscribe to presence
     const subscriberRealtimeClient = ablyRealtimeClientWithToken();
-    const subscriberRealtimeChannel = subscriberRealtimeClient.channels.get(room.messages.channel.name, {
+    const subscriberRealtimeChannel = subscriberRealtimeClient.channels.get(channelName, {
       modes: ['SUBSCRIBE', 'PRESENCE', 'PRESENCE_SUBSCRIBE'],
     });
     await subscriberRealtimeChannel.attach();
@@ -144,7 +146,7 @@ describe('occupancy', () => {
 
     // In a separate realtime client, attach to the same room
     const realtimeClient = ablyRealtimeClientWithToken();
-    const realtimeChannel = realtimeClient.channels.get(room.messages.channel.name);
+    const realtimeChannel = realtimeClient.channels.get((await room.messages.channelPromise).name);
     await realtimeChannel.attach();
     await realtimeChannel.presence.enter();
 
@@ -169,7 +171,7 @@ describe('occupancy', () => {
       discontinuityErrors.push(error);
     });
 
-    const channelSuspendable = room.occupancy.channel as Ably.RealtimeChannel & {
+    const channelSuspendable = (await room.messages.channelPromise) as Ably.RealtimeChannel & {
       notifyState(state: 'suspended' | 'attached'): void;
     };
 

--- a/test/core/occupancy.integration.test.ts
+++ b/test/core/occupancy.integration.test.ts
@@ -84,7 +84,7 @@ describe('occupancy', () => {
       presenceMembers: 0,
     });
 
-    const channelName = (await room.messages.channel).name;
+    const { name: channelName } = await room.messages.channel;
 
     // In a separate realtime client, attach to the same room
     const realtimeClient = ablyRealtimeClientWithToken();
@@ -146,7 +146,8 @@ describe('occupancy', () => {
 
     // In a separate realtime client, attach to the same room
     const realtimeClient = ablyRealtimeClientWithToken();
-    const realtimeChannel = realtimeClient.channels.get((await room.messages.channel).name);
+    const { name: channelName } = await room.messages.channel;
+    const realtimeChannel = realtimeClient.channels.get(channelName);
     await realtimeChannel.attach();
     await realtimeChannel.presence.enter();
 

--- a/test/core/occupancy.integration.test.ts
+++ b/test/core/occupancy.integration.test.ts
@@ -84,7 +84,7 @@ describe('occupancy', () => {
       presenceMembers: 0,
     });
 
-    const channelName = (await room.messages.channelPromise).name;
+    const channelName = (await room.messages.channel).name;
 
     // In a separate realtime client, attach to the same room
     const realtimeClient = ablyRealtimeClientWithToken();
@@ -146,7 +146,7 @@ describe('occupancy', () => {
 
     // In a separate realtime client, attach to the same room
     const realtimeClient = ablyRealtimeClientWithToken();
-    const realtimeChannel = realtimeClient.channels.get((await room.messages.channelPromise).name);
+    const realtimeChannel = realtimeClient.channels.get((await room.messages.channel).name);
     await realtimeChannel.attach();
     await realtimeChannel.presence.enter();
 
@@ -171,7 +171,7 @@ describe('occupancy', () => {
       discontinuityErrors.push(error);
     });
 
-    const channelSuspendable = (await room.messages.channelPromise) as Ably.RealtimeChannel & {
+    const channelSuspendable = (await room.messages.channel) as Ably.RealtimeChannel & {
       notifyState(state: 'suspended' | 'attached'): void;
     };
 

--- a/test/core/occupancy.test.ts
+++ b/test/core/occupancy.test.ts
@@ -19,11 +19,12 @@ interface TestContext {
 vi.mock('ably');
 
 describe('Occupancy', () => {
-  beforeEach<TestContext>((context) => {
+  beforeEach<TestContext>(async (context) => {
     context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
     context.chatApi = new ChatApi(context.realtime, makeTestLogger());
     context.room = makeRandomRoom({ chatApi: context.chatApi, realtime: context.realtime });
-    context.emulateOccupancyUpdate = channelEventEmitter(context.room.occupancy.channel);
+    const channel = await context.room.occupancy.channelPromise;
+    context.emulateOccupancyUpdate = channelEventEmitter(channel);
   });
 
   it<TestContext>('receives occupancy updates', (context) =>

--- a/test/core/occupancy.test.ts
+++ b/test/core/occupancy.test.ts
@@ -23,7 +23,7 @@ describe('Occupancy', () => {
     context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
     context.chatApi = new ChatApi(context.realtime, makeTestLogger());
     context.room = makeRandomRoom({ chatApi: context.chatApi, realtime: context.realtime });
-    const channel = await context.room.occupancy.channelPromise;
+    const channel = await context.room.occupancy.channel;
     context.emulateOccupancyUpdate = channelEventEmitter(channel);
   });
 

--- a/test/core/presence.integration.test.ts
+++ b/test/core/presence.integration.test.ts
@@ -110,7 +110,7 @@ describe('UserPresence', { timeout: 10000 }, () => {
     const enterEventPromise = waitForEvent(
       context.realtime,
       ['enter', 'present'],
-      context.chatRoom.messages.channel.name,
+      (await context.chatRoom.messages.channelPromise).name,
       (member: Ably.PresenceMessage) => {
         expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(
           context.defaultTestClientId,
@@ -132,7 +132,7 @@ describe('UserPresence', { timeout: 10000 }, () => {
     const enterEventPromise = waitForEvent(
       context.realtime,
       'update',
-      context.chatRoom.messages.channel.name,
+      (await context.chatRoom.messages.channelPromise).name,
       (member) => {
         expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(
           context.defaultTestClientId,
@@ -156,7 +156,7 @@ describe('UserPresence', { timeout: 10000 }, () => {
     const enterEventPromise = waitForEvent(
       context.realtime,
       'leave',
-      context.chatRoom.messages.channel.name,
+      (await context.chatRoom.messages.channelPromise).name,
       (member: Ably.PresenceMessage) => {
         expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(
           context.defaultTestClientId,
@@ -176,10 +176,12 @@ describe('UserPresence', { timeout: 10000 }, () => {
 
   // Test for successful fetching of presence users
   it<TestContext>('should successfully fetch presence users ', async (context) => {
+    const channelName = (await context.chatRoom.messages.channelPromise).name;
+
     // Connect 3 clients to the same channel
-    const client1 = ablyRealtimeClient({ clientId: 'clientId1' }).channels.get(context.chatRoom.messages.channel.name);
-    const client2 = ablyRealtimeClient({ clientId: 'clientId2' }).channels.get(context.chatRoom.messages.channel.name);
-    const client3 = ablyRealtimeClient({ clientId: 'clientId3' }).channels.get(context.chatRoom.messages.channel.name);
+    const client1 = ablyRealtimeClient({ clientId: 'clientId1' }).channels.get(channelName);
+    const client2 = ablyRealtimeClient({ clientId: 'clientId2' }).channels.get(channelName);
+    const client3 = ablyRealtimeClient({ clientId: 'clientId3' }).channels.get(channelName);
 
     // Data payload to check if the custom data is fetched correctly
     const testData: PresenceData = {
@@ -387,7 +389,7 @@ describe('UserPresence', { timeout: 10000 }, () => {
       discontinuityErrors.push(error);
     });
 
-    const channelSuspendable = room.presence.channel as Ably.RealtimeChannel & {
+    const channelSuspendable = (await room.presence.channelPromise) as Ably.RealtimeChannel & {
       notifyState(state: 'suspended' | 'attached'): void;
     };
 

--- a/test/core/presence.integration.test.ts
+++ b/test/core/presence.integration.test.ts
@@ -110,7 +110,7 @@ describe('UserPresence', { timeout: 10000 }, () => {
     const enterEventPromise = waitForEvent(
       context.realtime,
       ['enter', 'present'],
-      (await context.chatRoom.messages.channelPromise).name,
+      (await context.chatRoom.messages.channel).name,
       (member: Ably.PresenceMessage) => {
         expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(
           context.defaultTestClientId,
@@ -132,7 +132,7 @@ describe('UserPresence', { timeout: 10000 }, () => {
     const enterEventPromise = waitForEvent(
       context.realtime,
       'update',
-      (await context.chatRoom.messages.channelPromise).name,
+      (await context.chatRoom.messages.channel).name,
       (member) => {
         expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(
           context.defaultTestClientId,
@@ -156,7 +156,7 @@ describe('UserPresence', { timeout: 10000 }, () => {
     const enterEventPromise = waitForEvent(
       context.realtime,
       'leave',
-      (await context.chatRoom.messages.channelPromise).name,
+      (await context.chatRoom.messages.channel).name,
       (member: Ably.PresenceMessage) => {
         expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(
           context.defaultTestClientId,
@@ -176,7 +176,7 @@ describe('UserPresence', { timeout: 10000 }, () => {
 
   // Test for successful fetching of presence users
   it<TestContext>('should successfully fetch presence users ', async (context) => {
-    const channelName = (await context.chatRoom.messages.channelPromise).name;
+    const channelName = (await context.chatRoom.messages.channel).name;
 
     // Connect 3 clients to the same channel
     const client1 = ablyRealtimeClient({ clientId: 'clientId1' }).channels.get(channelName);
@@ -389,7 +389,7 @@ describe('UserPresence', { timeout: 10000 }, () => {
       discontinuityErrors.push(error);
     });
 
-    const channelSuspendable = (await room.presence.channelPromise) as Ably.RealtimeChannel & {
+    const channelSuspendable = (await room.presence.channel) as Ably.RealtimeChannel & {
       notifyState(state: 'suspended' | 'attached'): void;
     };
 

--- a/test/core/presence.integration.test.ts
+++ b/test/core/presence.integration.test.ts
@@ -107,10 +107,12 @@ describe('UserPresence', { timeout: 10000 }, () => {
 
   // Test for successful entering with clientId and custom user data
   it<TestContext>('successfully enter presence with clientId and custom user data', async (context) => {
+    const messageChannel = await context.chatRoom.messages.channel;
+    const messageChannelName = messageChannel.name;
     const enterEventPromise = waitForEvent(
       context.realtime,
       ['enter', 'present'],
-      (await context.chatRoom.messages.channel).name,
+      messageChannelName,
       (member: Ably.PresenceMessage) => {
         expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(
           context.defaultTestClientId,
@@ -129,19 +131,14 @@ describe('UserPresence', { timeout: 10000 }, () => {
 
   // Test for successful sending of presence update with clientId and custom user data
   it<TestContext>('should successfully send presence update with clientId and custom user data', async (context) => {
-    const enterEventPromise = waitForEvent(
-      context.realtime,
-      'update',
-      (await context.chatRoom.messages.channel).name,
-      (member) => {
-        expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(
-          context.defaultTestClientId,
-        );
-        expect(member.data, 'data should be equal to supplied userCustomData').toEqual({
-          userCustomData: { customKeyOne: 1 },
-        });
-      },
-    );
+    const messageChannel = await context.chatRoom.messages.channel;
+    const messageChannelName = messageChannel.name;
+    const enterEventPromise = waitForEvent(context.realtime, 'update', messageChannelName, (member) => {
+      expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(context.defaultTestClientId);
+      expect(member.data, 'data should be equal to supplied userCustomData').toEqual({
+        userCustomData: { customKeyOne: 1 },
+      });
+    });
 
     // Enter with custom user data
     await context.chatRoom.presence.enter({ customKeyOne: 1 });
@@ -153,10 +150,12 @@ describe('UserPresence', { timeout: 10000 }, () => {
 
   // Test for successful leaving of presence
   it<TestContext>('should successfully leave presence', async (context) => {
+    const messageChannel = await context.chatRoom.messages.channel;
+    const messageChannelName = messageChannel.name;
     const enterEventPromise = waitForEvent(
       context.realtime,
       'leave',
-      (await context.chatRoom.messages.channel).name,
+      messageChannelName,
       (member: Ably.PresenceMessage) => {
         expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(
           context.defaultTestClientId,
@@ -176,7 +175,7 @@ describe('UserPresence', { timeout: 10000 }, () => {
 
   // Test for successful fetching of presence users
   it<TestContext>('should successfully fetch presence users ', async (context) => {
-    const channelName = (await context.chatRoom.messages.channel).name;
+    const { name: channelName } = await context.chatRoom.messages.channel;
 
     // Connect 3 clients to the same channel
     const client1 = ablyRealtimeClient({ clientId: 'clientId1' }).channels.get(channelName);

--- a/test/core/room-lifecycle-manager.test.ts
+++ b/test/core/room-lifecycle-manager.test.ts
@@ -2,11 +2,7 @@ import * as Ably from 'ably';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, test, vi } from 'vitest';
 
 import { ErrorCodes } from '../../src/core/errors.ts';
-import {
-  ContributesToRoomLifecycle,
-  RoomLifecycleContributor,
-  RoomLifecycleManager,
-} from '../../src/core/room-lifecycle-manager.ts';
+import { RoomLifecycleContributor, RoomLifecycleManager } from '../../src/core/room-lifecycle-manager.ts';
 import { DefaultStatus, RoomLifecycle } from '../../src/core/room-status.ts';
 import { makeTestLogger } from '../helper/logger.ts';
 import { waitForRoomStatus } from '../helper/room.ts';

--- a/test/core/room-lifecycle-manager.test.ts
+++ b/test/core/room-lifecycle-manager.test.ts
@@ -200,7 +200,7 @@ const makeMockContributor = (
       discontinuityDetected() {},
       attachmentErrorCode,
       detachmentErrorCode,
-      channelPromise: Promise.resolve(channel),
+      channel: Promise.resolve(channel),
     },
     emulateStateChange(change: Ably.ChannelStateChange, update?: boolean) {
       vi.spyOn(contributor.channel, 'state', 'get').mockReturnValue(change.current);

--- a/test/core/room-lifecycle-manager.test.ts
+++ b/test/core/room-lifecycle-manager.test.ts
@@ -2,7 +2,7 @@ import * as Ably from 'ably';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, test, vi } from 'vitest';
 
 import { ErrorCodes } from '../../src/core/errors.ts';
-import { RoomLifecycleContributor, RoomLifecycleManager } from '../../src/core/room-lifecycle-manager.ts';
+import { ContributesToRoomLifecycle, RoomLifecycleManager } from '../../src/core/room-lifecycle-manager.ts';
 import { DefaultStatus, RoomLifecycle } from '../../src/core/room-status.ts';
 import { makeTestLogger } from '../helper/logger.ts';
 import { waitForRoomStatus } from '../helper/room.ts';
@@ -16,7 +16,9 @@ interface TestContext {
 
 vi.mock('ably');
 
-interface MockContributor extends RoomLifecycleContributor {
+interface MockContributor {
+  contributor: ContributesToRoomLifecycle;
+  channel: Ably.RealtimeChannel;
   emulateStateChange: (change: Ably.ChannelStateChange, update?: boolean) => void;
 }
 

--- a/test/core/room-reactions.integration.test.ts
+++ b/test/core/room-reactions.integration.test.ts
@@ -45,11 +45,11 @@ describe('room-level reactions integration test', () => {
     context.chat = newChatClient();
   });
 
-  it<TestContext>('sets the agent version on the channel', (context) => {
+  it<TestContext>('sets the agent version on the channel',async (context) => {
     const { chat } = context;
 
     const room = getRandomRoom(chat);
-    const channel = room.messages.channel as RealtimeChannelWithOptions;
+    const channel = (await room.messages.channelPromise) as RealtimeChannelWithOptions;
 
     expect(channel.channelOptions.params).toEqual(expect.objectContaining({ agent: CHANNEL_OPTIONS_AGENT_STRING }));
   });
@@ -92,7 +92,7 @@ describe('room-level reactions integration test', () => {
       discontinuityErrors.push(error);
     });
 
-    const channelSuspendable = room.reactions.channel as Ably.RealtimeChannel & {
+    const channelSuspendable = (await room.reactions.channelPromise) as Ably.RealtimeChannel & {
       notifyState(state: 'suspended' | 'attached'): void;
     };
 

--- a/test/core/room-reactions.integration.test.ts
+++ b/test/core/room-reactions.integration.test.ts
@@ -45,11 +45,11 @@ describe('room-level reactions integration test', () => {
     context.chat = newChatClient();
   });
 
-  it<TestContext>('sets the agent version on the channel',async (context) => {
+  it<TestContext>('sets the agent version on the channel', async (context) => {
     const { chat } = context;
 
     const room = getRandomRoom(chat);
-    const channel = (await room.messages.channelPromise) as RealtimeChannelWithOptions;
+    const channel = (await room.messages.channel) as RealtimeChannelWithOptions;
 
     expect(channel.channelOptions.params).toEqual(expect.objectContaining({ agent: CHANNEL_OPTIONS_AGENT_STRING }));
   });
@@ -92,7 +92,7 @@ describe('room-level reactions integration test', () => {
       discontinuityErrors.push(error);
     });
 
-    const channelSuspendable = (await room.reactions.channelPromise) as Ably.RealtimeChannel & {
+    const channelSuspendable = (await room.reactions.channel) as Ably.RealtimeChannel & {
       notifyState(state: 'suspended' | 'attached'): void;
     };
 

--- a/test/core/room-reactions.test.ts
+++ b/test/core/room-reactions.test.ts
@@ -33,7 +33,7 @@ describe('Reactions', () => {
     };
 
     context.room = makeRandomRoom({ chatApi: context.chatApi, realtime: context.realtime });
-    const channel = await context.room.reactions.channelPromise;
+    const channel = await context.room.reactions.channel;
     context.emulateBackendPublish = channelEventEmitter(channel);
 
     vi.spyOn(channel, 'publish').mockImplementation((message: Ably.Message) => {

--- a/test/core/room-reactions.test.ts
+++ b/test/core/room-reactions.test.ts
@@ -21,7 +21,7 @@ interface TestContext {
 vi.mock('ably');
 
 describe('Reactions', () => {
-  beforeEach<TestContext>((context) => {
+  beforeEach<TestContext>(async (context) => {
     const clientId = 'd.vader';
 
     context.realtime = new Ably.Realtime({ clientId: clientId, key: 'key' });
@@ -33,9 +33,10 @@ describe('Reactions', () => {
     };
 
     context.room = makeRandomRoom({ chatApi: context.chatApi, realtime: context.realtime });
-    context.emulateBackendPublish = channelEventEmitter(context.room.reactions.channel);
+    const channel = await context.room.reactions.channelPromise;
+    context.emulateBackendPublish = channelEventEmitter(channel);
 
-    vi.spyOn(context.room.reactions.channel, 'publish').mockImplementation((message: Ably.Message) => {
+    vi.spyOn(channel, 'publish').mockImplementation((message: Ably.Message) => {
       context.emulateBackendPublish({
         ...message,
         clientId: clientId,

--- a/test/core/room-status.test.ts
+++ b/test/core/room-status.test.ts
@@ -7,9 +7,9 @@ import { makeTestLogger } from '../helper/logger.ts';
 const baseError = new Ably.ErrorInfo('error', 500, 50000);
 
 describe('room status', () => {
-  it('defaults to initialized', () => {
+  it('defaults to initializing', () => {
     const status = new DefaultStatus(makeTestLogger());
-    expect(status.current).toEqual(RoomLifecycle.Initialized);
+    expect(status.current).toEqual(RoomLifecycle.Initializing);
     expect(status.error).toBeUndefined();
   });
 

--- a/test/core/room.integration.test.ts
+++ b/test/core/room.integration.test.ts
@@ -24,11 +24,11 @@ describe('Room', () => {
     expect(room.status.current).toEqual(RoomLifecycle.Attached);
 
     // If we check the underlying channels, they should be attached too
-    expect((await room.messages.channelPromise).state).toEqual('attached');
-    expect((await room.reactions.channelPromise).state).toEqual('attached');
-    expect((await room.typing.channelPromise).state).toEqual('attached');
-    expect((await room.presence.channelPromise).state).toEqual('attached');
-    expect((await room.occupancy.channelPromise).state).toEqual('attached');
+    expect((await room.messages.channel).state).toEqual('attached');
+    expect((await room.reactions.channel).state).toEqual('attached');
+    expect((await room.typing.channel).state).toEqual('attached');
+    expect((await room.presence.channel).state).toEqual('attached');
+    expect((await room.occupancy.channel).state).toEqual('attached');
   });
 
   it<TestContext>('should be detachable', async ({ room }) => {
@@ -39,11 +39,11 @@ describe('Room', () => {
     expect(room.status.current).toEqual(RoomLifecycle.Detached);
 
     // If we check the underlying channels, they should be detached too
-    expect((await room.messages.channelPromise).state).toEqual('detached');
-    expect((await room.reactions.channelPromise).state).toEqual('detached');
-    expect((await room.typing.channelPromise).state).toEqual('detached');
-    expect((await room.presence.channelPromise).state).toEqual('detached');
-    expect((await room.occupancy.channelPromise).state).toEqual('detached');
+    expect((await room.messages.channel).state).toEqual('detached');
+    expect((await room.reactions.channel).state).toEqual('detached');
+    expect((await room.typing.channel).state).toEqual('detached');
+    expect((await room.presence.channel).state).toEqual('detached');
+    expect((await room.occupancy.channel).state).toEqual('detached');
   });
 
   it<TestContext>('should be releasable', async ({ room }) => {

--- a/test/core/room.integration.test.ts
+++ b/test/core/room.integration.test.ts
@@ -24,11 +24,11 @@ describe('Room', () => {
     expect(room.status.current).toEqual(RoomLifecycle.Attached);
 
     // If we check the underlying channels, they should be attached too
-    expect(room.messages.channel.state).toEqual('attached');
-    expect(room.reactions.channel.state).toEqual('attached');
-    expect(room.typing.channel.state).toEqual('attached');
-    expect(room.presence.channel.state).toEqual('attached');
-    expect(room.occupancy.channel.state).toEqual('attached');
+    expect((await room.messages.channelPromise).state).toEqual('attached');
+    expect((await room.reactions.channelPromise).state).toEqual('attached');
+    expect((await room.typing.channelPromise).state).toEqual('attached');
+    expect((await room.presence.channelPromise).state).toEqual('attached');
+    expect((await room.occupancy.channelPromise).state).toEqual('attached');
   });
 
   it<TestContext>('should be detachable', async ({ room }) => {
@@ -39,11 +39,11 @@ describe('Room', () => {
     expect(room.status.current).toEqual(RoomLifecycle.Detached);
 
     // If we check the underlying channels, they should be detached too
-    expect(room.messages.channel.state).toEqual('detached');
-    expect(room.reactions.channel.state).toEqual('detached');
-    expect(room.typing.channel.state).toEqual('detached');
-    expect(room.presence.channel.state).toEqual('detached');
-    expect(room.occupancy.channel.state).toEqual('detached');
+    expect((await room.messages.channelPromise).state).toEqual('detached');
+    expect((await room.reactions.channelPromise).state).toEqual('detached');
+    expect((await room.typing.channelPromise).state).toEqual('detached');
+    expect((await room.presence.channelPromise).state).toEqual('detached');
+    expect((await room.occupancy.channelPromise).state).toEqual('detached');
   });
 
   it<TestContext>('should be releasable', async ({ room }) => {

--- a/test/core/room.integration.test.ts
+++ b/test/core/room.integration.test.ts
@@ -24,11 +24,20 @@ describe('Room', () => {
     expect(room.status.current).toEqual(RoomLifecycle.Attached);
 
     // If we check the underlying channels, they should be attached too
-    expect((await room.messages.channel).state).toEqual('attached');
-    expect((await room.reactions.channel).state).toEqual('attached');
-    expect((await room.typing.channel).state).toEqual('attached');
-    expect((await room.presence.channel).state).toEqual('attached');
-    expect((await room.occupancy.channel).state).toEqual('attached');
+    const messagesChannel = await room.messages.channel;
+    expect(messagesChannel.state).toEqual('attached');
+
+    const reactionsChannel = await room.reactions.channel;
+    expect(reactionsChannel.state).toEqual('attached');
+
+    const typingChannel = await room.typing.channel;
+    expect(typingChannel.state).toEqual('attached');
+
+    const presenceChannel = await room.presence.channel;
+    expect(presenceChannel.state).toEqual('attached');
+
+    const occupancyChannel = await room.occupancy.channel;
+    expect(occupancyChannel.state).toEqual('attached');
   });
 
   it<TestContext>('should be detachable', async ({ room }) => {
@@ -39,11 +48,20 @@ describe('Room', () => {
     expect(room.status.current).toEqual(RoomLifecycle.Detached);
 
     // If we check the underlying channels, they should be detached too
-    expect((await room.messages.channel).state).toEqual('detached');
-    expect((await room.reactions.channel).state).toEqual('detached');
-    expect((await room.typing.channel).state).toEqual('detached');
-    expect((await room.presence.channel).state).toEqual('detached');
-    expect((await room.occupancy.channel).state).toEqual('detached');
+    const messagesChannel = await room.messages.channel;
+    expect(messagesChannel.state).toEqual('detached');
+
+    const reactionsChannel = await room.reactions.channel;
+    expect(reactionsChannel.state).toEqual('detached');
+
+    const typingChannel = await room.typing.channel;
+    expect(typingChannel.state).toEqual('detached');
+
+    const presenceChannel = await room.presence.channel;
+    expect(presenceChannel.state).toEqual('detached');
+
+    const occupancyChannel = await room.occupancy.channel;
+    expect(occupancyChannel.state).toEqual('detached');
   });
 
   it<TestContext>('should be releasable', async ({ room }) => {

--- a/test/core/room.test.ts
+++ b/test/core/room.test.ts
@@ -3,13 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatApi } from '../../src/core/chat-api.ts';
 import { DefaultRoom, Room } from '../../src/core/room.ts';
+import { RoomLifecycleManager } from '../../src/core/room-lifecycle-manager.ts';
 import { RoomOptions, RoomOptionsDefaults } from '../../src/core/room-options.ts';
 import { DefaultTyping } from '../../src/core/typing.ts';
 import { randomRoomId } from '../helper/identifier.ts';
 import { makeTestLogger } from '../helper/logger.ts';
 import { ablyRealtimeClient } from '../helper/realtime-client.ts';
 import { defaultRoomOptions } from '../helper/room.ts';
-import { RoomLifecycleManager } from '../../src/core/room-lifecycle-manager.ts';
 
 vi.mock('ably');
 
@@ -95,11 +95,11 @@ describe('Room', () => {
 
       // Every underlying feature channel should have been released
       expect(context.realtime.channels.release).toHaveBeenCalledTimes(5);
-      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.messages.channelPromise).name);
-      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.presence.channelPromise).name);
-      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.typing.channelPromise).name);
-      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.reactions.channelPromise).name);
-      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.occupancy.channelPromise).name);
+      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.messages.channel).name);
+      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.presence.channel).name);
+      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.typing.channel).name);
+      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.reactions.channel).name);
+      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.occupancy.channel).name);
     });
 
     it<TestContext>('should only release with enabled features', async (context) => {
@@ -121,8 +121,8 @@ describe('Room', () => {
 
       // Every underlying feature channel should have been released
       expect(context.realtime.channels.release).toHaveBeenCalledTimes(2);
-      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.messages.channelPromise).name);
-      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.typing.channelPromise).name);
+      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.messages.channel).name);
+      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.typing.channel).name);
     });
 
     it<TestContext>('releasing multiple times is idempotent', async (context) => {

--- a/test/core/room.test.ts
+++ b/test/core/room.test.ts
@@ -251,7 +251,7 @@ describe('Room', () => {
       // allow a tick to happen
       await new Promise((res) => setTimeout(res, 0));
 
-      // must sill be Initializing since messages channel is not yet initialized
+      // must still be initializing since messages channel is not yet initialized
       expect(room.status.current).toBe(RoomLifecycle.Initializing);
 
       // this is the actual channel
@@ -330,7 +330,7 @@ describe('Room', () => {
     // allow a tick to happen
     await new Promise((res) => setTimeout(res, 0));
 
-    // must sill be initializing since messages channel is not yet initialized
+    // must still be initializing since messages channel is not yet initialized
     expect(room.status.current).toBe(RoomLifecycle.Initializing);
     const releasePromise = (room as DefaultRoom).release();
 

--- a/test/core/room.test.ts
+++ b/test/core/room.test.ts
@@ -95,11 +95,21 @@ describe('Room', () => {
 
       // Every underlying feature channel should have been released
       expect(context.realtime.channels.release).toHaveBeenCalledTimes(5);
-      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.messages.channel).name);
-      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.presence.channel).name);
-      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.typing.channel).name);
-      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.reactions.channel).name);
-      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.occupancy.channel).name);
+
+      const messagesChannel = await room.messages.channel;
+      expect(context.realtime.channels.release).toHaveBeenCalledWith(messagesChannel.name);
+
+      const presenceChannel = await room.presence.channel;
+      expect(context.realtime.channels.release).toHaveBeenCalledWith(presenceChannel.name);
+
+      const typingChannel = await room.typing.channel;
+      expect(context.realtime.channels.release).toHaveBeenCalledWith(typingChannel.name);
+
+      const reactionsChannel = await room.reactions.channel;
+      expect(context.realtime.channels.release).toHaveBeenCalledWith(reactionsChannel.name);
+
+      const occupancyChannel = await room.occupancy.channel;
+      expect(context.realtime.channels.release).toHaveBeenCalledWith(occupancyChannel.name);
     });
 
     it<TestContext>('should only release with enabled features', async (context) => {
@@ -121,8 +131,12 @@ describe('Room', () => {
 
       // Every underlying feature channel should have been released
       expect(context.realtime.channels.release).toHaveBeenCalledTimes(2);
-      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.messages.channel).name);
-      expect(context.realtime.channels.release).toHaveBeenCalledWith((await room.typing.channel).name);
+
+      const messagesChannel = await room.messages.channel;
+      expect(context.realtime.channels.release).toHaveBeenCalledWith(messagesChannel.name);
+
+      const typingChannel = await room.typing.channel;
+      expect(context.realtime.channels.release).toHaveBeenCalledWith(typingChannel.name);
     });
 
     it<TestContext>('releasing multiple times is idempotent', async (context) => {

--- a/test/core/room.test.ts
+++ b/test/core/room.test.ts
@@ -334,7 +334,7 @@ describe('Room', () => {
     expect(room.status.current).toBe(RoomLifecycle.Initializing);
     const releasePromise = (room as DefaultRoom).release();
 
-    // expect the release promise to be different than initAfter now, because
+    // expect the release promise to be different to initAfter now, because
     // the room has already started initialization of features.
     expect(releasePromise !== initAfter).toBe(true);
 

--- a/test/core/rooms.integration.test.ts
+++ b/test/core/rooms.integration.test.ts
@@ -40,7 +40,7 @@ describe('Rooms', () => {
     // Make sure our room is attached
     await room.attach();
 
-    const channelFailable = room.messages.channel as Ably.RealtimeChannel & {
+    const channelFailable = (await room.messages.channelPromise) as Ably.RealtimeChannel & {
       notifyState(state: 'failed'): void;
     };
     channelFailable.notifyState('failed');

--- a/test/core/rooms.integration.test.ts
+++ b/test/core/rooms.integration.test.ts
@@ -40,7 +40,7 @@ describe('Rooms', () => {
     // Make sure our room is attached
     await room.attach();
 
-    const channelFailable = (await room.messages.channelPromise) as Ably.RealtimeChannel & {
+    const channelFailable = (await room.messages.channel) as Ably.RealtimeChannel & {
       notifyState(state: 'failed'): void;
     };
     channelFailable.notifyState('failed');

--- a/test/core/rooms.test.ts
+++ b/test/core/rooms.test.ts
@@ -1,0 +1,43 @@
+import * as Ably from 'ably';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatApi } from '../../src/core/chat-api.ts';
+import { DefaultRoom, Room } from '../../src/core/room.ts';
+import { RoomLifecycleManager } from '../../src/core/room-lifecycle-manager.ts';
+import { RoomOptions, RoomOptionsDefaults } from '../../src/core/room-options.ts';
+import { DefaultTyping } from '../../src/core/typing.ts';
+import { randomRoomId } from '../helper/identifier.ts';
+import { makeTestLogger } from '../helper/logger.ts';
+import { ablyRealtimeClient } from '../helper/realtime-client.ts';
+import { defaultRoomOptions } from '../helper/room.ts';
+import { RoomLifecycle } from '@ably/chat';
+import { DefaultRooms, Rooms } from '../../src/core/rooms.ts';
+import { normalizeClientOptions } from '../../src/core/config.ts';
+
+vi.mock('ably');
+
+interface TestContext {
+  realtime: Ably.Realtime;
+  rooms: Rooms,
+}
+
+describe('Room', () => {
+  beforeEach<TestContext>((context) => {
+    context.realtime = ablyRealtimeClient();
+    const logger = makeTestLogger();
+    const chatApi = new ChatApi(context.realtime, logger);
+    context.rooms = new DefaultRooms(context.realtime, normalizeClientOptions({}), logger);
+  });
+
+  describe('room get-release lifecycle', () => {
+    // todo
+
+    it<TestContext>('should return a the same room if rooms.get called twice', async (context) => {
+    });
+    it<TestContext>('should return a fresh room in room.get if previous one is currently releasing', async (context) => {
+    });
+    it<TestContext>('should correctly forward releasing promises to new room instances', async (context) => {
+    });
+  });
+
+});

--- a/test/core/rooms.test.ts
+++ b/test/core/rooms.test.ts
@@ -1,43 +1,80 @@
 import * as Ably from 'ably';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ChatApi } from '../../src/core/chat-api.ts';
-import { DefaultRoom, Room } from '../../src/core/room.ts';
-import { RoomLifecycleManager } from '../../src/core/room-lifecycle-manager.ts';
-import { RoomOptions, RoomOptionsDefaults } from '../../src/core/room-options.ts';
-import { DefaultTyping } from '../../src/core/typing.ts';
+import { normalizeClientOptions } from '../../src/core/config.ts';
+import { DefaultRoom } from '../../src/core/room.ts';
+import { RoomOptions } from '../../src/core/room-options.ts';
+import { DefaultRooms, Rooms } from '../../src/core/rooms.ts';
 import { randomRoomId } from '../helper/identifier.ts';
 import { makeTestLogger } from '../helper/logger.ts';
 import { ablyRealtimeClient } from '../helper/realtime-client.ts';
 import { defaultRoomOptions } from '../helper/room.ts';
-import { RoomLifecycle } from '@ably/chat';
-import { DefaultRooms, Rooms } from '../../src/core/rooms.ts';
-import { normalizeClientOptions } from '../../src/core/config.ts';
 
 vi.mock('ably');
 
 interface TestContext {
   realtime: Ably.Realtime;
-  rooms: Rooms,
+  rooms: Rooms;
 }
 
 describe('Room', () => {
   beforeEach<TestContext>((context) => {
     context.realtime = ablyRealtimeClient();
     const logger = makeTestLogger();
-    const chatApi = new ChatApi(context.realtime, logger);
     context.rooms = new DefaultRooms(context.realtime, normalizeClientOptions({}), logger);
   });
 
   describe('room get-release lifecycle', () => {
-    // todo
+    it<TestContext>('should return a the same room if rooms.get called twice', (context) => {
+      const roomId = randomRoomId();
+      const roomOptions: RoomOptions = defaultRoomOptions;
+      const room1 = context.rooms.get(roomId, roomOptions);
+      const room2 = context.rooms.get(roomId, roomOptions);
+      expect(room1 === room2).toBeTruthy();
+    });
 
-    it<TestContext>('should return a the same room if rooms.get called twice', async (context) => {
+    it<TestContext>('should return a fresh room in room.get if previous one is currently releasing', (context) => {
+      const roomId = randomRoomId();
+      const roomOptions: RoomOptions = defaultRoomOptions;
+      const room1 = context.rooms.get(roomId, roomOptions);
+      void context.rooms.release(roomId);
+      const room2 = context.rooms.get(roomId, roomOptions);
+      expect(room1 === room2).not.toBeTruthy();
     });
-    it<TestContext>('should return a fresh room in room.get if previous one is currently releasing', async (context) => {
-    });
+
     it<TestContext>('should correctly forward releasing promises to new room instances', async (context) => {
+      const roomId = randomRoomId();
+      const roomOptions: RoomOptions = defaultRoomOptions;
+      const room1 = context.rooms.get(roomId, roomOptions);
+
+      let resolveReleasePromise: () => void = () => void 0;
+      const releasePromise = new Promise<void>((resolve) => {
+        resolveReleasePromise = resolve;
+      });
+
+      vi.spyOn(room1 as DefaultRoom, 'release').mockImplementationOnce(() => {
+        return releasePromise;
+      });
+
+      const room2 = context.rooms.get(roomId, roomOptions);
+
+      // this should forward the previous room's release() promise
+      const secondReleasePromise = (room2 as DefaultRoom).release();
+
+      // test that when we resolve the first promise the second one gets resolved
+      let secondReleasePromiseResolved = false;
+      void secondReleasePromise.then(() => {
+        secondReleasePromiseResolved = true;
+      });
+
+      // make sure second one doesn't just get resolved by itself
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      expect(secondReleasePromiseResolved).toBeFalsy();
+
+      // resolve first, wait for second
+      resolveReleasePromise();
+      await secondReleasePromise;
+      expect(secondReleasePromiseResolved).toBeTruthy();
     });
   });
-
 });

--- a/test/core/typing.integration.test.ts
+++ b/test/core/typing.integration.test.ts
@@ -184,7 +184,7 @@ describe('Typing', () => {
       discontinuityErrors.push(error);
     });
 
-    const channelSuspendable = room.typing.channel as Ably.RealtimeChannel & {
+    const channelSuspendable = (await room.typing.channelPromise) as Ably.RealtimeChannel & {
       notifyState(state: 'suspended' | 'attached'): void;
     };
 

--- a/test/core/typing.integration.test.ts
+++ b/test/core/typing.integration.test.ts
@@ -184,7 +184,7 @@ describe('Typing', () => {
       discontinuityErrors.push(error);
     });
 
-    const channelSuspendable = (await room.typing.channelPromise) as Ably.RealtimeChannel & {
+    const channelSuspendable = (await room.typing.channel) as Ably.RealtimeChannel & {
       notifyState(state: 'suspended' | 'attached'): void;
     };
 

--- a/test/core/typing.test.ts
+++ b/test/core/typing.test.ts
@@ -62,7 +62,7 @@ describe('Typing', () => {
     context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
     context.chatApi = new ChatApi(context.realtime, makeTestLogger());
     context.room = makeRandomRoom(context);
-    const channel = await context.room.typing.channelPromise;
+    const channel = await context.room.typing.channel;
     context.emulateBackendPublish = channelPresenceEventEmitter(channel);
   });
 
@@ -90,7 +90,7 @@ describe('Typing', () => {
 
   it<TestContext>('when stop is called, immediately stops typing', async (context) => {
     const { realtime, room } = context;
-    const presence = realtime.channels.get((await room.typing.channelPromise).name).presence;
+    const presence = realtime.channels.get((await room.typing.channel).name).presence;
 
     // If stop is called, it should call leaveClient
     vi.spyOn(presence, 'leaveClient').mockImplementation(async (): Promise<void> => {});
@@ -121,7 +121,7 @@ describe('Typing', () => {
       allEvents.push(event);
     });
 
-    const channel = await context.room.typing.channelPromise;
+    const channel = await context.room.typing.channel;
 
     let arrayToReturn = presenceGetResponse(['otherClient']);
 
@@ -186,7 +186,7 @@ describe('Typing', () => {
       receivedEvents2.push(event);
     });
 
-    const channel = await context.room.typing.channelPromise;
+    const channel = await context.room.typing.channel;
     let arrayToReturn = presenceGetResponse(['otherClient']);
     vi.spyOn(channel.presence, 'get').mockImplementation(() => {
       return Promise.resolve<Ably.PresenceMessage[]>(arrayToReturn);
@@ -289,7 +289,7 @@ describe('Typing', () => {
 
   it<TestContext>('should not emit the same typing set twice', async (context) => {
     const { room } = context;
-    const channel = await context.room.typing.channelPromise;
+    const channel = await context.room.typing.channel;
 
     // Add a listener
     const events: TypingEvent[] = [];
@@ -310,20 +310,20 @@ describe('Typing', () => {
       });
       calledTimes++;
     };
-    
+
     returnSet.add('client1');
     simulateEnter('client1');
     await waitForMessages(events, 1); // must be one event here
-    
+
     // these aren't faked in the presence.get() so should not trigger an event but only a call to presence.get
     simulateEnter('client2');
     simulateEnter('client3');
-    
+
     // add client4 and previously triggered client2 and client3
     returnSet.add('client2');
     returnSet.add('client3');
     returnSet.add('client4');
-    
+
     simulateEnter('client4');
     await waitForMessages(events, 2); // expecting only two events
     expect(channel.presence.get).toBeCalledTimes(calledTimes);
@@ -339,7 +339,7 @@ describe('Typing', () => {
 
   it<TestContext>('should retry on failure', async (context) => {
     const { room } = context;
-    const channel = await context.room.typing.channelPromise;
+    const channel = await context.room.typing.channel;
 
     // Add a listener
     const events: TypingEvent[] = [];
@@ -370,7 +370,7 @@ describe('Typing', () => {
 
   it<TestContext>('should not return stale responses even if they resolve out of order', async (context) => {
     const { room } = context;
-    const channel = await context.room.typing.channelPromise;
+    const channel = await context.room.typing.channel;
 
     // Add a listener
     const events: TypingEvent[] = [];

--- a/test/core/typing.test.ts
+++ b/test/core/typing.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 
 import { ChatClient } from '../../src/core/chat.ts';
 import { ChatApi } from '../../src/core/chat-api.ts';
-import { Room } from '../../src/core/room.ts';
+import { DefaultRoom, Room } from '../../src/core/room.ts';
 import { DefaultTyping, TypingEvent } from '../../src/core/typing.ts';
 import { ChannelEventEmitterReturnType, channelPresenceEventEmitter } from '../helper/channel.ts';
 import { makeTestLogger } from '../helper/logger.ts';
@@ -58,11 +58,12 @@ const waitForMessages = (messages: TypingEvent[], expectedCount: number, timeout
 };
 
 describe('Typing', () => {
-  beforeEach<TestContext>((context) => {
+  beforeEach<TestContext>(async (context) => {
     context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
     context.chatApi = new ChatApi(context.realtime, makeTestLogger());
     context.room = makeRandomRoom(context);
-    context.emulateBackendPublish = channelPresenceEventEmitter(context.room.typing.channel);
+    const channel = await context.room.typing.channelPromise;
+    context.emulateBackendPublish = channelPresenceEventEmitter(channel);
   });
 
   it<TestContext>('delays stop timeout while still typing', async (context) => {
@@ -89,7 +90,7 @@ describe('Typing', () => {
 
   it<TestContext>('when stop is called, immediately stops typing', async (context) => {
     const { realtime, room } = context;
-    const presence = realtime.channels.get(room.typing.channel.name).presence;
+    const presence = realtime.channels.get((await room.typing.channelPromise).name).presence;
 
     // If stop is called, it should call leaveClient
     vi.spyOn(presence, 'leaveClient').mockImplementation(async (): Promise<void> => {});
@@ -120,7 +121,7 @@ describe('Typing', () => {
       allEvents.push(event);
     });
 
-    const channel = context.room.typing.channel;
+    const channel = await context.room.typing.channelPromise;
 
     let arrayToReturn = presenceGetResponse(['otherClient']);
 
@@ -134,9 +135,8 @@ describe('Typing', () => {
       action: 'enter',
     });
 
-    expect(channel.presence.get).toBeCalledTimes(1);
-
     await waitForMessages(receivedEvents, 1);
+    expect(channel.presence.get).toBeCalledTimes(1);
 
     // Ensure that the listener received the event
     expect(receivedEvents).toHaveLength(1);
@@ -157,8 +157,8 @@ describe('Typing', () => {
     });
 
     // wait for check events to be length 2 to make sure second event was triggered
-    expect(channel.presence.get).toBeCalledTimes(2);
     await waitForMessages(allEvents, 2);
+    expect(channel.presence.get).toBeCalledTimes(2);
     expect(allEvents.length).toEqual(2);
     expect(allEvents[1]?.currentlyTyping).toEqual(new Set(['otherClient', 'anotherClient']));
 
@@ -186,7 +186,7 @@ describe('Typing', () => {
       receivedEvents2.push(event);
     });
 
-    const channel = context.room.typing.channel;
+    const channel = await context.room.typing.channelPromise;
     let arrayToReturn = presenceGetResponse(['otherClient']);
     vi.spyOn(channel.presence, 'get').mockImplementation(() => {
       return Promise.resolve<Ably.PresenceMessage[]>(arrayToReturn);
@@ -198,8 +198,8 @@ describe('Typing', () => {
       action: 'enter',
     });
 
-    expect(channel.presence.get).toBeCalledTimes(1);
     await waitForMessages(receivedEvents, 1);
+    expect(channel.presence.get).toBeCalledTimes(1);
 
     // Ensure that the listener received the event
     expect(receivedEvents).toHaveLength(1);
@@ -229,8 +229,8 @@ describe('Typing', () => {
       clientId: 'anotherClient2',
       action: 'enter',
     });
-    expect(channel.presence.get).toBeCalledTimes(2);
     await waitForMessages(checkEvents, 1);
+    expect(channel.presence.get).toBeCalledTimes(2);
     expect(checkEvents[0]?.currentlyTyping).toEqual(new Set(['otherClient', 'anotherClient2']));
 
     // Ensure that the listeners did not receive the event
@@ -289,7 +289,7 @@ describe('Typing', () => {
 
   it<TestContext>('should not emit the same typing set twice', async (context) => {
     const { room } = context;
-    const channel = context.room.typing.channel;
+    const channel = await context.room.typing.channelPromise;
 
     // Add a listener
     const events: TypingEvent[] = [];
@@ -309,24 +309,24 @@ describe('Typing', () => {
         action: 'enter',
       });
       calledTimes++;
-      expect(channel.presence.get).toBeCalledTimes(calledTimes);
     };
-
+    
     returnSet.add('client1');
     simulateEnter('client1');
     await waitForMessages(events, 1); // must be one event here
-
+    
     // these aren't faked in the presence.get() so should not trigger an event but only a call to presence.get
     simulateEnter('client2');
     simulateEnter('client3');
-
+    
     // add client4 and previously triggered client2 and client3
     returnSet.add('client2');
     returnSet.add('client3');
     returnSet.add('client4');
-
+    
     simulateEnter('client4');
     await waitForMessages(events, 2); // expecting only two events
+    expect(channel.presence.get).toBeCalledTimes(calledTimes);
     expect(events).toHaveLength(2);
     expect(events[0]?.currentlyTyping).toEqual(new Set(['client1'])); // first event unchanged
     expect(events[1]?.currentlyTyping).toEqual(new Set(['client1', 'client2', 'client3', 'client4'])); // second event has all clients
@@ -339,7 +339,7 @@ describe('Typing', () => {
 
   it<TestContext>('should retry on failure', async (context) => {
     const { room } = context;
-    const channel = context.room.typing.channel;
+    const channel = await context.room.typing.channelPromise;
 
     // Add a listener
     const events: TypingEvent[] = [];
@@ -362,7 +362,6 @@ describe('Typing', () => {
       action: 'enter',
     });
 
-    expect(channel.presence.get).toBeCalledTimes(1); // first call for the failure
     await waitForMessages(events, 1, 4000); // must be one event here but extra wait time for the retry
     expect(channel.presence.get).toBeCalledTimes(2); // second call for the retry
     expect(events).toHaveLength(1);
@@ -371,7 +370,7 @@ describe('Typing', () => {
 
   it<TestContext>('should not return stale responses even if they resolve out of order', async (context) => {
     const { room } = context;
-    const channel = context.room.typing.channel;
+    const channel = await context.room.typing.channelPromise;
 
     // Add a listener
     const events: TypingEvent[] = [];
@@ -407,16 +406,14 @@ describe('Typing', () => {
       clientId: 'client1',
       action: 'enter',
     });
-    expect(channel.presence.get).toBeCalledTimes(1);
 
     context.emulateBackendPublish({
       clientId: 'client2',
       action: 'enter',
     });
-    expect(channel.presence.get).toBeCalledTimes(2);
 
     await waitForThis; // at this point we should have exactly one message
-
+    expect(channel.presence.get).toBeCalledTimes(2);
     expect(events).toHaveLength(1);
     expect(events[0]?.currentlyTyping).toEqual(new Set(['client1', 'client2']));
   });

--- a/test/core/typing.test.ts
+++ b/test/core/typing.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 
 import { ChatClient } from '../../src/core/chat.ts';
 import { ChatApi } from '../../src/core/chat-api.ts';
-import { DefaultRoom, Room } from '../../src/core/room.ts';
+import { Room } from '../../src/core/room.ts';
 import { DefaultTyping, TypingEvent } from '../../src/core/typing.ts';
 import { ChannelEventEmitterReturnType, channelPresenceEventEmitter } from '../helper/channel.ts';
 import { makeTestLogger } from '../helper/logger.ts';
@@ -90,7 +90,8 @@ describe('Typing', () => {
 
   it<TestContext>('when stop is called, immediately stops typing', async (context) => {
     const { realtime, room } = context;
-    const presence = realtime.channels.get((await room.typing.channel).name).presence;
+    const channel = await room.typing.channel;
+    const presence = realtime.channels.get(channel.name).presence;
 
     // If stop is called, it should call leaveClient
     vi.spyOn(presence, 'leaveClient').mockImplementation(async (): Promise<void> => {});

--- a/test/helper/room.ts
+++ b/test/helper/room.ts
@@ -34,5 +34,12 @@ export const makeRandomRoom = (params: {
   const realtime = params.realtime ?? ablyRealtimeClient();
   const chatApi = params.chatApi ?? new ChatApi(realtime, logger);
 
-  return new DefaultRoom(randomRoomId(), params.options ?? defaultRoomOptions, realtime, chatApi, logger, Promise.resolve());
+  return new DefaultRoom(
+    randomRoomId(),
+    params.options ?? defaultRoomOptions,
+    realtime,
+    chatApi,
+    logger,
+    Promise.resolve(),
+  );
 };

--- a/test/helper/room.ts
+++ b/test/helper/room.ts
@@ -34,5 +34,5 @@ export const makeRandomRoom = (params: {
   const realtime = params.realtime ?? ablyRealtimeClient();
   const chatApi = params.chatApi ?? new ChatApi(realtime, logger);
 
-  return new DefaultRoom(randomRoomId(), params.options ?? defaultRoomOptions, realtime, chatApi, logger);
+  return new DefaultRoom(randomRoomId(), params.options ?? defaultRoomOptions, realtime, chatApi, logger, Promise.resolve());
 };


### PR DESCRIPTION
### Context

The problem is also described at [CHADR-049] and (loosely) tracked at [CHA-382](https://ably.atlassian.net/browse/CHA-382).

### Description

Our current public API allows users to get a room that is currently being released, which is undesirable:

```typescript
// options emitted for brevity
const r1 = rooms.get("abc");
rooms.release("abc").then(() => { console.log("released abc"); });
const r2 = rooms.get("abc"); // this is the room being released, unusable right now but we want it to work
// -> released abc
const r3 = rooms.get("abc") // this is now usable
```

The changes in this PR make `r2` above to be a usable room, which will have status `initializing` until the previous room (from `r1`) finishes releasing. No realtime channels are created in `initializing` state. Realtime channels are created when the previous room finishes releasing, and after channel creating completes (for all configured features) the room becomes `initialized` (which was the previous default status).

#### Summary of changes

1. Introduce new RoomLifecycle status `initializing` which is now the default status when a new room is created.
2. Make all room features receive a promise that they must await before creating any realtime channels.
3. Each feature's `channel` getter is now for a promise of a realtime channel. The room only changes status to `Initialized` and starts the usual lifecycle when all channel promises are resolved.
4. `RoomLifecycle` enum is now exported as value, not as type.
5. If a room is released before it started to initialize, then it will never initialize. Methods like `room.attach()` return a rejected promise explaining the room was released before initialization.


### Checklist

* [ ] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [ ] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] (Optional) Update documentation for new features.
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

- Run the tests
- Read the code around room.ts and channel initialisation in features carefully
- Read added comments in tests where I had to use tricks like waiting a small amount of time


[CHA-382]: https://ably.atlassian.net/browse/CHA-382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ