### PR TITLE
export RoomOptionsDefaults as a struct instead of a class

### DIFF
--- a/src/core/room-options.ts
+++ b/src/core/room-options.ts
@@ -3,11 +3,11 @@ import * as Ably from 'ably';
 /**
  * Represents the default options for a chat room.
  */
-export class RoomOptionsDefaults {
+export const RoomOptionsDefaults = {
   /**
    * The default presence options for a chat room.
    */
-  static presence: PresenceOptions = {
+  presence: {
     /**
      * The client should be able to enter presence.
      */
@@ -17,28 +17,28 @@ export class RoomOptionsDefaults {
      * The client should be able to subscribe to presence.
      */
     subscribe: true,
-  };
+  } as PresenceOptions,
 
   /**
    * The default typing options for a chat room.
    */
-  static typing: TypingOptions = {
+  typing: {
     /**
      * The default timeout for typing events in milliseconds.
      */
     timeoutMs: 10000,
-  };
+  } as TypingOptions,
 
   /**
    * The default reactions options for a chat room.
    */
-  static reactions: RoomReactionsOptions = {};
+  reactions: {} as RoomReactionsOptions,
 
   /**
    * The default occupancy options for a chat room.
    */
-  static occupancy: OccupancyOptions = {};
-}
+  occupancy: {} as OccupancyOptions,
+};
 
 /**
  * Represents the presence options for a chat room.


### PR DESCRIPTION
This allows `RoomOptionsDefaults` to be used directly in `rooms.get("abc", RoomOptionsDefaults)`. The class version made `dequal` throw an error if you did the above on the same room twice.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] (Optional) Update documentation for new features.
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).