### PR TITLE
CDN Bundle Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,13 @@ npm install @ably/chat
 For browsers, you can also include the Chat SDK directly into your HTML:
 
 ```html
-<script src="https://cdn.ably.com/lib/ably-chat-0.js"></script>
+<!-- Ably Chat also requires the core Ably SDK to be available -->
+<script src="https://cdn.ably.com/lib/ably.min-2.js"></script>
+<script src="https://cdn.ably.com/lib/ably-chat.umd.cjs-0.js"></script>
+<script>
+  const realtime = new Ably.Realtime({key: 'your-ably-key'})
+  const chatClient = new AblyChat.ChatClient(realtime);
+</script>
 ```
 
 The Ably client library follows [Semantic Versioning](http://semver.org/). To lock into a major or minor version of the client library, you can specify a specific version number such as https://cdn.ably.com/lib/ably-chat-0.js for all v0._ versions, or https://cdn.ably.com/lib/ably-chat-0.1.js for all v0.1._ versions, or you can lock into a single release with https://cdn.ably.com/lib/ably-chat-0.1.0.js. See https://github.com/ably/ably-chat-js/tags for a list of tagged releases.

--- a/src/core/vite.config.ts
+++ b/src/core/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     outDir: '../../dist/chat',
     lib: {
       entry: resolve(__dirname, 'index.ts'),
-      name: 'ably-chat-js',
+      name: 'AblyChat',
       fileName: 'ably-chat',
     },
     rollupOptions: {

--- a/src/react/vite.config.ts
+++ b/src/react/vite.config.ts
@@ -17,7 +17,10 @@ export default defineConfig({
     rollupOptions: {
       // We currently suggest that ably be installed as a separate dependency, so lets
       // not bundle it.
-      external: ['ably', '@ably/chat', 'react'],
+      // We don't bundle react, react-dom, and react/jsx-runtime as they are expected to be
+      // provided by the consuming application and not specifying them could lead to
+      // multiple conflicting versions of react.
+      external: ['ably', '@ably/chat', 'react', 'react-dom', 'react/jsx-runtime'],
     },
     sourcemap: true,
   },

--- a/src/react/vite.config.ts
+++ b/src/react/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     outDir: resolve(__dirname, '../../dist/react'),
     lib: {
       entry: resolve(__dirname, 'index.ts'),
-      name: 'ably-chat-react',
+      name: 'AblyChatReact',
       fileName: 'ably-chat-react',
     },
     rollupOptions: {


### PR DESCRIPTION
### Context

We were having some issues with using ably-js and ably-chat-js from the CDN, as the former doesn't export an ESM module (and the later tries to import it).

### Description

- Update the Vite library names for Chat and React to be `AblyChat` and `AblyChatReact` respectively. This means that users can do `const chatClient = new AblyChat.ChatClient()` instead of `const chatClient = new window['ably-chat-js'].ChatClient()` in the browser.
- Update the README instructions for using the CDN to point to the UMD variant of Chat, which does work with ably-js.
- Update the React dependencies to make `react-dom` and `react/jsx-runtime` externals - requiring the consumer to provide them and avoiding conflicts.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

Minimal working example:

```html
<script src="https://cdn.ably.com/lib/ably.min-2.js"></script>
<script src="./path-to-ably-chat-js-umd-variant"></script>
<script>
  const realtime = new Ably.Realtime({
          key: 'YOUR KEY HERE',
          clientId: 'client_' + client_id,
        });
  const chatClient = new AblyChat.ChatClient(realtime);
</script>
```

If the above doesn't error, you're good!