### PR TITLE
chat-core: decrease timeout of the stopTyping timer

### DIFF
--- a/src/core/room-options.ts
+++ b/src/core/room-options.ts
@@ -26,7 +26,7 @@ export const RoomOptionsDefaults = {
     /**
      * The default timeout for typing events in milliseconds.
      */
-    timeoutMs: 10000,
+    timeoutMs: 5000,
   } as TypingOptions,
 
   /**
@@ -68,7 +68,7 @@ export interface TypingOptions {
   /**
    * The timeout for typing events in milliseconds. If typing.start() is not called for this amount of time, a stop
    * typing event will be fired, resulting in the user being removed from the currently typing set.
-   * @defaultValue 10000
+   * @defaultValue 5000
    */
   timeoutMs: number;
 }

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -340,6 +340,9 @@ nearest `ChatRoomProvider`.
 You can also be supply an optional listener that will receive the underlying typing events,
 or use the state object returned by the hook to access the current list of clients currently typing.
 
+**The default timeout on the typing indicator can be configured in the `options` parameter you provided
+to the `ChatRoomProvider`.**
+
 ```tsx
 import { useTyping } from '@ably/chat/react';
 
@@ -351,6 +354,7 @@ const MyComponent = () => {
   });
 
   const handleStartClick = () => {
+    // calling starts a timer that will automatically call stop() after a pre defined time
     start();
   };
 


### PR DESCRIPTION
### Context

* After going through the new examples of chat in the Ably Docs, I noticed the timeout time for typing indicators seems really long for a default. It would probably confuse devs (I had to check as I thought it was set to 5 seconds) that they need to manually call `stop()`. 

### Description

* Decreased the default timeout to 5 seconds, which I think is much more reasonable.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

* Explain how to test the changes in this PR.
* Provide specific steps or commands to execute.
