### PR TITLE
react-hooks: Add usePresence listener hook

### DIFF
--- a/demo/src/components/UserPresenceComponent/UserPresenceComponent.tsx
+++ b/demo/src/components/UserPresenceComponent/UserPresenceComponent.tsx
@@ -1,5 +1,5 @@
 import { FC, useState } from 'react';
-import { useChatClient, useChatConnection, usePresence } from '@ably/chat/react';
+import { useChatClient, useChatConnection, usePresence, usePresenceListener } from '@ably/chat/react';
 import '../../../styles/global.css';
 import './UserPresenceComponent.css';
 import { ConnectionLifecycle, PresenceMember } from '@ably/chat';
@@ -8,18 +8,16 @@ interface UserListComponentProps {}
 
 export const UserPresenceComponent: FC<UserListComponentProps> = () => {
   const [isPanelOpen, setIsPanelOpen] = useState(true);
-  const [presenceMembers, setPresenceMembers] = useState<PresenceMember[]>([]);
+  const { update, isPresent, error } = usePresence({ enterWithData: { status: '💻 Online' } });
+  const { presenceData } = usePresenceListener({
+    listener: (event) => {
+      console.log('Presence data changed', { event });
+    },
+  });
+
   const clientId = useChatClient().clientId;
   const { currentStatus } = useChatConnection();
   const isConnected = currentStatus === ConnectionLifecycle.Connected;
-
-  const { update, presence, isPresent, error } = usePresence({ enterWithData: { status: '💻 Online' } });
-
-  presence.subscribe(() => {
-    presence.get().then((members) => {
-      setPresenceMembers(members);
-    });
-  });
 
   const [isOnline, setIsOnline] = useState(true);
 
@@ -61,7 +59,7 @@ export const UserPresenceComponent: FC<UserListComponentProps> = () => {
             <>
               <div className="user-list">
                 <h2>Present Users</h2>
-                <ul>{presenceMembers.map(renderPresentMember)}</ul>
+                <ul>{presenceData.map(renderPresentMember)}</ul>
               </div>
               <div className="actions">
                 <button

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -264,3 +264,42 @@ const MyComponent = () => {
   );
 };
 ```
+
+## usePresenceListener
+
+This hook accepts a listener callback for receiving presence events and provides a state variable kept up to date
+with the current presence state.
+
+It is intended solely for monitoring the state of `Presence` in a room, should you wish to enter presence and thus
+update the presence state, you should use the `usePresence` hook.
+
+This hook also allows you to access the `Presence` instance of a specific room from the nearest `ChatRoomProvider` in
+the component tree.
+
+```tsx
+import React from 'react';
+import { usePresenceListener } from '@ably/chat/react';
+
+const MyComponent = () => {
+  const { presenceData, error } = usePresenceListener({
+    listener: (event) => {
+      console.log('Presence event: ', event);
+    },
+  });
+
+  return (
+    <div>
+      <p>Presence data:</p>
+      {error === undefined ? (
+        <ul>
+          {presenceData.map((presence) => (
+            <li key={presence.clientId}>{presence.clientId}</li>
+          ))}
+        </ul>
+      ) : (
+        <p>Error loading presence data</p>
+      )}
+    </div>
+  );
+};
+```

--- a/src/react/hooks/use-presence-listener.ts
+++ b/src/react/hooks/use-presence-listener.ts
@@ -1,0 +1,223 @@
+import { Presence, PresenceListener, PresenceMember } from '@ably/chat';
+import * as Ably from 'ably';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { ChatStatusResponse } from '../types/chat-status-response.js';
+import { Listenable } from '../types/listenable.js';
+import { StatusParams } from '../types/status-params.js';
+import { useChatConnection } from './use-chat-connection.js';
+import { useRoom } from './use-room.js';
+
+/**
+ * The interval between retries when fetching presence data.
+ */
+const PRESENCE_GET_RETRY_INTERVAL_MS = 1500;
+
+/**
+ * The maximum interval between retries when fetching presence data.
+ */
+const PRESENCE_GET_RETRY_MAX_INTERVAL_MS = 30000;
+
+/**
+ * The maximum number of retries when fetching presence data with {@link Presence.get}.
+ */
+const PRESENCE_GET_MAX_RETRIES = 5;
+
+/**
+ * The options for the {@link usePresenceListener} hook.
+ */
+export interface UsePresenceListenerParams extends StatusParams, Listenable<PresenceListener> {
+  /**
+   * The listener to be called when the presence state changes.
+   */
+  listener?: PresenceListener;
+}
+
+export interface UsePresenceListenerResponse extends ChatStatusResponse {
+  /**
+   * The current state of the presence set, observed as a whole change, and only emitted while presence is not syncing.
+   */
+  readonly presenceData: PresenceMember[];
+
+  /**
+   * Provides access to the underlying {@link Presence} instance of the room.
+   */
+  readonly presence: Presence;
+
+  /**
+   * The error state of the presence listener.
+   * The hook keeps {@link presenceData} up to date asynchronously, so this error state is provided to allow
+   * the user to handle errors that may occur when fetching presence data.
+   * It will be set if there is an error fetching the initial presence data,
+   * or if there is an error when fetching presence data after a presence event.
+   * The error will be cleared once a new presence event is received and successfully processed.
+   */
+  readonly error?: Ably.ErrorInfo;
+}
+
+/**
+ * A hook that provides access to the {@link Presence} instance in the room and the current presence state.
+ * It will use the instance belonging to the room in the nearest {@link ChatRoomProvider} in the component tree.
+ * On calling, the hook will subscribe to the presence state of the room and update the state accordingly.
+ *
+ * @param params - Allows the registering of optional callbacks.
+ * @returns UsePresenceResponse - An object containing the {@link Presence} instance and the current presence state.
+ */
+export const usePresenceListener = (params?: UsePresenceListenerParams): UsePresenceListenerResponse => {
+  const { currentStatus: connectionStatus, error: connectionError } = useChatConnection({
+    onStatusChange: params?.onConnectionStatusChange,
+  });
+  const { room, roomError, roomStatus } = useRoom({
+    onStatusChange: params?.onRoomStatusChange,
+  });
+
+  const receivedEventNumber = useRef(0);
+  const triggeredEventNumber = useRef(0);
+  const retryTimeout = useRef<ReturnType<typeof setTimeout>>();
+  const numRetries = useRef(0);
+  const latestPresentData = useRef<PresenceMember[]>([]);
+  const [presenceData, setPresenceData] = useState<PresenceMember[]>([]);
+  const errorRef = useRef<Ably.ErrorInfo | undefined>();
+
+  const [error, setError] = useState<Ably.ErrorInfo | undefined>();
+
+  const setErrorState = useCallback((error: Ably.ErrorInfo) => {
+    errorRef.current = error;
+    setError(error);
+  }, []);
+
+  const clearErrorState = useCallback(() => {
+    errorRef.current = undefined;
+    setError(undefined);
+  }, []);
+
+  useEffect(() => {
+    // ensure we only process and return the latest presence data.
+    const updatePresenceData = () => {
+      receivedEventNumber.current += 1;
+
+      // clear the previous retry if we have received a new event
+      if (retryTimeout.current) {
+        clearTimeout(retryTimeout.current);
+        retryTimeout.current = undefined;
+        numRetries.current = 0;
+      }
+
+      // attempt to get the presence data
+      getAndSetState(receivedEventNumber.current);
+    };
+
+    const getAndSetState = (eventNumber: number) => {
+      room.presence
+        .get({ waitForSync: true })
+        .then((presenceMembers) => {
+          // clear the retry now we have resolved
+          if (retryTimeout.current) {
+            clearTimeout(retryTimeout.current);
+            retryTimeout.current = undefined;
+            numRetries.current = 0;
+          }
+
+          // ensure the current event is still the latest
+          if (triggeredEventNumber.current >= eventNumber) {
+            return;
+          }
+
+          triggeredEventNumber.current = eventNumber;
+
+          // update the presence data
+          latestPresentData.current = presenceMembers;
+          setPresenceData(presenceMembers);
+
+          // clear any previous errors as we have now resolved to the latest state
+          if (errorRef.current) {
+            clearErrorState();
+          }
+        })
+        .catch(() => {
+          const willReattempt = numRetries.current < PRESENCE_GET_MAX_RETRIES;
+
+          if (!willReattempt) {
+            // since we have reached the maximum number of retries, set the error state
+            setErrorState(new Ably.ErrorInfo(`failed to fetch presence data after max retries`, 50000, 500));
+            return;
+          }
+
+          // if we are currently waiting for a retry, do nothing as a new event has been received
+          if (retryTimeout.current) {
+            return;
+          }
+
+          const waitBeforeRetry = Math.min(
+            PRESENCE_GET_RETRY_MAX_INTERVAL_MS,
+            PRESENCE_GET_RETRY_INTERVAL_MS * Math.pow(2, numRetries.current),
+          );
+
+          numRetries.current += 1;
+
+          retryTimeout.current = setTimeout(() => {
+            retryTimeout.current = undefined;
+            receivedEventNumber.current += 1;
+            getAndSetState(receivedEventNumber.current);
+          }, waitBeforeRetry);
+        });
+    };
+
+    let unsubscribe: (() => void) | undefined;
+    room.presence
+      .get({ waitForSync: true })
+      .then((presenceMembers) => {
+        // on mount, fetch the initial presence data
+        latestPresentData.current = presenceMembers;
+        setPresenceData(presenceMembers);
+
+        // clear any previous errors
+        clearErrorState();
+      })
+      .catch((error: unknown) => {
+        setErrorState(error as Ably.ErrorInfo);
+      })
+      .finally(() => {
+        // subscribe to presence events
+        const result = room.presence.subscribe(() => {
+          updatePresenceData();
+        });
+        unsubscribe = result.unsubscribe;
+      });
+    return () => {
+      if (unsubscribe) {
+        unsubscribe();
+      }
+    };
+  }, [room, setErrorState, clearErrorState]);
+
+  // subscribe the user provided listener to presence changes
+  useEffect(() => {
+    if (!params?.listener) return;
+    const { unsubscribe } = room.presence.subscribe(params.listener);
+
+    return () => {
+      unsubscribe();
+    };
+  }, [room, params?.listener]);
+
+  // subscribe the user provided onDiscontinuity listener
+  useEffect(() => {
+    if (!params?.onDiscontinuity) return;
+    const { off } = room.presence.onDiscontinuity(params.onDiscontinuity);
+
+    return () => {
+      off();
+    };
+  }, [room, params?.onDiscontinuity]);
+
+  return {
+    connectionStatus,
+    connectionError,
+    roomStatus,
+    roomError,
+    error,
+    presenceData: presenceData,
+    presence: room.presence,
+  };
+};

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -12,6 +12,11 @@ export {
 } from './hooks/use-chat-connection.js';
 export { useOccupancy, type UseOccupancyParams, type UseOccupancyResponse } from './hooks/use-occupancy.js';
 export { usePresence, type UsePresenceParams, type UsePresenceResponse } from './hooks/use-presence.js';
+export {
+  usePresenceListener,
+  type UsePresenceListenerParams,
+  type UsePresenceListenerResponse,
+} from './hooks/use-presence-listener.js';
 export { useRoom, type UseRoomParams, type UseRoomResponse } from './hooks/use-room.js';
 export {
   useRoomReactions,

--- a/test/react/hooks/use-presence-listener.integration.test.tsx
+++ b/test/react/hooks/use-presence-listener.integration.test.tsx
@@ -14,6 +14,7 @@ import { usePresenceListener } from '../../../src/react/hooks/use-presence-liste
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
 import { newChatClient } from '../../helper/chat.ts';
+import { randomRoomId } from '../../helper/identifier.ts';
 
 function waitForPresenceEvents(presenceEvents: PresenceEvent[], expectedCount: number) {
   return new Promise<void>((resolve, reject) => {
@@ -26,7 +27,7 @@ function waitForPresenceEvents(presenceEvents: PresenceEvent[], expectedCount: n
     setTimeout(() => {
       clearInterval(interval);
       reject(new Error('Timed out waiting for presence events'));
-    }, 20000);
+    }, 10000);
   });
 }
 
@@ -37,7 +38,8 @@ describe('usePresenceListener', () => {
     const chatClientTwo = newChatClient() as unknown as ChatClient;
 
     // create a second room and attach it, so we can send presence events with it
-    const roomTwo = chatClientTwo.rooms.get('room-id', RoomOptionsDefaults);
+    const roomId = randomRoomId();
+    const roomTwo = chatClientTwo.rooms.get(roomId, RoomOptionsDefaults);
     await roomTwo.attach();
 
     // store the current presence member state
@@ -62,7 +64,7 @@ describe('usePresenceListener', () => {
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
-          id="room-id"
+          id={roomId}
           options={RoomOptionsDefaults}
         >
           <TestComponent

--- a/test/react/hooks/use-presence-listener.integration.test.tsx
+++ b/test/react/hooks/use-presence-listener.integration.test.tsx
@@ -1,0 +1,104 @@
+import {
+  ChatClient,
+  PresenceEvent,
+  PresenceListener,
+  PresenceMember,
+  RoomLifecycle,
+  RoomOptionsDefaults,
+} from '@ably/chat';
+import { render, waitFor } from '@testing-library/react';
+import React, { useEffect } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { usePresenceListener } from '../../../src/react/hooks/use-presence-listener.ts';
+import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
+import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
+import { newChatClient } from '../../helper/chat.ts';
+
+function waitForPresenceEvents(presenceEvents: PresenceEvent[], expectedCount: number) {
+  return new Promise<void>((resolve, reject) => {
+    const interval = setInterval(() => {
+      if (presenceEvents.length === expectedCount) {
+        clearInterval(interval);
+        resolve();
+      }
+    }, 100);
+    setTimeout(() => {
+      clearInterval(interval);
+      reject(new Error('Timed out waiting for presence events'));
+    }, 20000);
+  });
+}
+
+describe('usePresenceListener', () => {
+  it('should correctly listen to presence events', async () => {
+    // create new clients
+    const chatClientOne = newChatClient() as unknown as ChatClient;
+    const chatClientTwo = newChatClient() as unknown as ChatClient;
+
+    // create a second room and attach it, so we can send presence events with it
+    const roomTwo = chatClientTwo.rooms.get('room-id', RoomOptionsDefaults);
+    await roomTwo.attach();
+
+    // store the current presence member state
+    let currentPresenceData: PresenceMember[] = [];
+
+    let currentRoomStatus: RoomLifecycle;
+    const TestComponent = ({ listener }: { listener: PresenceListener }) => {
+      const { presenceData, roomStatus } = usePresenceListener({ listener });
+
+      useEffect(() => {
+        currentPresenceData = presenceData;
+      }, [presenceData]);
+
+      currentRoomStatus = roomStatus;
+
+      return null;
+    };
+
+    // store the presence events received by the test component
+    const presenceEventsReceived: PresenceEvent[] = [];
+
+    const TestProvider = () => (
+      <ChatClientProvider client={chatClientOne}>
+        <ChatRoomProvider
+          id="room-id"
+          options={RoomOptionsDefaults}
+        >
+          <TestComponent
+            listener={(event: PresenceEvent) => {
+              presenceEventsReceived.push(event);
+            }}
+          />
+        </ChatRoomProvider>
+      </ChatClientProvider>
+    );
+
+    const { unmount } = render(<TestProvider />);
+
+    // ensure we are attached first
+    await waitFor(
+      () => {
+        expect(currentRoomStatus).toBe(RoomLifecycle.Attached);
+      },
+      { timeout: 5000 },
+    );
+
+    // enter presence with room two, then update the presence state
+    await roomTwo.presence.enter('test enter');
+    await roomTwo.presence.update('test update');
+
+    // expect a presence enter and update event from the test component to be received
+    await waitForPresenceEvents(presenceEventsReceived, 2);
+    expect(presenceEventsReceived[0]?.clientId).toBe(chatClientTwo.clientId);
+    expect(presenceEventsReceived[0]?.data).toBe('test enter');
+    expect(presenceEventsReceived[1]?.clientId).toBe(chatClientTwo.clientId);
+    expect(presenceEventsReceived[1]?.data).toBe('test update');
+
+    // expect the current presence state to reflect only the latest presence data
+    expect(currentPresenceData.length).toBe(1);
+    expect(currentPresenceData[0]?.clientId).toBe(chatClientTwo.clientId);
+    expect(currentPresenceData[0]?.data).toBe('test update');
+    unmount();
+  }, 20000);
+});

--- a/test/react/hooks/use-presence-listener.test.tsx
+++ b/test/react/hooks/use-presence-listener.test.tsx
@@ -1,0 +1,438 @@
+import {
+  ConnectionLifecycle,
+  PresenceEvent,
+  PresenceEvents,
+  PresenceListener,
+  PresenceMember,
+  Room,
+  RoomLifecycle,
+} from '@ably/chat';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import * as Ably from 'ably';
+import { ErrorInfo } from 'ably';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { usePresenceListener } from '../../../src/react/hooks/use-presence-listener.ts';
+import { makeRandomRoom } from '../../helper/room.ts';
+
+let mockRoom: Room;
+
+let mockCurrentConnectionStatus: ConnectionLifecycle;
+let mockCurrentRoomStatus: RoomLifecycle;
+let mockConnectionError: Ably.ErrorInfo;
+let mockRoomError: Ably.ErrorInfo;
+
+// apply mocks for the useChatConnection and useRoom hooks
+vi.mock('../../../src/react/hooks/use-chat-connection.js', () => ({
+  useChatConnection: () => ({
+    currentStatus: mockCurrentConnectionStatus,
+    error: mockConnectionError,
+  }),
+}));
+
+vi.mock('../../../src/react/hooks/use-room.js', () => ({
+  useRoom: () => {
+    return {
+      room: mockRoom,
+      roomStatus: mockCurrentRoomStatus,
+      roomError: mockRoomError,
+    };
+  },
+}));
+
+vi.mock('ably');
+
+describe('usePresenceListener', () => {
+  beforeEach(() => {
+    // create a new mock room before each test
+    mockRoom = makeRandomRoom({ options: { presence: { subscribe: true } } });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should provide the room presence instance, presence data and correct chat status response metrics', () => {
+    mockConnectionError = new Ably.ErrorInfo('test', 500, 50000);
+    mockRoomError = new Ably.ErrorInfo('test', 500, 50000);
+    mockCurrentRoomStatus = RoomLifecycle.Attached;
+    mockCurrentConnectionStatus = ConnectionLifecycle.Connected;
+
+    const { result, unmount } = renderHook(() => usePresenceListener());
+
+    // check that the room presence instance is correctly provided
+    expect(result.current.presence).toBe(mockRoom.presence);
+    expect(result.current.presenceData).toEqual([]);
+
+    // check connection and room metrics are correctly provided
+    expect(result.current.roomStatus).toBe(RoomLifecycle.Attached);
+    expect(result.current.roomError).toBe(mockRoomError);
+    expect(result.current.connectionStatus).toEqual(ConnectionLifecycle.Connected);
+    expect(result.current.connectionError).toBe(mockConnectionError);
+    unmount();
+  });
+
+  it('should correctly subscribe and unsubscribe to presence', () => {
+    // mock listener and associated unsubscribe function
+    const mockListener = vi.fn();
+    const mockUnsubscribe = vi.fn();
+
+    vi.spyOn(mockRoom.presence, 'subscribe').mockReturnValue({ unsubscribe: mockUnsubscribe });
+    vi.spyOn(mockRoom.presence, 'get').mockResolvedValue([]);
+
+    const { unmount } = renderHook(() => usePresenceListener({ listener: mockListener }));
+
+    // verify that subscribe was called with the mock listener on mount
+    expect(mockRoom.presence.subscribe).toHaveBeenCalledWith(mockListener);
+
+    // unmount the hook and verify that unsubscribe was called
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalled();
+  });
+
+  it('should handle rerender if the room instance changes', () => {
+    const { result, rerender, unmount } = renderHook(() => usePresenceListener());
+
+    // check the initial state of the presence object
+    expect(result.current.presence).toBe(mockRoom.presence);
+
+    // change the mock room instance
+    mockRoom = makeRandomRoom({ options: { presence: { subscribe: true } } });
+
+    // re-render to trigger the useEffect
+    rerender();
+
+    // check that the room presence instance is updated
+    expect(result.current.presence).toBe(mockRoom.presence);
+    unmount();
+  });
+
+  it('should set the initial present clients on mount', async () => {
+    // spy on the subscribe method of the presence instance
+    vi.spyOn(mockRoom.presence, 'subscribe').mockImplementation(() => {
+      return { unsubscribe: vi.fn() };
+    });
+
+    const testPresenceMembers: PresenceMember[] = [
+      {
+        clientId: 'client1',
+        action: 'enter',
+        data: undefined,
+        extras: undefined,
+        updatedAt: Date.now(),
+      },
+      {
+        clientId: 'client2',
+        action: 'enter',
+        data: undefined,
+        extras: undefined,
+        updatedAt: Date.now(),
+      },
+    ];
+
+    // spy on the get method of the presence instance, return an initial set
+    vi.spyOn(mockRoom.presence, 'get').mockResolvedValue(testPresenceMembers);
+
+    // render the hook and check the initial state
+    const { result, unmount } = renderHook(() => usePresenceListener());
+
+    await waitFor(
+      () => {
+        // check that the presence data is correctly set
+        expect(result.current.presenceData.length).toBe(2);
+      },
+      { timeout: 3000 },
+    );
+
+    expect(mockRoom.presence.subscribe).toHaveBeenCalledOnce();
+    expect(mockRoom.presence.get).toHaveBeenCalledOnce();
+
+    // check that the presence data is correctly set
+    expect(result.current.presenceData).toEqual(testPresenceMembers);
+    unmount();
+  });
+
+  it('should set and return the error state when the call to get the initial presence data fails', async () => {
+    // spy on the get method of the presence instance and throw an error
+    vi.spyOn(mockRoom.presence, 'get').mockRejectedValue(new ErrorInfo('test', 500, 50000));
+    vi.spyOn(mockRoom.presence, 'subscribe');
+
+    // render the hook
+    const { result, unmount } = renderHook(() => usePresenceListener());
+
+    // wait for the hook to finish mounting and set the error state
+    await waitFor(
+      () => {
+        expect(result.current.error).toBeDefined();
+      },
+      { timeout: 3000 },
+    );
+
+    // ensure the get method was called
+    expect(mockRoom.presence.get).toHaveBeenCalledOnce();
+    expect(mockRoom.presence.subscribe).toHaveBeenCalledOnce();
+
+    // ensure we have the correct error state
+    expect(result.current.error).toBeErrorInfo({
+      message: 'test',
+      statusCode: 50000,
+      code: 500,
+    });
+    unmount();
+  });
+
+  it('should reset the current error state if a new presence event is received', async () => {
+    // in the case where we have an error state set, we should clear it if a new presence event is received, since
+    // this means we once again have the most up-to-date presence data
+
+    // spy on the get method of the presence instance and throw an error
+    vi.spyOn(mockRoom.presence, 'get').mockRejectedValue(new ErrorInfo('test', 500, 50000));
+
+    let subscribedListener: PresenceListener | undefined;
+
+    // spy on the subscribe method of the presence instance
+    vi.spyOn(mockRoom.presence, 'subscribe').mockImplementation((listener) => {
+      subscribedListener = listener;
+      return { unsubscribe: vi.fn() };
+    });
+
+    // render the hook
+    const { result, unmount } = renderHook(() => usePresenceListener());
+
+    // wait for the hook to finish mounting and set the error state
+    await waitFor(
+      () => {
+        expect(result.current.error).toBeDefined();
+      },
+      { timeout: 3000 },
+    );
+
+    expect(mockRoom.presence.get).toHaveBeenCalledOnce();
+
+    // change the spy so that the next call to get will resolve successfully
+    vi.spyOn(mockRoom.presence, 'get').mockReturnValue(Promise.resolve([]));
+
+    const testPresenceEvent: PresenceEvent = {
+      clientId: 'client1',
+      action: PresenceEvents.Enter,
+      data: undefined,
+      timestamp: Date.now(),
+    };
+
+    // now emit a presence event which should clear the error state
+    act(() => {
+      if (subscribedListener) {
+        subscribedListener(testPresenceEvent);
+      }
+    });
+
+    // check that the error state is now cleared
+    await waitFor(
+      () => {
+        expect(result.current.error).toBeUndefined();
+      },
+      { timeout: 3000 },
+    );
+    unmount();
+  });
+
+  it('should subscribe and unsubscribe to discontinuity events', () => {
+    const mockOff = vi.fn();
+    const mockDiscontinuityListener = vi.fn();
+
+    // spy on the onDiscontinuity method of the room presence instance
+    vi.spyOn(mockRoom.presence, 'onDiscontinuity').mockReturnValue({ off: mockOff });
+
+    // render the hook with a discontinuity listener
+    const { unmount } = renderHook(() => usePresenceListener({ onDiscontinuity: mockDiscontinuityListener }));
+
+    // check that the listener was subscribed to the discontinuity events
+    expect(mockRoom.presence.onDiscontinuity).toHaveBeenCalledWith(mockDiscontinuityListener);
+
+    // unmount the hook and verify that the listener was unsubscribed
+    unmount();
+
+    expect(mockOff).toHaveBeenCalled();
+  });
+
+  it('should retry updating the presence state on failure', async () => {
+    let subscribedListener: PresenceListener | undefined;
+
+    // spy on the subscribe method of the room presence instance
+    vi.spyOn(mockRoom.presence, 'subscribe').mockImplementation((listener?: PresenceListener) => {
+      subscribedListener = listener;
+      return { unsubscribe: vi.fn() };
+    });
+
+    // during mount, set initial resolve to an empty array as we are not
+    // testing this behavior here
+    vi.spyOn(mockRoom.presence, 'get').mockResolvedValue([]);
+
+    // render the hook, this should trigger a useEffect call to subscribe to the presence events
+    const { result, unmount } = renderHook(() => usePresenceListener());
+
+    // wait for the hook to subscribe the listener
+    await waitFor(() => {
+      return subscribedListener !== undefined;
+    });
+
+    if (!subscribedListener) {
+      expect.fail('subscribedListener is undefined');
+    }
+
+    // change the mock so it now throws an error on the next call,
+    // this should trigger a retry to get the presence data
+    let callNum = 0;
+    vi.spyOn(mockRoom.presence, 'get').mockImplementation(() => {
+      callNum++;
+      if (callNum === 1) {
+        return Promise.reject<PresenceMember[]>(new Ably.ErrorInfo('test', 500, 50000));
+      } else {
+        // return a successful response on the second call with a presence member
+        return Promise.resolve<PresenceMember[]>([
+          {
+            clientId: 'client1',
+            action: 'enter',
+            data: undefined,
+            extras: undefined,
+            updatedAt: Date.now(),
+          },
+        ]);
+      }
+    });
+
+    // trigger the listener; this should trigger the next call to presence.get
+    subscribedListener({
+      action: PresenceEvents.Enter,
+      clientId: 'client1',
+      timestamp: Date.now(),
+      data: undefined,
+    });
+
+    expect(mockRoom.presence.get).toBeCalledTimes(1);
+
+    // wait for the hook to retry the presence.get call
+    await waitFor(
+      () => {
+        expect(result.current.presenceData.length).toBe(1);
+      },
+      { timeout: 3000 },
+    );
+
+    // we should have retried the presence.get call
+    expect(mockRoom.presence.get).toBeCalledTimes(2);
+
+    // our returned data should be the presence member we received
+    expect(result.current.presenceData[0]?.clientId).toEqual('client1');
+    expect(result.current.presenceData[0]?.action).toEqual('enter');
+    unmount();
+  }, 10000);
+
+  it('should not return stale presence data even if they resolve out of order', async () => {
+    let subscribedListener: PresenceListener | undefined;
+
+    // spy on the subscribe method of the room presence instance
+    vi.spyOn(mockRoom.presence, 'subscribe').mockImplementation((listener?: PresenceListener) => {
+      subscribedListener = listener;
+      return { unsubscribe: vi.fn() };
+    });
+
+    // render the hook, this should trigger a useEffect call to subscribe to the presence events
+    const { result, rerender, unmount } = renderHook(() => usePresenceListener());
+
+    // wait for the hook to subscribe the listener
+    await waitFor(() => {
+      return subscribedListener !== undefined;
+    });
+
+    if (!subscribedListener) {
+      expect.fail('subscribedListener is undefined');
+    }
+
+    // this promise will allow us to resolve an event late
+    let stopWaiting: () => void;
+    const waitForThis = new Promise<void>((accept) => {
+      stopWaiting = accept;
+    });
+
+    const testPresenceData1: PresenceMember[] = [
+      {
+        clientId: 'client1',
+        action: 'enter',
+        data: undefined,
+        extras: undefined,
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const testPresenceData2: PresenceMember[] = [
+      {
+        clientId: 'client2',
+        action: 'enter',
+        data: undefined,
+        extras: undefined,
+        updatedAt: Date.now(),
+      },
+    ];
+
+    let callNum = 0;
+    vi.spyOn(mockRoom.presence, 'get').mockImplementation(() => {
+      callNum++;
+      if (callNum === 1) {
+        return new Promise((accept) => {
+          setTimeout(() => {
+            accept(testPresenceData1);
+            // delay resolving the first event, allowing the second event to resolve first
+            setTimeout(stopWaiting, 500);
+          }, 500);
+        });
+      } else {
+        return new Promise((accept) => {
+          setTimeout(() => {
+            accept(testPresenceData2);
+          }, 100);
+        });
+      }
+    });
+
+    // emit the first presence event, this should trigger the first call to presence.get
+    subscribedListener({
+      action: PresenceEvents.Enter,
+      clientId: 'client1',
+      timestamp: Date.now(),
+      data: undefined,
+    });
+
+    // ensure that the first call to presence.get was made
+    expect(mockRoom.presence.get).toBeCalledTimes(1);
+
+    // now emit the second presence event, this should trigger the second call to presence.get
+    subscribedListener({
+      action: PresenceEvents.Enter,
+      clientId: 'client2',
+      timestamp: Date.now(),
+      data: undefined,
+    });
+
+    // ensure that the second call to presence.get was made
+    expect(mockRoom.presence.get).toBeCalledTimes(2);
+
+    // since we already have a newer event, triggering the first event to resolve
+    // should result in the first event being discarded
+    await waitForThis;
+
+    // wait for the hook to update the presence data
+    await waitFor(
+      () => {
+        // force the hook to run again until the presence data is updated
+        rerender();
+        expect(result.current.presenceData.length).toBe(1);
+      },
+      { timeout: 5000 },
+    );
+
+    // our returned data should be the second event we received
+    expect(result.current.presenceData).toHaveLength(1);
+    expect(result.current.presenceData[0]).toStrictEqual(testPresenceData2[0]);
+    unmount();
+  }, 10000);
+});

--- a/test/react/hooks/use-presence.integration.test.tsx
+++ b/test/react/hooks/use-presence.integration.test.tsx
@@ -7,6 +7,7 @@ import { usePresence } from '../../../src/react/hooks/use-presence.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
 import { newChatClient } from '../../helper/chat.ts';
+import { randomRoomId } from '../../helper/identifier.ts';
 
 function waitForPresenceEvents(presenceEvents: PresenceEvent[], expectedCount: number) {
   return new Promise<void>((resolve, reject) => {
@@ -30,7 +31,8 @@ describe('usePresence', () => {
     const chatClientTwo = newChatClient() as unknown as ChatClient;
 
     // create a second room and attach it, so we can listen for presence events
-    const roomTwo = chatClientTwo.rooms.get('room-id', RoomOptionsDefaults);
+    const roomId = randomRoomId();
+    const roomTwo = chatClientTwo.rooms.get(roomId, RoomOptionsDefaults);
     await roomTwo.attach();
 
     // start listening for presence events on room two
@@ -64,7 +66,7 @@ describe('usePresence', () => {
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
-          id="room-id"
+          id={roomId}
           options={RoomOptionsDefaults}
         >
           <TestComponent

--- a/test/react/hooks/use-room-reactions.integration.test.tsx
+++ b/test/react/hooks/use-room-reactions.integration.test.tsx
@@ -7,6 +7,7 @@ import { useRoomReactions } from '../../../src/react/hooks/use-room-reactions.ts
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
 import { newChatClient } from '../../helper/chat.ts';
+import { randomRoomId } from '../../helper/identifier.ts';
 
 function waitForReactions(reactions: Reaction[], expectedCount: number) {
   return new Promise<void>((resolve, reject) => {
@@ -30,7 +31,8 @@ describe('useRoomReactions', () => {
     const chatClientTwo = newChatClient() as unknown as ChatClient;
 
     // create a second room and attach it, so we can receive reactions
-    const roomTwo = chatClientTwo.rooms.get('room-id', RoomOptionsDefaults);
+    const roomId = randomRoomId();
+    const roomTwo = chatClientTwo.rooms.get(roomId, RoomOptionsDefaults);
     await roomTwo.attach();
 
     // store the received reactions
@@ -58,7 +60,7 @@ describe('useRoomReactions', () => {
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
-          id="room-id"
+          id={roomId}
           options={RoomOptionsDefaults}
         >
           <TestComponent />
@@ -73,13 +75,15 @@ describe('useRoomReactions', () => {
     // check the reaction was received
     expect(reactions.find((reaction) => reaction.type === 'like')).toBeTruthy();
   });
+
   it('should receive room reactions', async () => {
     // create new clients
     const chatClientOne = newChatClient() as unknown as ChatClient;
     const chatClientTwo = newChatClient() as unknown as ChatClient;
 
     // create a second room and attach it, so we can send a reaction
-    const roomTwo = chatClientTwo.rooms.get('room-id', RoomOptionsDefaults);
+    const roomId = randomRoomId();
+    const roomTwo = chatClientTwo.rooms.get(roomId, RoomOptionsDefaults);
     await roomTwo.attach();
 
     // store the received reactions
@@ -100,7 +104,7 @@ describe('useRoomReactions', () => {
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
-          id="room-id"
+          id={roomId}
           options={RoomOptionsDefaults}
         >
           <TestComponent listener={(reaction) => reactions.push(reaction)} />

--- a/test/react/hooks/use-typing.integration.test.tsx
+++ b/test/react/hooks/use-typing.integration.test.tsx
@@ -7,6 +7,7 @@ import { useTyping } from '../../../src/react/hooks/use-typing.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
 import { newChatClient } from '../../helper/chat.ts';
+import { randomRoomId } from '../../helper/identifier.ts';
 
 function waitForTypingEvents(typingEvents: TypingEvent[], expectedCount: number) {
   return new Promise<void>((resolve, reject) => {
@@ -30,7 +31,8 @@ describe('useTyping', () => {
     const chatClientTwo = newChatClient() as unknown as ChatClient;
 
     // create a second room and attach it, so we can listen for typing events
-    const roomTwo = chatClientTwo.rooms.get('room-id', RoomOptionsDefaults);
+    const roomId = randomRoomId();
+    const roomTwo = chatClientTwo.rooms.get(roomId, RoomOptionsDefaults);
     await roomTwo.attach();
 
     // start listening for typing events on room two
@@ -55,7 +57,7 @@ describe('useTyping', () => {
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
-          id="room-id"
+          id={roomId}
           options={RoomOptionsDefaults}
         >
           <TestComponent />
@@ -76,7 +78,8 @@ describe('useTyping', () => {
     const chatClientTwo = newChatClient() as unknown as ChatClient;
 
     // create a second room and attach it, so we can send typing events
-    const roomTwo = chatClientTwo.rooms.get('room-id', RoomOptionsDefaults);
+    const roomId = randomRoomId();
+    const roomTwo = chatClientTwo.rooms.get(roomId, RoomOptionsDefaults);
     await roomTwo.attach();
 
     // store the received typing events for room one
@@ -97,7 +100,7 @@ describe('useTyping', () => {
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
-          id="room-id"
+          id={roomId}
           options={RoomOptionsDefaults}
         >
           <TestComponent listener={(typingEvent) => typingEventsRoomOne.push(typingEvent)} />


### PR DESCRIPTION
### Context

* [CHA-388]

### Description

- Added the `usePresenceListener` hook to the Chat React library. This allows the user to interact with the underlying `Presence` instance, and subscribe a listener to presence events.
- The hook also returns the current state of presence members, which is kept up to date by the hook.

- Updated the demo app to use the new hook, the presence list is now updated via the returned state from the hook.
- Updated the readme to document hook usage.
- Added unit tests for the new hook.
- Added integration tests for the new hook.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

1. Spin up a local instance of the demo app.
2. Open up two tabs with different clients and join presence
3. Ensure both tabs show presence for both clients


[CHA-388]: https://ably.atlassian.net/browse/CHA-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ