### PR TITLE
docs: add react section on room option memoization

### DIFF
--- a/src/react/README.md
+++ b/src/react/README.md
@@ -144,6 +144,7 @@ const App = () => {
     <ChatClientProvider client={chatClient}>
       <ChatRoomProvider
         id="my-room-id"
+        // The value passed to options should be memoized, or use the defaults.
         options={RoomOptionsDefaults}
       >
         <RestOfYourApp />
@@ -154,6 +155,9 @@ const App = () => {
 ```
 
 By default, the `ChatRoomProvider` will automatically call `attach()` on the room when it first mounts, and will subsequently call `release()` when it unmounts. If you do not wish for this behavior, you may set the `attach` parameter to `false`, which will allow you to manually control the attachment via the `useRoom` hook (see below). You may also inhibit the `release` behavior, to simply only `detach` the room when the component unmounts.
+
+> [!IMPORTANT]
+> The `ChatClientProvider` does **not** memoize the value passed in to the `options` parameter. If the value changes between re-renders, then the chat room will be discarded and recreated with the new options. To prevent a parent component re-render causing the `ChatRoomProvider` to re-render, be sure to memoize / provide a stable reference to, your desired room options.
 
 To use the room-level hooks below, you **must** wrap any components utilizing the hooks inside a `ChatRoomProvider`.
 

--- a/src/react/providers/chat-room-provider.tsx
+++ b/src/react/providers/chat-room-provider.tsx
@@ -26,6 +26,9 @@ export interface ChatRoomProviderProps {
    *   reactions: RoomOptionsDefaults.reactions,
    * }} />
    * ```
+   *
+   * NOTE: This value is not memoized by the provider. It must be memoized in your component to prevent
+   * re-renders of a parent component from causing the room to be recreated.
    */
   options: RoomOptions;
 


### PR DESCRIPTION
### Context

N/A

### Description

This change adds information about memoizing the room options passed to the `ChatRoomProvider` in React.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A
