### PR TITLE
async room initialization with sync rooms.get

### DIFF
--- a/demo/src/main.tsx
+++ b/demo/src/main.tsx
@@ -40,7 +40,7 @@ const realtimeClient = new Ably.Realtime({
   clientId,
 });
 
-const chatClient = new ChatClient(realtimeClient, { logLevel: LogLevel.Debug });
+const chatClient = new ChatClient(realtimeClient);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/core/discontinuity.ts
+++ b/src/core/discontinuity.ts
@@ -7,11 +7,6 @@ import EventEmitter from './utils/event-emitter.js';
  */
 export interface HandlesDiscontinuity {
   /**
-   * The channel that this object is associated with.
-   */
-  get channel(): Ably.RealtimeChannel;
-
-  /**
    * Called when a discontinuity is detected on the channel.
    * @param reason The error that caused the discontinuity.
    */

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -197,7 +197,7 @@ export interface Messages extends EmitsDiscontinuities {
    *
    * @returns the realtime channel
    */
-  get channel(): Ably.RealtimeChannel;
+  get channelPromise(): Promise<Ably.RealtimeChannel>;
 }
 
 /**
@@ -208,7 +208,7 @@ export class DefaultMessages
   implements Messages, HandlesDiscontinuity, ContributesToRoomLifecycle
 {
   private readonly _roomId: string;
-  private readonly _channel: Ably.RealtimeChannel;
+  private readonly _channelPromise: Promise<Ably.RealtimeChannel>;
   private readonly _chatApi: ChatApi;
   private readonly _clientId: string;
   private readonly _listenerSubscriptionPoints: Map<
@@ -228,32 +228,45 @@ export class DefaultMessages
    * @param clientId The client ID of the user.
    * @param logger An instance of the Logger.
    */
-  constructor(roomId: string, realtime: Ably.Realtime, chatApi: ChatApi, clientId: string, logger: Logger) {
+  constructor(
+    roomId: string,
+    realtime: Ably.Realtime,
+    chatApi: ChatApi,
+    clientId: string,
+    logger: Logger,
+    waitForMe: Promise<void>,
+  ) {
     super();
     this._roomId = roomId;
-    this._channel = getChannel(messagesChannelName(roomId), realtime);
-    addListenerToChannelWithoutAttach({
-      listener: this._processEvent.bind(this),
-      events: [MessageEvents.Created],
-      channel: this._channel,
+
+    this._channelPromise = waitForMe.then(() => {
+      const channel = getChannel(messagesChannelName(roomId), realtime);
+
+      addListenerToChannelWithoutAttach({
+        listener: this._processEvent.bind(this),
+        events: [MessageEvents.Created],
+        channel: channel,
+      });
+
+      // Handles the case where channel attaches and resume state is false. This can happen when the channel is first attached,
+      // or when the channel is reattached after a detach. In both cases, we reset the subscription points for all listeners.
+      channel.on('attached', (message) => {
+        this._handleAttach(message.resumed);
+      });
+      // Handles the case where an update message is received from a channel after a detach and reattach.
+      channel.on('update', (message) => {
+        if (message.current === 'attached' && message.previous === 'attached') {
+          this._handleAttach(message.resumed);
+        }
+      });
+
+      return channel;
     });
 
     this._chatApi = chatApi;
     this._clientId = clientId;
     this._logger = logger;
     this._listenerSubscriptionPoints = new Map<MessageListener, Promise<{ fromSerial: string }>>();
-
-    // Handles the case where channel attaches and resume state is false. This can happen when the channel is first attached,
-    // or when the channel is reattached after a detach. In both cases, we reset the subscription points for all listeners.
-    this._channel.on('attached', (message) => {
-      this._handleAttach(message.resumed);
-    });
-    // Handles the case where an update message is received from a channel after a detach and reattach.
-    this._channel.on('update', (message) => {
-      if (message.current === 'attached' && message.previous === 'attached') {
-        this._handleAttach(message.resumed);
-      }
-    });
   }
 
   /**
@@ -328,10 +341,10 @@ export class DefaultMessages
   private async _resolveSubscriptionStart(): Promise<{
     fromSerial: string;
   }> {
-    const channelWithProperties = this._getChannelProperties();
+    const channelWithProperties = await this._getChannelProperties();
 
     // If we are attached, we can resolve with the channelSerial
-    if (this._channel.state === 'attached') {
+    if (channelWithProperties.state === 'attached') {
       if (channelWithProperties.properties.channelSerial) {
         return { fromSerial: channelWithProperties.properties.channelSerial };
       }
@@ -342,11 +355,14 @@ export class DefaultMessages
     return this._subscribeAtChannelAttach();
   }
 
-  private _getChannelProperties(): Ably.RealtimeChannel & {
-    properties: { attachSerial: string | undefined; channelSerial: string | undefined };
-  } {
+  private async _getChannelProperties(): Promise<
+    Ably.RealtimeChannel & {
+      properties: { attachSerial: string | undefined; channelSerial: string | undefined };
+    }
+  > {
     // Get the attachSerial from the channel properties
-    return this._channel as Ably.RealtimeChannel & {
+    const channel = await this._channelPromise;
+    return channel as Ably.RealtimeChannel & {
       properties: {
         attachSerial: string | undefined;
         channelSerial: string | undefined;
@@ -355,11 +371,11 @@ export class DefaultMessages
   }
 
   private async _subscribeAtChannelAttach(): Promise<{ fromSerial: string }> {
+    const channelWithProperties = await this._getChannelProperties();
     return new Promise((resolve, reject) => {
       // Check if the state is now attached
-      if (this._channel.state === 'attached') {
+      if (channelWithProperties.state === 'attached') {
         // Get the attachSerial from the channel properties
-        const channelWithProperties = this._getChannelProperties();
         // AttachSerial should always be defined at this point, but we check just in case
         this._logger.debug('Messages._subscribeAtChannelAttach(); channel is attached already, using attachSerial', {
           attachSerial: channelWithProperties.properties.attachSerial,
@@ -374,9 +390,8 @@ export class DefaultMessages
         }
       }
 
-      this._channel.once('attached', () => {
+      channelWithProperties.once('attached', () => {
         // Get the attachSerial from the channel properties
-        const channelWithProperties = this._getChannelProperties();
         // AttachSerial should always be defined at this point, but we check just in case
         this._logger.debug('Messages._subscribeAtChannelAttach(); channel is now attached, using attachSerial', {
           attachSerial: channelWithProperties.properties.attachSerial,
@@ -396,8 +411,8 @@ export class DefaultMessages
   /**
    * @inheritdoc Messages
    */
-  get channel(): Ably.RealtimeChannel {
-    return this._channel;
+  get channelPromise(): Promise<Ably.RealtimeChannel> {
+    return this._channelPromise;
   }
 
   /**

--- a/src/core/room-status.ts
+++ b/src/core/room-status.ts
@@ -8,6 +8,11 @@ import EventEmitter from './utils/event-emitter.js';
  */
 export enum RoomLifecycle {
   /**
+   * The library is currently initializing the room.
+   */
+  Initializing = 'initializing',
+
+  /**
    * A temporary state for when the library is first initialized.
    */
   Initialized = 'initialized',
@@ -162,7 +167,7 @@ type RoomStatusEventsMap = {
  * @internal
  */
 export class DefaultStatus extends EventEmitter<RoomStatusEventsMap> implements InternalRoomStatus {
-  private _state: RoomLifecycle = RoomLifecycle.Initialized;
+  private _state: RoomLifecycle = RoomLifecycle.Initializing;
   private _error?: Ably.ErrorInfo;
   private readonly _logger: Logger;
   private readonly _internalEmitter = new EventEmitter<RoomStatusEventsMap>();
@@ -174,7 +179,7 @@ export class DefaultStatus extends EventEmitter<RoomStatusEventsMap> implements 
   constructor(logger: Logger) {
     super();
     this._logger = logger;
-    this._state = RoomLifecycle.Initialized;
+    this._state = RoomLifecycle.Initializing;
     this._error = undefined;
   }
 

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -8,7 +8,7 @@ import { DefaultPresence, Presence } from './presence.js';
 import { ContributesToRoomLifecycle, RoomLifecycleManager } from './room-lifecycle-manager.js';
 import { RoomOptions, validateRoomOptions } from './room-options.js';
 import { DefaultRoomReactions, RoomReactions } from './room-reactions.js';
-import { DefaultStatus, RoomStatus } from './room-status.js';
+import { DefaultStatus, RoomLifecycle, RoomStatus } from './room-status.js';
 import { DefaultTyping, Typing } from './typing.js';
 
 /**
@@ -107,9 +107,9 @@ export class DefaultRoom implements Room {
   private readonly _occupancy?: DefaultOccupancy;
   private readonly _logger: Logger;
   private readonly _status: DefaultStatus;
-  private readonly _lifecycleManager: RoomLifecycleManager;
-  private readonly _finalizer: () => Promise<void>;
-  private readonly _waitForMe: Promise<void>;
+  private _lifecycleManager?: RoomLifecycleManager;
+  private _finalizer: () => Promise<void>;
+  private _asyncOpsAfter: Promise<void>;
 
   /**
    * Constructs a new Room instance.
@@ -119,7 +119,7 @@ export class DefaultRoom implements Room {
    * @param realtime An instance of the Ably Realtime client.
    * @param chatApi An instance of the ChatApi.
    * @param logger An instance of the Logger.
-   * @param waitForMe The room will wait for this promise to finish before trying any async operation.
+   * @param initAfter The room will wait for this promise to finish before initializing
    */
   constructor(
     roomId: string,
@@ -127,7 +127,7 @@ export class DefaultRoom implements Room {
     realtime: Ably.Realtime,
     chatApi: ChatApi,
     logger: Logger,
-    waitForMe?: Promise<void>,
+    initAfter: Promise<void>,
   ) {
     validateRoomOptions(options);
     logger.debug('Room();', { roomId, options });
@@ -138,59 +138,168 @@ export class DefaultRoom implements Room {
     this._logger = logger;
     this._status = new DefaultStatus(logger);
 
-    this._waitForMe = waitForMe ? new Promise((resolve) => {
-        waitForMe.finally(() => {
+    // This function gets called if release() is called before initialization
+    // starts. It allows for the room to not be initialised at all since it
+    // won't be needed.
+    let stopInitializingFeatures: (() => void) | undefined;
+
+    // This promise is the same as initAfter but it gets rejected if release()
+    // is called before initialization starts. This make sure that room
+    // features will not permanently hang waiting for this promise to resolve.
+    //
+    // This promise is passed down to all features to wait before starting to
+    // create or use any realtime channels.
+    const initFeaturesAfter = new Promise<void>((resolve, reject) => {
+      let rejected = false;
+      stopInitializingFeatures = () => {
+        rejected = true;
+        stopInitializingFeatures = undefined;
+        this._status.setStatus({ status: RoomLifecycle.Released });
+        reject(new Ably.ErrorInfo('Room released before initialization started', 40000, 400));
+      };
+      initAfter
+        .catch((error: unknown) => {
+          return error;
+        })
+        .finally(() => {
+          if (rejected) {
+            return;
+          }
           resolve();
         });
-      }) : Promise.resolve();
+    });
+
+    // At this stage finalizer (release) only needs to cancel the pending
+    // initialization.
+    this._finalizer = async () => {
+      if (stopInitializingFeatures) {
+        stopInitializingFeatures();
+      }
+      // return the original initAfter promise because in this state the
+      // previous room is still being released
+      return initAfter;
+    };
 
     // Setup features
-    this._messages = new DefaultMessages(roomId, realtime, this._chatApi, realtime.auth.clientId, logger);
+    this._messages = new DefaultMessages(
+      roomId,
+      realtime,
+      this._chatApi,
+      realtime.auth.clientId,
+      logger,
+      initFeaturesAfter,
+    );
+
     const features: ContributesToRoomLifecycle[] = [this._messages];
+
     if (options.presence) {
       this._logger.debug('enabling presence on room', { roomId });
-      this._presence = new DefaultPresence(roomId, options, realtime, realtime.auth.clientId, logger);
+      this._presence = new DefaultPresence(
+        roomId,
+        options,
+        realtime,
+        realtime.auth.clientId,
+        logger,
+        initFeaturesAfter,
+      );
       features.push(this._presence);
     }
 
     if (options.typing) {
       this._logger.debug('enabling typing on room', { roomId });
-      this._typing = new DefaultTyping(roomId, options.typing, realtime, realtime.auth.clientId, logger);
+      this._typing = new DefaultTyping(
+        roomId,
+        options.typing,
+        realtime,
+        realtime.auth.clientId,
+        logger,
+        initFeaturesAfter,
+      );
       features.push(this._typing);
     }
 
     if (options.reactions) {
       this._logger.debug('enabling reactions on room', { roomId });
-      this._reactions = new DefaultRoomReactions(roomId, realtime, realtime.auth.clientId, logger);
+      this._reactions = new DefaultRoomReactions(roomId, realtime, realtime.auth.clientId, logger, initFeaturesAfter);
       features.push(this._reactions);
     }
 
     if (options.occupancy) {
       this._logger.debug('enabling occupancy on room', { roomId });
-      this._occupancy = new DefaultOccupancy(roomId, realtime, this._chatApi, logger);
+      this._occupancy = new DefaultOccupancy(roomId, realtime, this._chatApi, logger, initFeaturesAfter);
       features.push(this._occupancy);
     }
 
-    // Setup lifecycle manager - reverse the features so messages always comes in last
-    this._lifecycleManager = new RoomLifecycleManager(this._status, features.toReversed(), logger, 5000);
+    // Wait for features to finish initializing and then finish initializing
+    // the room. Set _asyncOpsAfter to the promise that waits for the room to
+    // finish initializing. This promise is awaited before performing any async
+    // operations at room level (attach and detach).
+    this._asyncOpsAfter = initFeaturesAfter.then(() => {
+      // Features have now started initializing so we can no longer stop the
+      // initialization process. Features haven't yet finished initializing,
+      // so if release() is called we first need to wait for initialization to
+      // finish before releasing. We use a promise to wait for the correct
+      // release function.
 
-    // Setup a finalization function to clean up resources
-    let finalized = false;
-    this._finalizer = async () => {
-      // Cycle the channels in the feature and release them from the realtime client
-      if (finalized) {
-        this._logger.debug('Room.finalizer(); already finalized');
-        return;
+      let setFinalizerFunc: (f: () => Promise<void>) => void;
+      const finalizerFuncPromise = new Promise<() => void>((resolve) => {
+        setFinalizerFunc = resolve;
+      });
+      this._finalizer = () => {
+        return finalizerFuncPromise.then((f) => {
+          f();
+        });
+      };
+
+      // Setup all contributors with resolved channels
+      interface ContributorWithChannel extends ContributesToRoomLifecycle {
+        channel: Ably.RealtimeChannel;
       }
+      const promises = features.map((feature) => {
+        return feature.channelPromise.then((channel): ContributorWithChannel => {
+          return {
+            ...feature,
+            channel: channel,
+          };
+        });
+      });
 
-      await this._lifecycleManager.release();
+      // With all features with resolved channels:
+      // - setup room lifecycle manager
+      // - mark the room as initialized
+      // - setup finalizer function
+      return Promise.all(promises)
+        .then((contributors) => {
+          const manager = new RoomLifecycleManager(this._status, contributors.toReversed(), logger, 5000);
+          this._lifecycleManager = manager;
 
-      for (const feature of features) {
-        realtime.channels.release(feature.channel.name);
-      }
-
-      finalized = true;
-    };
+          let finalized = false;
+          setFinalizerFunc((): Promise<void> => {
+            if (finalized) {
+              return Promise.resolve();
+            }
+            finalized = true;
+            return manager.release().then(() => {
+              for (const contributor of contributors) {
+                realtime.channels.release(contributor.channel.name);
+              }
+            });
+          });
+          this._status.setStatus({ status: RoomLifecycle.Initialized });
+        })
+        .catch((error: unknown) => {
+          // this should never happen because contributor channel promises
+          // should only reject when initFeaturesAfter is rejected. We log
+          // here just in case.
+          setFinalizerFunc(() => Promise.resolve());
+          this._logger.error('Room features initialization failed', { error: error });
+          this._status.setStatus({
+            status: RoomLifecycle.Failed,
+            error: new Ably.ErrorInfo('Room features initialization failed', 40000, 400, error as Error),
+          });
+          return Promise.reject(error);
+        });
+    });
   }
 
   /**
@@ -272,9 +381,9 @@ export class DefaultRoom implements Room {
   /**
    * @inheritdoc Room
    */
-  async attach() {
+  async attach(): Promise<void> {
     this._logger.trace('Room.attach();');
-    return this._waitForMe.then(() => this._lifecycleManager.attach());
+    return this._asyncOpsAfter.then(() => this._lifecycleManager?.attach());
   }
 
   /**
@@ -282,7 +391,7 @@ export class DefaultRoom implements Room {
    */
   async detach(): Promise<void> {
     this._logger.trace('Room.detach();');
-    return this._waitForMe.then(() => this._lifecycleManager.detach());
+    return this._asyncOpsAfter.then(() => this._lifecycleManager?.detach());
   }
 
   /**
@@ -291,13 +400,6 @@ export class DefaultRoom implements Room {
    */
   release(): Promise<void> {
     this._logger.trace('Room.release();');
-    return this._waitForMe.then(() => this._finalizer());
-  }
-
-  /**
-   * @internal
-   */
-  get lifecycleManager(): RoomLifecycleManager {
-    return this._lifecycleManager;
+    return this._finalizer();
   }
 }

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -71,7 +71,7 @@ export interface Typing extends EmitsDiscontinuities {
    * Get the name of the realtime channel underpinning typing events.
    * @returns The name of the realtime channel.
    */
-  channel: Ably.RealtimeChannel;
+  channelPromise: Promise<Ably.RealtimeChannel>;
 }
 
 /**
@@ -115,7 +115,7 @@ export class DefaultTyping
   implements Typing, HandlesDiscontinuity, ContributesToRoomLifecycle
 {
   private readonly _clientId: string;
-  private readonly _channel: Ably.RealtimeChannel;
+  private readonly _channelPromise: Promise<Ably.RealtimeChannel>;
   private readonly _logger: Logger;
   private readonly _discontinuityEmitter: DiscontinuityEmitter = newDiscontinuityEmitter();
 
@@ -137,13 +137,23 @@ export class DefaultTyping
    * @param clientId The client ID of the user.
    * @param logger An instance of the Logger.
    */
-  constructor(roomId: string, options: TypingOptions, realtime: Ably.Realtime, clientId: string, logger: Logger) {
+  constructor(
+    roomId: string,
+    options: TypingOptions,
+    realtime: Ably.Realtime,
+    clientId: string,
+    logger: Logger,
+    initAfter: Promise<void>,
+  ) {
     super();
     this._clientId = clientId;
-    this._channel = getChannel(`${roomId}::$chat::$typingIndicators`, realtime);
-    addListenerToChannelPresenceWithoutAttach({
-      listener: this._internalSubscribeToEvents.bind(this),
-      channel: this._channel,
+    this._channelPromise = initAfter.then(() => {
+      const channel = getChannel(`${roomId}::$chat::$typingIndicators`, realtime);
+      addListenerToChannelPresenceWithoutAttach({
+        listener: this._internalSubscribeToEvents.bind(this),
+        channel: channel,
+      });
+      return channel;
     });
 
     // Timeout for typing
@@ -155,14 +165,16 @@ export class DefaultTyping
    * @inheritDoc
    */
   get(): Promise<Set<string>> {
-    return this._channel.presence.get().then((members) => new Set<string>(members.map((m) => m.clientId)));
+    return this._channelPromise.then((channel) =>
+      channel.presence.get().then((members) => new Set<string>(members.map((m) => m.clientId))),
+    );
   }
 
   /**
    * @inheritDoc
    */
-  get channel(): Ably.RealtimeChannel {
-    return this._channel;
+  get channelPromise(): Promise<Ably.RealtimeChannel> {
+    return this._channelPromise;
   }
 
   /**
@@ -191,7 +203,8 @@ export class DefaultTyping
 
     // Start typing and emit typingStarted event
     this._startTypingTimer();
-    return this._channel.presence.enterClient(this._clientId).then();
+    const channel = await this.channelPromise;
+    return channel.presence.enterClient(this._clientId).then();
   }
 
   /**
@@ -206,7 +219,8 @@ export class DefaultTyping
     }
 
     // Will throw an error if the user is not typing
-    return this._channel.presence.leaveClient(this._clientId);
+    const channel = await this.channelPromise;
+    return channel.presence.leaveClient(this._clientId);
   }
 
   /**


### PR DESCRIPTION
This is an early draft for the async room initialization. I've added a new status, `RoomLifecycle.Initializing`, to show that the room didn't start init yet.

Please have a look at:
- `room.ts` (start here)
- `rooms.ts`
- `room-lifecycle-manager.ts`
- and one of the features like `messages.ts`, `typing-indicators.ts` etc (they're all refactored the same way)
