### PR TITLE
Use logger hook

### DIFF
--- a/src/core/chat.ts
+++ b/src/core/chat.ts
@@ -3,7 +3,7 @@ import * as Ably from 'ably';
 import { ClientOptions, normalizeClientOptions, NormalizedClientOptions } from './config.js';
 import { Connection, DefaultConnection } from './connection.js';
 import { DefaultConnectionStatus } from './connection-status.js';
-import { makeLogger } from './logger.js';
+import { Logger, makeLogger } from './logger.js';
 import { RealtimeWithOptions } from './realtime-extensions.js';
 import { DefaultRooms, Rooms } from './rooms.js';
 import { VERSION } from './version.js';
@@ -33,6 +33,11 @@ export class ChatClient {
   private readonly _connection: Connection;
 
   /**
+   * @internal
+   */
+  private readonly _logger: Logger;
+
+  /**
    * Constructor for Chat
    * @param realtime - The Ably Realtime client.
    * @param clientOptions - The client options.
@@ -40,11 +45,11 @@ export class ChatClient {
   constructor(realtime: Ably.Realtime, clientOptions?: ClientOptions) {
     this._realtime = realtime;
     this._clientOptions = normalizeClientOptions(clientOptions);
-    const logger = makeLogger(this._clientOptions);
-    this._connection = new DefaultConnection(new DefaultConnectionStatus(realtime, logger));
-    this._rooms = new DefaultRooms(realtime, this._clientOptions, logger);
+    this._logger = makeLogger(this._clientOptions);
+    this._connection = new DefaultConnection(new DefaultConnectionStatus(realtime, this._logger));
+    this._rooms = new DefaultRooms(realtime, this._clientOptions, this._logger);
     this._addAgent('chat-js');
-    logger.trace(`ably chat client version ${VERSION}; initialized`);
+    this._logger.trace(`ably chat client version ${VERSION}; initialized`);
   }
 
   /**
@@ -89,6 +94,15 @@ export class ChatClient {
    */
   get clientOptions(): ClientOptions {
     return this._clientOptions;
+  }
+
+  /**
+   * Returns the logger instance for the client.
+   * @internal
+   * @returns The logger instance.
+   */
+  get logger(): Logger {
+    return this._logger;
   }
 
   /**

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -25,7 +25,7 @@ export {
   reactionFromAblyMessage,
   reactionFromEncoded,
 } from './helpers.js';
-export type { LogContext, LogHandler } from './logger.js';
+export type { LogContext, Logger, LogHandler } from './logger.js';
 export { LogLevel } from './logger.js';
 export type { Message, MessageHeaders, MessageMetadata } from './message.js';
 export type {

--- a/src/react/hooks/use-chat-connection.ts
+++ b/src/react/hooks/use-chat-connection.ts
@@ -42,6 +42,7 @@ export interface UseChatConnectionResponse {
  */
 export const useChatConnection = (options?: UseChatConnectionOptions): UseChatConnectionResponse => {
   const chatClient = useChatClient();
+  chatClient.logger.trace('useChatConnection();', options);
 
   // Initialize states with the current values from chatClient
   const [currentStatus, setCurrentStatus] = useState<ConnectionLifecycle>(chatClient.connection.status.current);
@@ -57,6 +58,7 @@ export const useChatConnection = (options?: UseChatConnectionOptions): UseChatCo
 
   // Apply the listener to the chatClient's connection status changes to keep the state update across re-renders
   useEffect(() => {
+    chatClient.logger.debug('useChatConnection(); applying internal listener');
     const { off } = chatClient.connection.status.onChange((change: ConnectionStatusChange) => {
       // Update states with new values
       setCurrentStatus(change.current);
@@ -64,20 +66,23 @@ export const useChatConnection = (options?: UseChatConnectionOptions): UseChatCo
     });
     // Cleanup listener on un-mount
     return () => {
+      chatClient.logger.debug('useChatConnection(); cleaning up listener');
       off();
     };
-  }, [chatClient.connection.status]);
+  }, [chatClient.connection.status, chatClient.logger]);
 
   // Register the listener for the user-provided onStatusChange callback
   useEffect(() => {
     if (!options?.onStatusChange) return;
+    chatClient.logger.debug('useChatConnection(); applying client listener');
     const { onStatusChange } = options;
     const { off } = chatClient.connection.status.onChange(onStatusChange);
 
     return () => {
+      chatClient.logger.debug('useChatConnection(); cleaning up client listener');
       off();
     };
-  }, [chatClient.connection.status, options]);
+  }, [chatClient.connection.status, options, chatClient.logger]);
 
   return {
     currentStatus,

--- a/src/react/hooks/use-logger.ts
+++ b/src/react/hooks/use-logger.ts
@@ -1,0 +1,16 @@
+import { Logger } from '@ably/chat';
+import { useMemo } from 'react';
+
+import { useChatClient } from './use-chat-client.js';
+
+/**
+ * A hook that provides access to the {@link Logger} instance of the {@link ChatClient}.
+ * It will use the instance belonging to the {@link ChatClient} in the nearest {@link ChatProvider} in the component tree.
+ * @internal
+ *
+ * @returns Logger - The logger instance.
+ */
+export const useLogger = (): Logger => {
+  const chatClient = useChatClient();
+  return useMemo(() => chatClient.logger, [chatClient]);
+};

--- a/src/react/hooks/use-room-reactions.ts
+++ b/src/react/hooks/use-room-reactions.ts
@@ -5,6 +5,7 @@ import { ChatStatusResponse } from '../types/chat-status-response.js';
 import { Listenable } from '../types/listenable.js';
 import { StatusParams } from '../types/status-params.js';
 import { useChatConnection } from './use-chat-connection.js';
+import { useLogger } from './use-logger.js';
 import { useRoom } from './use-room.js';
 
 /**
@@ -46,24 +47,30 @@ export const useRoomReactions = (params?: UseRoomReactionsParams): UseRoomReacti
   const { room, roomError, roomStatus } = useRoom({
     onStatusChange: params?.onRoomStatusChange,
   });
+  const logger = useLogger();
+  logger.trace('useRoomReactions();', { params, roomId: room.roomId });
 
   // if provided, subscribes the user provided discontinuity listener
   useEffect(() => {
     if (!params?.onDiscontinuity) return;
+    logger.debug('useRoomReactions(); applying onDiscontinuity listener', { roomId: room.roomId });
     const { off } = room.reactions.onDiscontinuity(params.onDiscontinuity);
     return () => {
+      logger.debug('useRoomReactions(); removing onDiscontinuity listener', { roomId: room.roomId });
       off();
     };
-  }, [room, params]);
+  }, [room, params, logger]);
 
   // if provided, subscribe the user provided listener to room reactions
   useEffect(() => {
     if (!params?.listener) return;
+    logger.debug('useRoomReactions(); applying listener', { roomId: room.roomId });
     const { unsubscribe } = room.reactions.subscribe(params.listener);
     return () => {
+      logger.debug('useRoomReactions(); removing listener', { roomId: room.roomId });
       unsubscribe();
     };
-  }, [room, params]);
+  }, [room, params, logger]);
 
   const send = useCallback((params: SendReactionParams) => room.reactions.send(params), [room.reactions]);
 

--- a/src/react/providers/chat-room-provider.tsx
+++ b/src/react/providers/chat-room-provider.tsx
@@ -5,6 +5,7 @@ import React, { ReactNode, useEffect, useState } from 'react';
 
 import { ChatRoomContext } from '../contexts/chat-room-context.js';
 import { useChatClient } from '../hooks/use-chat-client.js';
+import { useLogger } from '../hooks/use-logger.js';
 
 /**
  * Props for the {@link ChatRoomProvider} component.
@@ -73,6 +74,8 @@ export const ChatRoomProvider: React.FC<ChatRoomProviderProps> = ({
   children,
 }) => {
   const client = useChatClient();
+  const logger = useLogger();
+  logger.trace(`ChatRoomProvider();`, { roomId, options, release, attach });
 
   const [value, setValue] = useState({ room: client.rooms.get(roomId, options) });
 
@@ -90,18 +93,21 @@ export const ChatRoomProvider: React.FC<ChatRoomProviderProps> = ({
     if (attach) {
       // attachment error and/or room status is available via useRoom
       // or room.status, no need to do anything with the promise here
+      logger.debug(`ChatRoomProvider(); attaching room`, { roomId });
       void room.attach();
     }
     return () => {
       // Releasing the room will implicitly detach if needed.
 
       if (release) {
+        logger.debug(`ChatRoomProvider(); releasing room`, { roomId });
         void client.rooms.release(roomId);
       } else if (attach) {
+        logger.debug(`ChatRoomProvider(); detaching room`, { roomId });
         void room.detach();
       }
     };
-  }, [client, roomId, options, release, attach]);
+  }, [client, roomId, options, release, attach, logger]);
 
   return <ChatRoomContext.Provider value={value}>{children}</ChatRoomContext.Provider>;
 };

--- a/test/react/hooks/use-chat-connection.test.tsx
+++ b/test/react/hooks/use-chat-connection.test.tsx
@@ -8,6 +8,7 @@ import {
   ConnectionStatusListener,
 } from '../../../src/core/connection-status.ts';
 import { useChatConnection } from '../../../src/react/hooks/use-chat-connection.ts';
+import { makeTestLogger } from '../../helper/logger.ts';
 
 let mockCallbacks: ConnectionStatusListener[] = [];
 
@@ -27,6 +28,7 @@ const createMockChatClient = (currentStatus: ConnectionLifecycle, error?: Ably.E
         },
       },
     },
+    logger: makeTestLogger(),
   };
 };
 

--- a/test/react/hooks/use-occupancy.test.tsx
+++ b/test/react/hooks/use-occupancy.test.tsx
@@ -3,6 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useOccupancy } from '../../../src/react/hooks/use-occupancy.ts';
+import { makeTestLogger } from '../../helper/logger.ts';
 import { makeRandomRoom } from '../../helper/room.ts';
 
 let mockRoom: Room;
@@ -14,6 +15,10 @@ vi.mock('../../../src/react/hooks/use-chat-connection.js', () => ({
 
 vi.mock('../../../src/react/hooks/use-room.js', () => ({
   useRoom: () => ({ room: mockRoom, roomStatus: RoomLifecycle.Attached }),
+}));
+
+vi.mock('../../../src/react/hooks/use-logger.js', () => ({
+  useLogger: () => makeTestLogger(),
 }));
 
 vi.mock('ably');

--- a/test/react/hooks/use-presence-listener.test.tsx
+++ b/test/react/hooks/use-presence-listener.test.tsx
@@ -1,5 +1,6 @@
 import {
   ConnectionLifecycle,
+  Logger,
   PresenceEvent,
   PresenceEvents,
   PresenceListener,
@@ -13,9 +14,11 @@ import { ErrorInfo } from 'ably';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { usePresenceListener } from '../../../src/react/hooks/use-presence-listener.ts';
+import { makeTestLogger } from '../../helper/logger.ts';
 import { makeRandomRoom } from '../../helper/room.ts';
 
 let mockRoom: Room;
+let mockLogger: Logger;
 
 let mockCurrentConnectionStatus: ConnectionLifecycle;
 let mockCurrentRoomStatus: RoomLifecycle;
@@ -40,12 +43,17 @@ vi.mock('../../../src/react/hooks/use-room.js', () => ({
   },
 }));
 
+vi.mock('../../../src/react/hooks/use-logger.js', () => ({
+  useLogger: () => mockLogger,
+}));
+
 vi.mock('ably');
 
 describe('usePresenceListener', () => {
   beforeEach(() => {
     // create a new mock room before each test
     mockRoom = makeRandomRoom({ options: { presence: { subscribe: true } } });
+    mockLogger = makeTestLogger();
   });
   afterEach(() => {
     vi.restoreAllMocks();

--- a/test/react/hooks/use-presence.test.tsx
+++ b/test/react/hooks/use-presence.test.tsx
@@ -4,6 +4,7 @@ import * as Ably from 'ably';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { usePresence } from '../../../src/react/hooks/use-presence.ts';
+import { makeTestLogger } from '../../helper/logger.ts';
 import { makeRandomRoom } from '../../helper/room.ts';
 
 let mockRoom: Room;
@@ -26,6 +27,10 @@ vi.mock('../../../src/react/hooks/use-room.js', () => ({
     roomStatus: mockCurrentRoomStatus,
     roomError: mockRoomError,
   }),
+}));
+
+vi.mock('../../../src/react/hooks/use-logger.js', () => ({
+  useLogger: () => makeTestLogger(),
 }));
 
 vi.mock('ably');

--- a/test/react/hooks/use-room-reactions.test.tsx
+++ b/test/react/hooks/use-room-reactions.test.tsx
@@ -3,6 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useRoomReactions } from '../../../src/react/hooks/use-room-reactions.ts';
+import { makeTestLogger } from '../../helper/logger.ts';
 import { makeRandomRoom } from '../../helper/room.ts';
 
 let mockRoom: Room;
@@ -14,6 +15,10 @@ vi.mock('../../../src/react/hooks/use-chat-connection.js', () => ({
 
 vi.mock('../../../src/react/hooks/use-room.js', () => ({
   useRoom: () => ({ room: mockRoom, roomStatus: RoomLifecycle.Attached }),
+}));
+
+vi.mock('../../../src/react/hooks/use-logger.js', () => ({
+  useLogger: () => makeTestLogger(),
 }));
 
 vi.mock('ably');

--- a/test/react/hooks/use-room.test.tsx
+++ b/test/react/hooks/use-room.test.tsx
@@ -23,7 +23,14 @@ function newChatClient() {
 
 describe('useRoom', () => {
   it('should throw an error if used outside of ChatRoomProvider', () => {
-    expect(() => render(<TestComponent />)).toThrowErrorInfo({
+    const chatClient = newChatClient();
+    const TestProvider = () => (
+      <ChatClientProvider client={chatClient}>
+        <TestComponent />
+      </ChatClientProvider>
+    );
+
+    expect(() => render(<TestProvider />)).toThrowErrorInfo({
       code: 40000,
       message: 'useRoom hook must be used within a ChatRoomProvider',
     });

--- a/test/react/hooks/use-typing.test.tsx
+++ b/test/react/hooks/use-typing.test.tsx
@@ -1,12 +1,14 @@
-import { ConnectionLifecycle, Room, RoomLifecycle, TypingListener } from '@ably/chat';
+import { ConnectionLifecycle, Logger, Room, RoomLifecycle, TypingListener } from '@ably/chat';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { ErrorInfo } from 'ably';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useTyping } from '../../../src/react/hooks/use-typing.ts';
+import { makeTestLogger } from '../../helper/logger.ts';
 import { makeRandomRoom } from '../../helper/room.ts';
 
 let mockRoom: Room;
+let mockLogger: Logger;
 
 // apply mocks for the useChatConnection and useRoom hooks
 vi.mock('../../../src/react/hooks/use-chat-connection.js', () => ({
@@ -17,6 +19,10 @@ vi.mock('../../../src/react/hooks/use-room.js', () => ({
   useRoom: () => ({ room: mockRoom, roomStatus: RoomLifecycle.Attached }),
 }));
 
+vi.mock('../../../src/react/hooks/use-logger.js', () => ({
+  useLogger: () => mockLogger,
+}));
+
 vi.mock('ably');
 
 describe('useTyping', () => {
@@ -24,6 +30,7 @@ describe('useTyping', () => {
     // create a new mock room before each test, enabling typing
     vi.resetAllMocks();
     mockRoom = makeRandomRoom({ options: { typing: { timeoutMs: 500 } } });
+    mockLogger = makeTestLogger();
   });
 
   it('should provide the typing instance and chat status response metrics', () => {


### PR DESCRIPTION
### Context

N/A

### Description

This change introduces a new hook `useLogger`, which is intended to be an internal hook. The purpose of the hook is to expose the logger on the `ChatClient`, which allows us to use the logger to log events in the React hooks, including errors, traces and more.

To achieve this, we add `logger` as an internal property on the `ChatClient`, so that the hook can get it.

This change also adds logging across the hooks that exist so far.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

Turn on trace logging and see that logs happen!
