### PR TITLE
react: use stable references to event listeners in hooks

### DIFF
--- a/src/react/README.md
+++ b/src/react/README.md
@@ -54,6 +54,8 @@ At a client-level, changes to the connection status can be subscribed to by prov
 
 Listeners can be provided for events related to a particular `Room` instances status changes via `onRoomStatusChange`. Furthermore, discontinuities in the event stream for room features can be monitored via the `onDiscontinuity` event listener. Room-level events pertain to the nearest parent `RoomProvider` in the React component tree.
 
+Changing the value provided for each of the available listeners will cause the previously registered listener instance to stop receiving events. However, all message events will be received by exactly one listener. If your listener becomes `undefined`, then the subscription will be removed.
+
 ```tsx
 import { useOccupancy } from '@ably/chat/react';
 
@@ -210,13 +212,19 @@ const MyComponent = () => {
 ### Subscribing To Messages
 
 You can provide an optional listener that will receive the messages sent to the room; if provided, the hook will
-automatically subscribe to messages in the room.
+automatically subscribe to messages in the room. As long as a defined value is provided, the subscription will persist
+across renders: making your listener value `undefined` will cause the subscription to be removed until it becomes defined
+again.
 
 Additionally, providing the listener will allow you to access the `getPreviousMessages` method, which can be used to
 fetch previous messages up until the listener was subscribed.
 
-The `getPreviousMessages` method can be useful when recovering from a discontinuity event,
-as it allows you to fetch all the messages that were missed while the listener was not subscribed.
+The `getPreviousMessages` method can be useful when recovering from a discontinuity event, as it allows you to fetch all
+the messages that were missed while the listener was not subscribed. As long as you provide a defined value for the
+listener (and there are no message discontinuities), `getPreviousMessages` will consistently return messages from the
+same point across renders. However, if your listener becomes `undefined`, then the subscription to messages will be
+removed meaning that, if you then re-define your listener, `getPreviousMessages` will now return messages from the
+new subscription point.
 
 ```tsx
 import { useEffect, useState } from 'react';

--- a/src/react/helper/use-event-listener-ref.ts
+++ b/src/react/helper/use-event-listener-ref.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * The type of a callback function that can be stored in the reference.
+ */
+type Callback<CallbackArguments extends unknown[]> = (...args: CallbackArguments) => void;
+
+/**
+ * A hook that creates a reference to an event listener callback function. It is used to stabilize the reference
+ * across renders, so that listeners don't get unsubscribed and resubscribed on every render when passed in as a prop.
+ *
+ * For example, doing this:
+ *
+ * ```jsx
+ *   export function MySubscription() {
+ *     useHookWithListener(() => {})
+ *
+ *     return <div>My Subscription</div>
+ *   }
+ * ```
+ *
+ * Where the `useHookWithListener` hook is defined as:
+ *
+ * ```jsx
+ *  export function useHookWithListener(listener) {
+ *    const listenerRef = useEventListenerRef(listener);
+ *    useEffect(() => {
+ *      // Use the listenerRef
+ *    }, [listenerRef]);
+ * }
+ * ```
+ *
+ * Will ensure that the listener is not unsubscribed and resubscribed on every render (i.e. the useEffect will not be called
+ * on every render).
+ *
+ * We allow for the callback to be undefined, as callbacks in the majority of our hooks are optional. In this instance we return undefined,
+ * so that subscriptions will be unwound by the useEffect hook that's using them.
+ *
+ * @internal
+ * @template Arguments - The type of arguments accepted by the callback function.
+ * @param callback - The callback function to be stored in the reference.
+ * @returns A static callback function that wraps the provided callback function, or undefined if no callback is provided.
+ */
+export const useEventListenerRef = <Arguments extends unknown[]>(
+  callback?: Callback<Arguments>,
+): Callback<Arguments> | undefined => {
+  const ref = useRef<Callback<Arguments> | undefined>(callback);
+  useEffect(() => {
+    ref.current = callback;
+  });
+
+  const returnVal = useCallback((...args: Arguments) => {
+    ref.current && ref.current(...args);
+  }, []);
+
+  return callback ? returnVal : undefined;
+};

--- a/src/react/hooks/use-messages.ts
+++ b/src/react/hooks/use-messages.ts
@@ -1,6 +1,7 @@
 import { MessageListener, Messages, MessageSubscriptionResponse, QueryOptions, SendMessageParams } from '@ably/chat';
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
+import { useEventListenerRef } from '../helper/use-event-listener-ref.js';
 import { ChatStatusResponse } from '../types/chat-status-response.js';
 import { Listenable } from '../types/listenable.js';
 import { StatusParams } from '../types/status-params.js';
@@ -73,11 +74,8 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
 
   // we are storing the params in a ref so that we don't end up with an infinite loop should the user pass
   // in an unstable reference
-  const paramsRef = useRef(params);
-
-  useLayoutEffect(() => {
-    paramsRef.current = params;
-  });
+  const listenerRef = useEventListenerRef(params?.listener);
+  const onDiscontinuityRef = useEventListenerRef(params?.onDiscontinuity);
 
   const send = useCallback((params: SendMessageParams) => room.messages.send(params), [room]);
   const get = useCallback((options: QueryOptions) => room.messages.get(options), [room]);
@@ -85,36 +83,34 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
   const [getPreviousMessages, setGetPreviousMessages] = useState<MessageSubscriptionResponse['getPreviousMessages']>();
 
   useEffect(() => {
-    if (paramsRef.current?.listener) {
-      logger.debug('useMessages(); applying listener', { roomId: room.roomId });
-      const sub = room.messages.subscribe(paramsRef.current.listener);
+    if (!listenerRef) return;
+    logger.debug('useMessages(); applying listener', { roomId: room.roomId });
+    const sub = room.messages.subscribe(listenerRef);
 
-      // set the getPreviousMessages method if a listener is provided
-      setGetPreviousMessages(() => {
-        logger.debug('useMessages(); setting getPreviousMessages state', { roomId: room.roomId });
-        return (params: Omit<QueryOptions, 'direction'>) => {
-          return sub.getPreviousMessages(params);
-        };
-      });
-
-      return () => {
-        logger.debug('useMessages(); removing listener and getPreviousMessages state', { roomId: room.roomId });
-        sub.unsubscribe();
-        setGetPreviousMessages(undefined);
+    // set the getPreviousMessages method if a listener is provided
+    setGetPreviousMessages(() => {
+      logger.debug('useMessages(); setting getPreviousMessages state', { roomId: room.roomId });
+      return (params: Omit<QueryOptions, 'direction'>) => {
+        return sub.getPreviousMessages(params);
       };
-    }
-  }, [room, logger]);
+    });
+
+    return () => {
+      logger.debug('useMessages(); removing listener and getPreviousMessages state', { roomId: room.roomId });
+      sub.unsubscribe();
+      setGetPreviousMessages(undefined);
+    };
+  }, [room, logger, listenerRef]);
 
   useEffect(() => {
-    if (paramsRef.current?.onDiscontinuity) {
-      logger.debug('useMessages(); applying onDiscontinuity listener', { roomId: room.roomId });
-      const { off } = room.messages.onDiscontinuity(paramsRef.current.onDiscontinuity);
-      return () => {
-        logger.debug('useMessages(); removing onDiscontinuity listener', { roomId: room.roomId });
-        off();
-      };
-    }
-  }, [room, logger]);
+    if (!onDiscontinuityRef) return;
+    logger.debug('useMessages(); applying onDiscontinuity listener', { roomId: room.roomId });
+    const { off } = room.messages.onDiscontinuity(onDiscontinuityRef);
+    return () => {
+      logger.debug('useMessages(); removing onDiscontinuity listener', { roomId: room.roomId });
+      off();
+    };
+  }, [room, logger, onDiscontinuityRef]);
 
   return {
     send,

--- a/src/react/hooks/use-presence-listener.ts
+++ b/src/react/hooks/use-presence-listener.ts
@@ -2,6 +2,7 @@ import { Presence, PresenceListener, PresenceMember } from '@ably/chat';
 import * as Ably from 'ably';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { useEventListenerRef } from '../helper/use-event-listener-ref.js';
 import { ChatStatusResponse } from '../types/chat-status-response.js';
 import { Listenable } from '../types/listenable.js';
 import { StatusParams } from '../types/status-params.js';
@@ -84,6 +85,10 @@ export const usePresenceListener = (params?: UsePresenceListenerParams): UsePres
   const errorRef = useRef<Ably.ErrorInfo | undefined>();
 
   const [error, setError] = useState<Ably.ErrorInfo | undefined>();
+
+  // create stable references for the listeners
+  const listenerRef = useEventListenerRef(params?.listener);
+  const onDiscontinuityRef = useEventListenerRef(params?.onDiscontinuity);
 
   const setErrorState = useCallback(
     (error: Ably.ErrorInfo) => {
@@ -218,27 +223,27 @@ export const usePresenceListener = (params?: UsePresenceListenerParams): UsePres
 
   // subscribe the user provided listener to presence changes
   useEffect(() => {
-    if (!params?.listener) return;
-    const { unsubscribe } = room.presence.subscribe(params.listener);
+    if (!listenerRef) return;
+    const { unsubscribe } = room.presence.subscribe(listenerRef);
     logger.debug('usePresenceListener(); applying external listener', { roomId: room.roomId });
 
     return () => {
       logger.debug('usePresenceListener(); cleaning up external listener', { roomId: room.roomId });
       unsubscribe();
     };
-  }, [room, params?.listener, logger]);
+  }, [room, listenerRef, logger]);
 
   // subscribe the user provided onDiscontinuity listener
   useEffect(() => {
-    if (!params?.onDiscontinuity) return;
+    if (!onDiscontinuityRef) return;
     logger.debug('usePresenceListener(); applying onDiscontinuity listener', { roomId: room.roomId });
-    const { off } = room.presence.onDiscontinuity(params.onDiscontinuity);
+    const { off } = room.presence.onDiscontinuity(onDiscontinuityRef);
 
     return () => {
       logger.debug('usePresenceListener(); removing onDiscontinuity listener', { roomId: room.roomId });
       off();
     };
-  }, [room, params?.onDiscontinuity, logger]);
+  }, [room, onDiscontinuityRef, logger]);
 
   return {
     connectionStatus,

--- a/src/react/types/status-params.ts
+++ b/src/react/types/status-params.ts
@@ -10,6 +10,9 @@ import * as Ably from 'ably';
  *
  * It's an alternative to {@link ChatStatusResponse} which provide this
  * information via a callback.
+ *
+ * Changing the value provided for each of the available listeners will cause the previously registered listener instance
+ * to stop receiving events. However, all message events will be received by exactly one listener.
  */
 export interface StatusParams {
   /**

--- a/test/react/helper/use-event-listener-ref.test.tsx
+++ b/test/react/helper/use-event-listener-ref.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useEventListenerRef } from '../../../src/react/helper/use-event-listener-ref.js';
+
+describe('useEventListenerRef', () => {
+  it('should update the callback as it changes', () => {
+    const originalCallback = vi.fn();
+    const { result, rerender } = renderHook(({ callback }) => useEventListenerRef(callback), {
+      initialProps: { callback: originalCallback },
+    });
+
+    const initialResult = result.current;
+
+    (result.current as (arg0: string, arg1: string) => void)('arg1', 'arg2');
+    expect(originalCallback).toHaveBeenCalledWith('arg1', 'arg2');
+
+    const newCallback = vi.fn();
+    rerender({ callback: newCallback });
+
+    (result.current as (arg0: string, arg1: string) => void)('arg3', 'arg4');
+    expect(newCallback).toHaveBeenCalledWith('arg3', 'arg4');
+    expect(originalCallback).lastCalledWith('arg1', 'arg2');
+
+    expect(result.current).toBe(initialResult);
+  });
+
+  it('should return undefined for undefined callbacks ', () => {
+    const { result } = renderHook(() => useEventListenerRef());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should return handle undefined callbacks becoming defined and undefined', () => {
+    const { result, rerender } = renderHook(
+      ({ callback }: { callback?: (arg0: string, arg1: string) => void }) => useEventListenerRef(callback),
+      { initialProps: {} },
+    );
+
+    // Callback starts as undefined
+    expect(result.current).toBeUndefined();
+
+    // Set a new callback, it should be called
+    const callback1: (arg0: string, arg1: string) => void = vi.fn();
+    rerender({ callback: callback1 });
+    (result.current as (arg0: string, arg1: string) => void)('arg1', 'arg2');
+    expect(callback1).toHaveBeenCalledWith('arg1', 'arg2');
+
+    // Store reference to initial callback
+    const initialCallback = result.current;
+
+    // Go back to undefined
+    rerender({ callback: undefined });
+    expect(result.current).toBeUndefined();
+
+    // Set a new callback, it should be called
+    const callback2: (arg0: string, arg1: string) => void = vi.fn();
+    rerender({ callback: callback2 });
+    (result.current as (arg0: string, arg1: string) => void)('arg3', 'arg4');
+    expect(callback2).toHaveBeenCalledWith('arg3', 'arg4');
+
+    // When we inspect the result, it should be the same as the initial result
+    console.log(result.current);
+    expect(result.current).toBe(initialCallback);
+  });
+});

--- a/test/react/hooks/use-messages.integration.test.tsx
+++ b/test/react/hooks/use-messages.integration.test.tsx
@@ -1,7 +1,7 @@
-import { ChatClient, Message, RoomLifecycle, RoomOptionsDefaults } from '@ably/chat';
+import { ChatClient, Message, MessageListener, RoomLifecycle, RoomOptionsDefaults } from '@ably/chat';
 import { render, waitFor } from '@testing-library/react';
 import React, { useEffect } from 'react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { useMessages } from '../../../src/react/hooks/use-messages.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
@@ -188,4 +188,239 @@ describe('useMessages', () => {
     expect(results.items.find((item) => item.text === 'I have the high ground')).toBeDefined();
     expect(results.items.find((item) => item.text === 'You underestimate my power')).toBeDefined();
   }, 10000);
+
+  it('should reset getPreviousMessages if the listener becomes undefined then redefined', async () => {
+    const chatClient = newChatClient() as unknown as ChatClient;
+
+    // create a second room instance so we can send messages from it
+    const roomId = randomRoomId();
+    const room = chatClient.rooms.get(roomId, RoomOptionsDefaults);
+    await room.attach();
+
+    let lastSeenMessageText: string | undefined;
+    room.messages.subscribe((message) => {
+      lastSeenMessageText = message.message.text;
+    });
+
+    // send a few messages before the first room has subscribed
+    await room.messages.send({ text: 'The force is strong with this one' });
+    await room.messages.send({ text: 'I have the high ground' });
+    await room.messages.send({ text: 'You underestimate my power' });
+
+    // Wait til we see the message text
+    await waitFor(
+      () => {
+        expect(lastSeenMessageText).toBe('You underestimate my power');
+      },
+      { timeout: 3000 },
+    );
+
+    let getPreviousMessages: ReturnType<typeof useMessages>['getPreviousMessages'] | undefined;
+
+    const TestComponent = ({ defineListener }: { defineListener: boolean }) => {
+      const { getPreviousMessages: previous } = useMessages({
+        listener: defineListener ? () => {} : undefined,
+      });
+
+      getPreviousMessages = previous;
+
+      return null;
+    };
+
+    const TestProvider = ({ defineListener }: { defineListener: boolean }) => (
+      <ChatClientProvider client={chatClient}>
+        <ChatRoomProvider
+          id={roomId}
+          options={RoomOptionsDefaults}
+        >
+          <TestComponent defineListener={defineListener} />
+        </ChatRoomProvider>
+      </ChatClientProvider>
+    );
+
+    const { rerender, unmount } = render(<TestProvider defineListener={true} />);
+
+    // Wait until the getPreviousMessages is defined
+    await waitFor(
+      () => {
+        expect(getPreviousMessages).toBeDefined();
+      },
+      { timeout: 3000 },
+    );
+
+    // Do a get previous messages call
+    if (!getPreviousMessages) {
+      expect.fail('getPreviousMessages was not defined');
+    }
+    const results = await getPreviousMessages({ limit: 3 });
+
+    // Check we get the expected messages
+    expect(results.items.length).toBe(3);
+    const messageTexts = results.items.map((item) => item.text);
+    expect(messageTexts[0]).toBe('You underestimate my power');
+    expect(messageTexts[1]).toBe('I have the high ground');
+    expect(messageTexts[2]).toBe('The force is strong with this one');
+
+    // Rerender the component with the listener undefined
+    rerender(<TestProvider defineListener={false} />);
+
+    // Wait until the getPreviousMessages is undefined
+    await waitFor(
+      () => {
+        expect(getPreviousMessages).toBeUndefined();
+      },
+      { timeout: 3000 },
+    );
+
+    // Now, send two more messages
+    await room.messages.send({ text: 'Tis but a scratch' });
+    await room.messages.send({ text: 'Time is an illusion. Lunchtime doubly so.' });
+
+    // Wait until we see the last message
+    await waitFor(
+      () => {
+        expect(lastSeenMessageText).toBe('Time is an illusion. Lunchtime doubly so.');
+      },
+      { timeout: 3000 },
+    );
+
+    // Rerender the component with the listener defined
+    rerender(<TestProvider defineListener={true} />);
+
+    // Wait until the getPreviousMessages is defined
+    await waitFor(
+      () => {
+        expect(getPreviousMessages).toBeDefined();
+      },
+      { timeout: 3000 },
+    );
+
+    // Check we get the expected messages
+    const results2 = await getPreviousMessages({ limit: 3 });
+    expect(results2.items.length).toBe(3);
+    const messageTexts2 = results2.items.map((item) => item.text);
+    expect(messageTexts2[0]).toBe('Time is an illusion. Lunchtime doubly so.');
+    expect(messageTexts2[1]).toBe('Tis but a scratch');
+    expect(messageTexts2[2]).toBe('You underestimate my power');
+
+    // Send one more message
+    await room.messages.send({ text: 'I am your father' });
+
+    // Wait until we see the last message
+    await waitFor(
+      () => {
+        expect(lastSeenMessageText).toBe('I am your father');
+      },
+      { timeout: 3000 },
+    );
+
+    // Do a get previous messages call, we should still get the same messages
+    const results3 = await getPreviousMessages({ limit: 3 });
+    expect(results3.items.length).toBe(3);
+    const messageTexts3 = results3.items.map((item) => item.text);
+    expect(messageTexts3[0]).toBe('Time is an illusion. Lunchtime doubly so.');
+    expect(messageTexts3[1]).toBe('Tis but a scratch');
+    expect(messageTexts3[2]).toBe('You underestimate my power');
+
+    // Unmount the component
+    unmount();
+  }, 20000);
+
+  it('should persist the getPreviousMessages subscription point across renders, if listener remains defined', async () => {
+    const chatClient = newChatClient() as unknown as ChatClient;
+
+    // create a second room instance so we can send messages from it
+    const roomId = randomRoomId();
+    const room = chatClient.rooms.get(roomId, RoomOptionsDefaults);
+    await room.attach();
+
+    let lastSeenMessageText: string | undefined;
+    room.messages.subscribe((message) => {
+      lastSeenMessageText = message.message.text;
+    });
+
+    // send a few messages before the first room has subscribed
+    await room.messages.send({ text: 'The force is strong with this one' });
+    await room.messages.send({ text: 'I have the high ground' });
+    await room.messages.send({ text: 'You underestimate my power' });
+
+    // Wait til we see the message text
+    await waitFor(
+      () => {
+        expect(lastSeenMessageText).toBe('You underestimate my power');
+      },
+      { timeout: 3000 },
+    );
+
+    let getPreviousMessages: ReturnType<typeof useMessages>['getPreviousMessages'] | undefined;
+
+    const TestComponent = ({ listener }: { listener: MessageListener }) => {
+      const { getPreviousMessages: previous } = useMessages({
+        listener,
+      });
+
+      getPreviousMessages = previous;
+
+      return null;
+    };
+
+    const TestProvider = ({ listener }: { listener: MessageListener }) => (
+      <ChatClientProvider client={chatClient}>
+        <ChatRoomProvider
+          id={roomId}
+          options={RoomOptionsDefaults}
+        >
+          <TestComponent listener={listener} />
+        </ChatRoomProvider>
+      </ChatClientProvider>
+    );
+
+    const { rerender, unmount } = render(<TestProvider listener={vi.fn()} />);
+
+    // Wait until the getPreviousMessages is defined
+    await waitFor(
+      () => {
+        expect(getPreviousMessages).toBeDefined();
+      },
+      { timeout: 3000 },
+    );
+
+    // Do a get previous messages call
+    if (!getPreviousMessages) {
+      expect.fail('getPreviousMessages was not defined');
+    }
+    const results = await getPreviousMessages({ limit: 3 });
+
+    // Check we get the expected messages
+    expect(results.items.length).toBe(3);
+    const messageTexts = results.items.map((item) => item.text);
+    expect(messageTexts[0]).toBe('You underestimate my power');
+    expect(messageTexts[1]).toBe('I have the high ground');
+    expect(messageTexts[2]).toBe('The force is strong with this one');
+
+    // Rerender the component with a new listener
+    rerender(<TestProvider listener={vi.fn()} />);
+
+    // Wait a few seconds to make sure the listener is redefined
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // Now, send two more messages
+    await room.messages.send({ text: 'Tis but a scratch' });
+    await room.messages.send({ text: 'Time is an illusion. Lunchtime doubly so.' });
+
+    // Wait 2 seconds to make sure all messages are received
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    const results2 = await getPreviousMessages({ limit: 3 });
+
+    // Check we get the expected messages
+    expect(results.items.length).toBe(3);
+    const messageTexts2 = results2.items.map((item) => item.text);
+    expect(messageTexts2[0]).toBe('You underestimate my power');
+    expect(messageTexts2[1]).toBe('I have the high ground');
+    expect(messageTexts2[2]).toBe('The force is strong with this one');
+
+    // Unmount the component
+    unmount();
+  }, 20000);
 });

--- a/test/react/hooks/use-room.test.tsx
+++ b/test/react/hooks/use-room.test.tsx
@@ -254,8 +254,6 @@ describe('useRoom', () => {
       { wrapper: WithClient },
     );
 
-    expect(room.status.onChange).toHaveBeenCalledWith(listener);
-
     act(() => {
       for (const l of listeners) l(expectedChange);
     });


### PR DESCRIPTION
### Context

N/A

### Description

A number of our hooks allow users to pass in their own listeners to be able to monitor events such as new messages or occupancy updates, even if the hook exposes the latest data.

At present, we use the listener param in a useEffect to apply listener subscriptions. This causes listener cycling if the hook is called using an inline listener, as the reference changes every time. This behaviour is not desired, as it may cause the subscriber to miss events.

This change fixes the issue by introducing a new internal hook, useEventListenerRef. This hook creates a stable reference to the passed in listener between re-renders. So whilst the underlying listener may change, we avoid cycling subscriptions on every render and thus potentially missing messages.

We also replace all instances of listener use in the other hooks with calls to this new hook, so that the listener passed in is maintained.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

On main, try the in-repo demo app using trace level logging. If you type something into the input, you'll see that the useRoomReactions listener unmounts and remounts.

On this branch, you'll see that no longer happens.
