### PR TITLE
api: pass correct api protocol version to realtime.request

### DIFF
--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -41,6 +41,7 @@ interface SendMessageParams {
 export class ChatApi {
   private readonly _realtime: Ably.Realtime;
   private readonly _logger: Logger;
+  private readonly _apiProtocolVersion: number = 3;
 
   constructor(realtime: Ably.Realtime, logger: Logger) {
     this._realtime = realtime;
@@ -98,7 +99,7 @@ export class ChatApi {
     method: 'POST' | 'GET' | ' PUT' | 'DELETE' | 'PATCH',
     body?: REQ,
   ): Promise<RES> {
-    const response = await this._realtime.request<RES>(method, url, 1.1, {}, body);
+    const response = await this._realtime.request<RES>(method, url, this._apiProtocolVersion, {}, body);
     if (!response.success) {
       this._logger.error('ChatApi._makeAuthorizedRequest(); failed to make request', {
         url,
@@ -117,7 +118,7 @@ export class ChatApi {
     params?: unknown,
     body?: REQ,
   ): Promise<PaginatedResult<RES>> {
-    const response = await this._realtime.request('GET', url, 1.1, params, body);
+    const response = await this._realtime.request('GET', url, this._apiProtocolVersion, params, body);
     if (!response.success) {
       this._logger.error('ChatApi._makeAuthorizedPaginatedRequest(); failed to make request', {
         url,


### PR DESCRIPTION
### Description

- Updates ChatApi to pass the correct protocol version to `realtime.request`
- The value should be an integer, the current value in ably-js being 3.
- This won't have any significant effect on what we're calling, as we version our API for chat by endpoint, but it ensures that our request is nonetheless valid.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A
