### PR TITLE
deps: remove dependency on structuredClone

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -110,11 +110,16 @@ module.exports = {
     // For everything React, use additional rules and plugins
     {
       files: ['src/react/**/*.{ts,tsx}'],
-      extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
-      plugins: ['react', 'react-hooks'],
+      extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended', 'plugin:react-native/all'],
+      plugins: ['react', 'react-hooks', 'react-native'],
       settings: {
         react: {
           version: 'detect',
+        },
+      },
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
         },
       },
     },

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ This SDK supports the following platforms:
 
 **React Native** We aim to support all platforms supported by React Native. If you find any issues please raise an issue or contact us.
 
-There is a known caveat in the current version of the library in environments where `structuredClone` is not defined. To address this, you can use a polyfill such as [@ungap/structured-clone](https://www.npmjs.com/package/@ungap/structured-clone).
-
 ## Supported chat features
 
 This project is under development so we will be incrementally adding new features. At this stage, you'll find APIs for the following chat features:

--- a/cspell.json
+++ b/cspell.json
@@ -16,7 +16,7 @@
     "Failable",
     "livestreams",
     "livestream",
-    "ungap"
+    "clonedeep"
   ],
   "ignoreRegExpList": ["/.*@\\d{13}-/"],
   "flagWords": ["cancelled"]

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -38,11 +38,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "async-mutex": "^0.5.0",
-        "dequal": "^2.0.3"
+        "dequal": "^2.0.3",
+        "lodash.clonedeep": "^4.5.0"
       },
       "devDependencies": {
         "@testing-library/react": "^16.0.0",
         "@types/jsonwebtoken": "^9.0.6",
+        "@types/lodash.clonedeep": "^4.5.9",
         "@types/react": "^18.3.3",
         "@typescript-eslint/eslint-plugin": "^7.14.1",
         "@typescript-eslint/parser": "^7.14.1",
@@ -56,6 +58,7 @@
         "eslint-plugin-jsdoc": "^48.5.0",
         "eslint-plugin-react": "^7.34.3",
         "eslint-plugin-react-hooks": "^4.6.2",
+        "eslint-plugin-react-native": "^4.1.0",
         "eslint-plugin-react-refresh": "^0.4.7",
         "eslint-plugin-security": "^3.0.1",
         "eslint-plugin-simple-import-sort": "^12.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "async-mutex": "^0.5.0",
-        "dequal": "^2.0.3"
+        "dequal": "^2.0.3",
+        "lodash.clonedeep": "^4.5.0"
       },
       "devDependencies": {
         "@testing-library/react": "^16.0.0",
         "@types/jsonwebtoken": "^9.0.6",
+        "@types/lodash.clonedeep": "^4.5.9",
         "@types/react": "^18.3.3",
         "@typescript-eslint/eslint-plugin": "^7.14.1",
         "@typescript-eslint/parser": "^7.14.1",
@@ -28,6 +30,7 @@
         "eslint-plugin-jsdoc": "^48.5.0",
         "eslint-plugin-react": "^7.34.3",
         "eslint-plugin-react-hooks": "^4.6.2",
+        "eslint-plugin-react-native": "^4.1.0",
         "eslint-plugin-react-refresh": "^0.4.7",
         "eslint-plugin-security": "^3.0.1",
         "eslint-plugin-simple-import-sort": "^12.1.0",
@@ -2003,6 +2006,21 @@
       "peer": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
+      "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.clonedeep": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.9.tgz",
+      "integrity": "sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
       }
     },
     "node_modules/@types/node": {
@@ -4388,6 +4406,24 @@
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
+    "node_modules/eslint-plugin-react-native": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-native/-/eslint-plugin-react-native-4.1.0.tgz",
+      "integrity": "sha512-QLo7rzTBOl43FvVqDdq5Ql9IoElIuTdjrz9SKAXCvULvBoRZ44JGSkx9z4999ZusCsb4rK3gjS8gOGyeYqZv2Q==",
+      "dev": true,
+      "dependencies": {
+        "eslint-plugin-react-native-globals": "^0.1.1"
+      },
+      "peerDependencies": {
+        "eslint": "^3.17.0 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-native-globals": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-native-globals/-/eslint-plugin-react-native-globals-0.1.2.tgz",
+      "integrity": "sha512-9aEPf1JEpiTjcFAmmyw8eiIXmcNZOqaZyHO77wgm0/dWfT/oxC1SrIq8ET38pMxHYrcB6Uew+TzUVsBeczF88g==",
+      "dev": true
+    },
     "node_modules/eslint-plugin-react-refresh": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.7.tgz",
@@ -6333,8 +6369,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@testing-library/react": "^16.0.0",
     "@types/jsonwebtoken": "^9.0.6",
+    "@types/lodash.clonedeep": "^4.5.9",
     "@types/react": "^18.3.3",
     "@typescript-eslint/eslint-plugin": "^7.14.1",
     "@typescript-eslint/parser": "^7.14.1",
@@ -80,6 +81,7 @@
     "eslint-plugin-jsdoc": "^48.5.0",
     "eslint-plugin-react": "^7.34.3",
     "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-native": "^4.1.0",
     "eslint-plugin-react-refresh": "^0.4.7",
     "eslint-plugin-security": "^3.0.1",
     "eslint-plugin-simple-import-sort": "^12.1.0",
@@ -99,7 +101,8 @@
   },
   "dependencies": {
     "async-mutex": "^0.5.0",
-    "dequal": "^2.0.3"
+    "dequal": "^2.0.3",
+    "lodash.clonedeep": "^4.5.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-darwin-arm64": "^4.18",

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -1,4 +1,5 @@
 import * as Ably from 'ably';
+import cloneDeep from 'lodash.clonedeep';
 
 import { ChatApi } from './chat-api.js';
 import { Logger } from './logger.js';
@@ -370,7 +371,7 @@ export class DefaultRoom implements Room {
    * @inheritDoc Room
    */
   options(): RoomOptions {
-    return structuredClone(this._options);
+    return cloneDeep(this._options);
   }
 
   /**


### PR DESCRIPTION
### Context

[CHA-494]

### Description

This method is not available in React Native runtimes, so replace it with the `lodash.cloneDeep` function instead, which is entirely self-contained.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A


[CHA-494]: https://ably.atlassian.net/browse/CHA-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ