### PR TITLE
demo: stop showing typing indicator for current user

### DIFF
--- a/demo/src/containers/Chat/Chat.tsx
+++ b/demo/src/containers/Chat/Chat.tsx
@@ -154,9 +154,11 @@ export const Chat = () => {
       )}
       {!typingError && (
         <div className="typing-indicator-container">
-          {new Array(...currentlyTyping).map((client) => (
-            <p key={client}>{client} is typing...</p>
-          ))}
+          {new Array(...currentlyTyping)
+            .filter((client) => client !== clientId)
+            .map((client) => (
+              <p key={client}>{client} is typing...</p>
+            ))}
         </div>
       )}
       <div className="border-t-2 border-gray-200 px-4 pt-4 mb-2 sm:mb-0">


### PR DESCRIPTION
### Context

The demo app shows typing indicator for the current user (yourself). This PR filters your own typing indicators out before displaying them.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] (Optional) Update documentation for new features.
* [ ] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

- Open two tabs.
- _Tip: change clientIds on both to something human-readable_
- Type something. You should now only see the other tab's typing indicator, not your own.