### PR TITLE
react: ensure we don't show old errors in typing indicators

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -15,7 +15,8 @@
     "Suspendable",
     "Failable",
     "livestreams",
-    "livestream"
+    "livestream",
+    "unsubscribable"
   ],
   "ignoreRegExpList": ["/.*@\\d{13}-/"],
   "flagWords": [

--- a/src/react/unsubscribable.ts
+++ b/src/react/unsubscribable.ts
@@ -1,0 +1,36 @@
+/**
+ * Utility function to make working with promises inside effects easier.
+ *
+ * It returns an object with a `unsubscribe` function and a callback wrapper
+ * function `cb`. `cb` should be used to wrap all callbacks passed to promises,
+ * either in `.then()`, `.catch()`, or `.finally()` if you do not want your
+ * code inside the callback to be run after `unsubscribe()` was called.
+ *
+ * Example usage inside an effect:
+ * ```
+ * useEffect(() => {
+ *   const { unsubscribe, cb } = unsubscribable();
+ *   somePromise.then(cb((value) => {
+ *     console.log("never prints if unsubscribe is called");
+ *   }));
+ *   return () => { unsubscribe(); }
+ * });
+ * ```
+ *
+ * @returns An object with an `unsubscribe` function and a callback wrapper `cb`.
+ */
+export function unsubscribable() {
+  let subscribed = true;
+  const unsubscribe = () => {
+    subscribed = false;
+  };
+  function callbackWrapper<Arguments extends unknown[], Return>(callback: (...args: Arguments) => Return) {
+    if (subscribed) {
+      return callback;
+    }
+  }
+  return {
+    unsubscribe,
+    cb: callbackWrapper,
+  };
+}

--- a/test/react/hooks/use-typing.test.tsx
+++ b/test/react/hooks/use-typing.test.tsx
@@ -54,6 +54,7 @@ describe('useTyping', () => {
     const mockTyping = {
       ...mockRoom.typing,
       subscribe: vi.fn().mockReturnValue({ unsubscribe: mockUnsubscribe }),
+      get: mockRoom.typing.get,
     };
 
     // update the mock room with the new typing object

--- a/test/react/unsubscribable.test.ts
+++ b/test/react/unsubscribable.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { unsubscribable } from '../../src/react/unsubscribable.ts';
+
+describe('unsubscribable', () => {
+  it('should call the callback after wrapper was called and correctly pass argumnets', () => {
+    const f = vi.fn((a: number, b: string, c: string | undefined, d: boolean, e: boolean, g: number) => {
+      return g * 2;
+    });
+    const { cb } = unsubscribable();
+    const wrapped = cb(f);
+
+    expect(wrapped).toBeDefined(); // fail if not defined
+    if (!wrapped) return; // please linter
+
+    expect(wrapped(1, '2', undefined, true, false, 6)).toBe(12);
+    expect(f).toHaveBeenCalledWith(1, '2', undefined, true, false, 6);
+    expect(f).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call the callback after unsubscribe even after you call wrapper', () => {
+    const f = vi.fn();
+    const { unsubscribe, cb } = unsubscribable();
+    const wrapped = cb(f);
+    unsubscribe();
+
+    expect(wrapped).toBeDefined(); // fail if not defined
+    if (!wrapped) return; // please linter
+
+    wrapped();
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it('should not call the callback when you unsubscribe before wrapping and after calling wrap', () => {
+    const f = vi.fn();
+    const { unsubscribe, cb } = unsubscribable();
+    unsubscribe();
+    const wrapped = cb(f);
+
+    expect(wrapped).toBeDefined(); // fail if not defined
+    if (!wrapped) return; // please linter
+
+    wrapped();
+    expect(f).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Context

I've noticed that this error was shown briefly when loading the demo app and started digging:

![Error that flashes when loading demo app](https://github.com/user-attachments/assets/10d27f49-5f5f-4043-8424-79d4d7f3fb90)

This only happens when you are still waiting for something from a room that's been released, which means we update an old state. The room is only released when a parent component of what we see there (ChatRoomProvider) is unmounted.

This PR adds a new convenience function `unsubscribablePromise` to make it easy to ensure old promises don't settle. IT also clears old errors when the effect runs.

The old version of this code was also not registering the unsubscribe from the hook correctly.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [ ] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [ ] (Optional) Update documentation for new features.
* [ ] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

Open demo app - enjoy the absence of the flashing error.