### PR TITLE
React unhandled rejection errors

### DIFF
--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,3 +1,5 @@
+import * as Ably from 'ably';
+
 /**
  * Error codes for the Chat SDK.
  */
@@ -86,3 +88,13 @@ export enum ErrorCodes {
    */
   RoomLifecycleError = 102105,
 }
+
+/**
+ * Returns true if the {@link Ably.ErrorInfo} code matches the provided ErrorCodes value.
+ *
+ * @param errorInfo The error info to check.
+ * @param error The error code to compare against.
+ * @returns true if the error code matches, false otherwise.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+export const errorInfoIs = (errorInfo: Ably.ErrorInfo, error: ErrorCodes): boolean => errorInfo.code === error;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -13,7 +13,7 @@ export type {
 } from './connection-status.js';
 export { ConnectionLifecycle } from './connection-status.js';
 export type { DiscontinuityListener, OnDiscontinuitySubscriptionResponse } from './discontinuity.js';
-export type { ErrorCodes } from './errors.js';
+export { ErrorCodes, errorInfoIs } from './errors.js';
 export { MessageEvents, PresenceEvents } from './events.js';
 export type { Headers } from './headers.js';
 export {

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -482,7 +482,16 @@ export class DefaultMessages
     super.on([MessageEvents.Created], listener);
 
     // Set the subscription point to a promise that resolves when the channel attaches or with the latest message
-    this._listenerSubscriptionPoints.set(listener, this._resolveSubscriptionStart());
+    const resolvedSubscriptionStart = this._resolveSubscriptionStart();
+
+    // Add a handler for unhandled rejections incase the room is released before the subscription point is resolved
+    resolvedSubscriptionStart.catch(() => {
+      this._logger.debug('Messages.subscribe(); subscription point was not resolved before the room was released', {
+        roomId: this._roomId,
+      });
+    });
+
+    this._listenerSubscriptionPoints.set(listener, resolvedSubscriptionStart);
 
     return {
       unsubscribe: () => {

--- a/src/react/hooks/use-presence-listener.ts
+++ b/src/react/hooks/use-presence-listener.ts
@@ -1,4 +1,4 @@
-import { Presence, PresenceListener, PresenceMember } from '@ably/chat';
+import { ErrorCodes, errorInfoIs, Presence, PresenceListener, PresenceMember } from '@ably/chat';
 import * as Ably from 'ably';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -201,8 +201,14 @@ export const usePresenceListener = (params?: UsePresenceListenerParams): UsePres
         clearErrorState();
       })
       .catch((error: unknown) => {
-        logger.error('usePresenceListener(); error fetching initial presence data', { error, roomId: room.roomId });
-        setErrorState(error as Ably.ErrorInfo);
+        const errorInfo = error as Ably.ErrorInfo;
+        if (errorInfoIs(errorInfo, ErrorCodes.RoomIsReleased)) return;
+
+        logger.error('usePresenceListener(); error fetching initial presence data', {
+          error,
+          roomId: room.roomId,
+        });
+        setErrorState(errorInfo);
       })
       .finally(() => {
         // subscribe to presence events

--- a/src/react/hooks/use-typing.ts
+++ b/src/react/hooks/use-typing.ts
@@ -1,4 +1,4 @@
-import { Typing, TypingEvent, TypingListener } from '@ably/chat';
+import { ErrorCodes, errorInfoIs, Typing, TypingEvent, TypingListener } from '@ably/chat';
 import * as Ably from 'ably';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -103,8 +103,10 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
         setCurrentlyTyping(currentlyTyping);
       })
       .catch((error: unknown) => {
-        if (!mounted) return;
-        setErrorState(error as Ably.ErrorInfo);
+        const errorInfo = error as Ably.ErrorInfo;
+        if (!mounted || errorInfoIs(errorInfo, ErrorCodes.RoomIsReleased)) return;
+
+        setErrorState(errorInfo);
       });
 
     const subscription = room.typing.subscribe((event) => {

--- a/src/react/providers/chat-room-provider.tsx
+++ b/src/react/providers/chat-room-provider.tsx
@@ -96,17 +96,20 @@ export const ChatRoomProvider: React.FC<ChatRoomProviderProps> = ({
       // attachment error and/or room status is available via useRoom
       // or room.status, no need to do anything with the promise here
       logger.debug(`ChatRoomProvider(); attaching room`, { roomId });
-      void room.attach();
+      void room.attach().catch(() => {
+        // Ignore, the error will be available via various room status properties
+      });
     }
     return () => {
       // Releasing the room will implicitly detach if needed.
-
       if (release) {
         logger.debug(`ChatRoomProvider(); releasing room`, { roomId });
         void client.rooms.release(roomId);
       } else if (attach) {
         logger.debug(`ChatRoomProvider(); detaching room`, { roomId });
-        void room.detach();
+        void room.detach().catch(() => {
+          // Ignore, the error will be available via various room status properties
+        });
       }
     };
   }, [client, roomId, options, release, attach, logger]);

--- a/test/core/messages.integration.test.ts
+++ b/test/core/messages.integration.test.ts
@@ -4,9 +4,11 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { ChatClient } from '../../src/core/chat.ts';
 import { Message } from '../../src/core/message.ts';
 import { RealtimeChannelWithOptions } from '../../src/core/realtime-extensions.ts';
+import { RoomOptionsDefaults } from '../../src/core/room-options.ts';
 import { RoomLifecycle } from '../../src/core/room-status.ts';
 import { CHANNEL_OPTIONS_AGENT_STRING } from '../../src/core/version.ts';
 import { newChatClient } from '../helper/chat.ts';
+import { randomRoomId } from '../helper/identifier.ts';
 import { getRandomRoom, waitForRoomStatus } from '../helper/room.ts';
 
 interface TestContext {
@@ -440,5 +442,20 @@ describe('messages integration', () => {
 
     // Calling off again should be a no-op
     off();
+  });
+
+  it<TestContext>('handles the room being released before getPreviousMessages is called', async (context) => {
+    const chat = context.chat;
+    const roomId = randomRoomId();
+    const room = chat.rooms.get(roomId, RoomOptionsDefaults);
+
+    // Create a subscription to messages
+    room.messages.subscribe(() => {});
+
+    // Now release the room
+    // We should not have any unhanded promise rejections
+    // Note that an unhandled rejection will not cause the test to fail, but it will cause the process to exit
+    // with a non-zero exit code.
+    await chat.rooms.release(roomId);
   });
 });

--- a/test/core/room.test.ts
+++ b/test/core/room.test.ts
@@ -514,4 +514,13 @@ describe('Room', () => {
     expect(attached).toBe(false);
     expect(attachedError).toBe(true);
   });
+
+  it<TestContext>('can be released immediately without unhandled rejections', async (context) => {
+    const room = context.getRoom(defaultRoomOptions);
+
+    // Release the room
+    // Note that an unhandled rejection will not cause the test to fail, but it will cause the process to exit
+    // with a non-zero exit code.
+    await (room as DefaultRoom).release();
+  });
 });

--- a/test/core/room.test.ts
+++ b/test/core/room.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { messagesChannelName } from '../../src/core/channel.ts';
 import { ChatApi } from '../../src/core/chat-api.ts';
+import { ErrorCodes } from '../../src/core/errors.ts';
 import { DefaultRoom, Room } from '../../src/core/room.ts';
 import { RoomLifecycleManager } from '../../src/core/room-lifecycle-manager.ts';
 import { RoomOptions, RoomOptionsDefaults } from '../../src/core/room-options.ts';
@@ -292,7 +293,7 @@ describe('Room', () => {
     expect(releasePromise === initAfter).toBe(true);
 
     expect(context.realtime.channels.get).not.toHaveBeenCalled();
-    await expect(initStatus).rejects.toBeErrorInfoWithCode(40000);
+    await expect(initStatus).rejects.toBeErrorInfoWithCode(ErrorCodes.RoomIsReleased);
     expect(room.status.current).toBe(RoomLifecycle.Released);
   });
 


### PR DESCRIPTION
### Context

Fixes #350 

### Description

- Adds a promise rejection handler in ChatRoomProvider to handle unhandled rejections (due to initialization skips)
- Adds a promise rejection handler for getPreviousMessages if the room is released before initialization
- Changes the room release before initialization to use an appropriate error code
- Avoid error logging in usePresenceListener and useTyping if room is released

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

Open demo app, refresh many times - notice there are no errors (compare to main).
