### PR TITLE
react: ensure we don't show old errors in typing indicators

### DIFF
--- a/test/react/hooks/use-typing.test.tsx
+++ b/test/react/hooks/use-typing.test.tsx
@@ -63,6 +63,7 @@ describe('useTyping', () => {
         return { unsubscribe: mockUnsubscribe };
       }),
       onDiscontinuity: vi.fn().mockReturnValue({ off: vi.fn() }),
+      get: mockRoom.typing.get,
     };
 
     // update the mock room with the new typing object


### PR DESCRIPTION
### Context

I've noticed that this error was shown briefly when loading the demo app and started digging:

![Error that flashes when loading demo app](https://github.com/user-attachments/assets/10d27f49-5f5f-4043-8424-79d4d7f3fb90)

This only happens when you are still waiting for something from a room that's been released, which means we update an old state. The room is only released when a parent component of what we see there (ChatRoomProvider) is unmounted.

The existing version of this code was also not setting the unsubscribe from the hook correctly.

This version uses a simple `mounted` variable to address the problem. Commits in a [previous PR #342] (https://github.com/ably/ably-chat-js/pull/342) attempted 2 different approaches but both turned out be more trouble than worth.


### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [ ] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [ ] (Optional) Update documentation for new features.
* [ ] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

Open demo app - enjoy the absence of the flashing error.