### PR TITLE
react-hooks: Cleanup and fix hook tests.

### DIFF
--- a/test/react/hooks/use-chat-client.test.tsx
+++ b/test/react/hooks/use-chat-client.test.tsx
@@ -1,11 +1,12 @@
 import { ChatClient } from '@ably/chat';
-import { render } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { RealtimeWithOptions } from '../../../src/core/realtime-extensions.ts';
 import { VERSION } from '../../../src/core/version.ts';
 import { useChatClient } from '../../../src/react/hooks/use-chat-client.ts';
+import { useRoom } from '../../../src/react/hooks/use-room.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { newChatClient } from '../../helper/chat.ts';
 
@@ -18,11 +19,20 @@ const TestComponent: React.FC<{ callback: (client: ChatClient) => void }> = ({ c
 vi.mock('ably');
 
 describe('useChatClient', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it('should throw an error if used outside of ChatClientProvider', () => {
-    expect(() => render(<TestComponent callback={() => {}} />)).toThrowErrorInfo({
-      code: 40000,
-      message: 'useChatClient hook must be used within a chat client provider',
-    });
+    const TestThrowError: React.FC = () => {
+      expect(() => useRoom()).toThrowErrorInfo({
+        code: 40000,
+        message: 'useChatClient hook must be used within a chat client provider',
+      });
+      return null;
+    };
+
+    render(<TestThrowError />);
   });
 
   it('should get the chat client from the context without error and with the correct agent', () => {

--- a/test/react/hooks/use-chat-connection.test.tsx
+++ b/test/react/hooks/use-chat-connection.test.tsx
@@ -1,6 +1,6 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, cleanup, renderHook } from '@testing-library/react';
 import * as Ably from 'ably';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   ConnectionLifecycle,
@@ -51,6 +51,10 @@ describe('useChatConnection', () => {
   beforeEach(() => {
     mockCallbacks = [];
     mockChatClient = createMockChatClient(ConnectionLifecycle.Initialized);
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('should provide the initial state of the connection on render', () => {

--- a/test/react/hooks/use-messages.integration.test.tsx
+++ b/test/react/hooks/use-messages.integration.test.tsx
@@ -1,7 +1,7 @@
 import { ChatClient, Message, MessageListener, RoomLifecycle, RoomOptionsDefaults } from '@ably/chat';
-import { render, waitFor } from '@testing-library/react';
+import { cleanup, render, waitFor } from '@testing-library/react';
 import React, { useEffect } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { useMessages } from '../../../src/react/hooks/use-messages.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
@@ -25,6 +25,10 @@ function waitForMessages(messages: Message[], expectedCount: number) {
 }
 
 describe('useMessages', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it('should send messages correctly', async () => {
     // create new clients
     const chatClientOne = newChatClient() as unknown as ChatClient;
@@ -238,7 +242,7 @@ describe('useMessages', () => {
       </ChatClientProvider>
     );
 
-    const { rerender, unmount } = render(<TestProvider defineListener={true} />);
+    const { rerender } = render(<TestProvider defineListener={true} />);
 
     // Wait until the getPreviousMessages is defined
     await waitFor(
@@ -321,9 +325,6 @@ describe('useMessages', () => {
     expect(messageTexts3[0]).toBe('Time is an illusion. Lunchtime doubly so.');
     expect(messageTexts3[1]).toBe('Tis but a scratch');
     expect(messageTexts3[2]).toBe('You underestimate my power');
-
-    // Unmount the component
-    unmount();
   }, 20000);
 
   it('should persist the getPreviousMessages subscription point across renders, if listener remains defined', async () => {
@@ -375,7 +376,7 @@ describe('useMessages', () => {
       </ChatClientProvider>
     );
 
-    const { rerender, unmount } = render(<TestProvider listener={vi.fn()} />);
+    const { rerender } = render(<TestProvider listener={vi.fn()} />);
 
     // Wait until the getPreviousMessages is defined
     await waitFor(
@@ -419,8 +420,5 @@ describe('useMessages', () => {
     expect(messageTexts2[0]).toBe('You underestimate my power');
     expect(messageTexts2[1]).toBe('I have the high ground');
     expect(messageTexts2[2]).toBe('The force is strong with this one');
-
-    // Unmount the component
-    unmount();
   }, 20000);
 });

--- a/test/react/hooks/use-occupancy.integration.test.tsx
+++ b/test/react/hooks/use-occupancy.integration.test.tsx
@@ -1,8 +1,8 @@
 import { ChatClient, OccupancyEvent, OccupancyListener, RoomOptionsDefaults } from '@ably/chat';
-import { render } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 import { dequal } from 'dequal';
 import React from 'react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { useOccupancy } from '../../../src/react/hooks/use-occupancy.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
@@ -12,6 +12,10 @@ import { waitForExpectedInbandOccupancy } from '../../helper/common.ts';
 import { randomRoomId } from '../../helper/identifier.ts';
 
 describe('useOccupancy', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it(
     'should receive occupancy updates',
     async () => {

--- a/test/react/hooks/use-occupancy.test.tsx
+++ b/test/react/hooks/use-occupancy.test.tsx
@@ -6,9 +6,9 @@ import {
   Room,
   RoomLifecycle,
 } from '@ably/chat';
-import { act, renderHook } from '@testing-library/react';
+import { act, cleanup, renderHook } from '@testing-library/react';
 import * as Ably from 'ably';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useOccupancy } from '../../../src/react/hooks/use-occupancy.ts';
 import { makeTestLogger } from '../../helper/logger.ts';
@@ -38,6 +38,10 @@ describe('useOccupancy', () => {
     vi.resetAllMocks();
     mockLogger = makeTestLogger();
     mockRoom = makeRandomRoom({ options: { occupancy: true } });
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('should provide the occupancy instance, associated metrics, and chat status response metrics', () => {

--- a/test/react/hooks/use-presence-listener.integration.test.tsx
+++ b/test/react/hooks/use-presence-listener.integration.test.tsx
@@ -6,9 +6,9 @@ import {
   RoomLifecycle,
   RoomOptionsDefaults,
 } from '@ably/chat';
-import { render, waitFor } from '@testing-library/react';
+import { cleanup, render, waitFor } from '@testing-library/react';
 import React, { useEffect } from 'react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { usePresenceListener } from '../../../src/react/hooks/use-presence-listener.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
@@ -32,6 +32,10 @@ function waitForPresenceEvents(presenceEvents: PresenceEvent[], expectedCount: n
 }
 
 describe('usePresenceListener', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it('should correctly listen to presence events', async () => {
     // create new clients
     const chatClientOne = newChatClient() as unknown as ChatClient;
@@ -76,7 +80,7 @@ describe('usePresenceListener', () => {
       </ChatClientProvider>
     );
 
-    const { unmount } = render(<TestProvider />);
+    render(<TestProvider />);
 
     // ensure we are attached first
     await waitFor(
@@ -101,6 +105,5 @@ describe('usePresenceListener', () => {
     expect(currentPresenceData.length).toBe(1);
     expect(currentPresenceData[0]?.clientId).toBe(chatClientTwo.clientId);
     expect(currentPresenceData[0]?.data).toBe('test update');
-    unmount();
   }, 20000);
 });

--- a/test/react/hooks/use-presence-listener.test.tsx
+++ b/test/react/hooks/use-presence-listener.test.tsx
@@ -9,7 +9,7 @@ import {
   Room,
   RoomLifecycle,
 } from '@ably/chat';
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import * as Ably from 'ably';
 import { ErrorInfo } from 'ably';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -58,6 +58,7 @@ describe('usePresenceListener', () => {
   });
   afterEach(() => {
     vi.restoreAllMocks();
+    cleanup();
   });
 
   it('should provide the room presence instance, presence data and correct chat status response metrics', () => {
@@ -66,7 +67,7 @@ describe('usePresenceListener', () => {
     mockCurrentRoomStatus = RoomLifecycle.Attached;
     mockCurrentConnectionStatus = ConnectionLifecycle.Connected;
 
-    const { result, unmount } = renderHook(() => usePresenceListener());
+    const { result } = renderHook(() => usePresenceListener());
 
     // check that the room presence instance is correctly provided
     expect(result.current.presence).toBe(mockRoom.presence);
@@ -77,7 +78,6 @@ describe('usePresenceListener', () => {
     expect(result.current.roomError).toBe(mockRoomError);
     expect(result.current.connectionStatus).toEqual(ConnectionLifecycle.Connected);
     expect(result.current.connectionError).toBe(mockConnectionError);
-    unmount();
   });
 
   it('should correctly subscribe and unsubscribe to presence', () => {
@@ -113,7 +113,7 @@ describe('usePresenceListener', () => {
   });
 
   it('should handle rerender if the room instance changes', () => {
-    const { result, rerender, unmount } = renderHook(() => usePresenceListener());
+    const { result, rerender } = renderHook(() => usePresenceListener());
 
     // check the initial state of the presence object
     expect(result.current.presence).toBe(mockRoom.presence);
@@ -126,7 +126,6 @@ describe('usePresenceListener', () => {
 
     // check that the room presence instance is updated
     expect(result.current.presence).toBe(mockRoom.presence);
-    unmount();
   });
 
   it('should set the initial present clients on mount', async () => {
@@ -156,7 +155,7 @@ describe('usePresenceListener', () => {
     vi.spyOn(mockRoom.presence, 'get').mockResolvedValue(testPresenceMembers);
 
     // render the hook and check the initial state
-    const { result, unmount } = renderHook(() => usePresenceListener());
+    const { result } = renderHook(() => usePresenceListener());
 
     await waitFor(
       () => {
@@ -171,7 +170,6 @@ describe('usePresenceListener', () => {
 
     // check that the presence data is correctly set
     expect(result.current.presenceData).toEqual(testPresenceMembers);
-    unmount();
   });
 
   it('should set and return the error state when the call to get the initial presence data fails', async () => {
@@ -180,7 +178,7 @@ describe('usePresenceListener', () => {
     vi.spyOn(mockRoom.presence, 'subscribe');
 
     // render the hook
-    const { result, unmount } = renderHook(() => usePresenceListener());
+    const { result } = renderHook(() => usePresenceListener());
 
     // wait for the hook to finish mounting and set the error state
     await waitFor(
@@ -200,7 +198,6 @@ describe('usePresenceListener', () => {
       statusCode: 50000,
       code: 500,
     });
-    unmount();
   });
 
   it('should reset the current error state if a new presence event is received', async () => {
@@ -219,7 +216,7 @@ describe('usePresenceListener', () => {
     });
 
     // render the hook
-    const { result, unmount } = renderHook(() => usePresenceListener());
+    const { result } = renderHook(() => usePresenceListener());
 
     // wait for the hook to finish mounting and set the error state
     await waitFor(
@@ -255,7 +252,6 @@ describe('usePresenceListener', () => {
       },
       { timeout: 3000 },
     );
-    unmount();
   });
 
   it('should subscribe and unsubscribe to discontinuity events', () => {
@@ -297,7 +293,7 @@ describe('usePresenceListener', () => {
     vi.spyOn(mockRoom.presence, 'get').mockResolvedValue([]);
 
     // render the hook, this should trigger a useEffect call to subscribe to the presence events
-    const { result, unmount } = renderHook(() => usePresenceListener());
+    const { result } = renderHook(() => usePresenceListener());
 
     // wait for the hook to subscribe the listener
     await waitFor(() => {
@@ -353,7 +349,6 @@ describe('usePresenceListener', () => {
     // our returned data should be the presence member we received
     expect(result.current.presenceData[0]?.clientId).toEqual('client1');
     expect(result.current.presenceData[0]?.action).toEqual('enter');
-    unmount();
   }, 10000);
 
   it('should not return stale presence data even if they resolve out of order', async () => {
@@ -366,7 +361,7 @@ describe('usePresenceListener', () => {
     });
 
     // render the hook, this should trigger a useEffect call to subscribe to the presence events
-    const { result, rerender, unmount } = renderHook(() => usePresenceListener());
+    const { result, rerender } = renderHook(() => usePresenceListener());
 
     // wait for the hook to subscribe the listener
     await waitFor(() => {
@@ -462,6 +457,5 @@ describe('usePresenceListener', () => {
     // our returned data should be the second event we received
     expect(result.current.presenceData).toHaveLength(1);
     expect(result.current.presenceData[0]).toStrictEqual(testPresenceData2[0]);
-    unmount();
   }, 10000);
 });

--- a/test/react/hooks/use-room-reactions.integration.test.tsx
+++ b/test/react/hooks/use-room-reactions.integration.test.tsx
@@ -1,7 +1,7 @@
 import { ChatClient, Reaction, RoomLifecycle, RoomOptionsDefaults, RoomReactionListener } from '@ably/chat';
-import { render, waitFor } from '@testing-library/react';
+import { cleanup, render, waitFor } from '@testing-library/react';
 import React, { useEffect } from 'react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { useRoomReactions } from '../../../src/react/hooks/use-room-reactions.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
@@ -25,6 +25,10 @@ function waitForReactions(reactions: Reaction[], expectedCount: number) {
 }
 
 describe('useRoomReactions', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it('should send a room reaction', async () => {
     // create new clients
     const chatClientOne = newChatClient() as unknown as ChatClient;

--- a/test/react/hooks/use-room-reactions.test.tsx
+++ b/test/react/hooks/use-room-reactions.test.tsx
@@ -1,7 +1,7 @@
 import { ConnectionLifecycle, DiscontinuityListener, Room, RoomLifecycle, RoomReactionListener } from '@ably/chat';
-import { act, renderHook } from '@testing-library/react';
+import { act, cleanup, renderHook } from '@testing-library/react';
 import * as Ably from 'ably';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useRoomReactions } from '../../../src/react/hooks/use-room-reactions.ts';
 import { makeTestLogger } from '../../helper/logger.ts';
@@ -31,6 +31,10 @@ describe('useRoomReactions', () => {
     vi.resetAllMocks();
     mockLogger = makeTestLogger();
     mockRoom = makeRandomRoom({ options: { reactions: true } });
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('should provide the room reactions instance and correct chat status response metrics', () => {

--- a/test/react/hooks/use-typing.integration.test.tsx
+++ b/test/react/hooks/use-typing.integration.test.tsx
@@ -1,7 +1,7 @@
 import { ChatClient, RoomLifecycle, RoomOptionsDefaults, TypingEvent, TypingListener } from '@ably/chat';
-import { render } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 import React, { useEffect } from 'react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { useTyping } from '../../../src/react/hooks/use-typing.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
@@ -25,6 +25,10 @@ function waitForTypingEvents(typingEvents: TypingEvent[], expectedCount: number)
 }
 
 describe('useTyping', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it('should send typing events', async () => {
     // create new clients
     const chatClientOne = newChatClient() as unknown as ChatClient;

--- a/test/react/hooks/use-typing.test.tsx
+++ b/test/react/hooks/use-typing.test.tsx
@@ -1,7 +1,7 @@
 import { ConnectionLifecycle, DiscontinuityListener, Logger, Room, RoomLifecycle, TypingListener } from '@ably/chat';
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import * as Ably from 'ably';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useTyping } from '../../../src/react/hooks/use-typing.ts';
 import { makeTestLogger } from '../../helper/logger.ts';
@@ -31,6 +31,10 @@ describe('useTyping', () => {
     vi.resetAllMocks();
     mockRoom = makeRandomRoom({ options: { typing: { timeoutMs: 500 } } });
     mockLogger = makeTestLogger();
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('should provide the typing instance and chat status response metrics', () => {

--- a/test/react/providers/chat-client-provider.test.tsx
+++ b/test/react/providers/chat-client-provider.test.tsx
@@ -1,7 +1,7 @@
 import { ChatClient } from '@ably/chat';
-import { render } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 import React from 'react';
-import { describe, it, vi } from 'vitest';
+import { afterEach, describe, it, vi } from 'vitest';
 
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { newChatClient } from '../../helper/chat.ts';
@@ -9,6 +9,10 @@ import { newChatClient } from '../../helper/chat.ts';
 vi.mock('ably');
 
 describe('useChatClient', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it('should create a provider without error', () => {
     const chatClient = newChatClient() as unknown as ChatClient;
     const TestComponent = () => {

--- a/test/react/providers/room-provider.test.tsx
+++ b/test/react/providers/room-provider.test.tsx
@@ -1,7 +1,7 @@
 import { ChatClient, RoomOptionsDefaults } from '@ably/chat';
-import { render } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
@@ -11,6 +11,10 @@ import { randomRoomId } from '../../helper/identifier.ts';
 vi.mock('ably');
 
 describe('ChatRoomProvider', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it('should create a provider without error', () => {
     const chatClient = newChatClient() as unknown as ChatClient;
     const TestComponent = () => {


### PR DESCRIPTION
### Context

* Some of the tests were experiencing flaky failures, I believe this was in part due to not unmounting hooks correctly after each test. 
* It seems we also dumped expected throw error information to the console log, this was unnecessary and could be removed.
* A package that is no longer used had been left in the package-lock file.

### Description

* Removed the unused lodash package.
* Refactored the test case for `useChatClient` to use a dedicated `TestThrowError` component for throwing errors outside of `ChatClientProvider`. (`test/react/hooks/use-chat-client.test.tsx`)
* Added `cleanup` calls to ensure proper unmounting of components after each test case.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).
