### PR TITLE
materialization: add fields to support deletion and edits in chat.

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@ably/chat": "file:..",
-        "ably": "^2.4.1",
+        "ably": "^2.5.0",
         "clsx": "^2.1.1",
         "nanoid": "^5.0.7",
         "react": "^18.3.1",
@@ -84,7 +84,7 @@
         "@rollup/rollup-linux-x64-gnu": "^4.18"
       },
       "peerDependencies": {
-        "ably": "^2.3.1"
+        "ably": "^2.5.0"
       }
     },
     "node_modules/@ably/chat": {
@@ -1697,9 +1697,10 @@
       }
     },
     "node_modules/ably": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/ably/-/ably-2.4.1.tgz",
-      "integrity": "sha512-0zGqjPBdDMcnMPG+f0/N0d6BN92XAIo7o/PtLTR2cY0y8Q1fPPtCfb74Eib6q2VCoe4HfutSAbdl+OQp4WDSTQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ably/-/ably-2.5.0.tgz",
+      "integrity": "sha512-PgZk1gDO7K5p5QbTGAV6n2un6otbu91J8n+2Bv/sCoNmfFqyAtQFnj/dWpcJTC3kwbxX/E3kimZAgnSXeNG8dg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",
         "fastestsmallesttextencoderdecoder": "^1.0.22",

--- a/demo/package.json
+++ b/demo/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@ably/chat": "file:..",
-    "ably": "^2.4.1",
+    "ably": "^2.5.0",
     "clsx": "^2.1.1",
     "nanoid": "^5.0.7",
     "react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "@rollup/rollup-linux-x64-gnu": "^4.18"
       },
       "peerDependencies": {
-        "ably": "^2.3.1"
+        "ably": "^2.5.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2720,9 +2720,10 @@
       "dev": true
     },
     "node_modules/ably": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/ably/-/ably-2.3.1.tgz",
-      "integrity": "sha512-OQ9PUwQe0qehOUPqvLargmUTlPQsxCAdStIpLZE7pT68yDd3JF28R1Ap7C50DluCIa6NqXrieRSa2tcLNN95PA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ably/-/ably-2.5.0.tgz",
+      "integrity": "sha512-PgZk1gDO7K5p5QbTGAV6n2un6otbu91J8n+2Bv/sCoNmfFqyAtQFnj/dWpcJTC3kwbxX/E3kimZAgnSXeNG8dg==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "homepage": "https://github.com/ably/ably-chat-js#readme",
   "peerDependencies": {
-    "ably": "^2.3.1"
+    "ably": "^2.5.0"
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.0",

--- a/src/core/action-metadata.ts
+++ b/src/core/action-metadata.ts
@@ -1,0 +1,10 @@
+/**
+ * The type for metadata contained in the latestActionDetails field of a chat message.
+ * This is a key-value pair where the key is a string, and the value is a string, it represents the metadata supplied
+ * to a message update or deletion request.
+ *
+ * Do not use metadata for authoritative information. There is no server-side
+ * validation. When reading the metadata, treat it like user input.
+ *
+ */
+export type ActionMetadata = Record<string, string>;

--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -45,7 +45,7 @@ export class ChatApi {
   }
 
   async getMessages(roomId: string, params: GetMessagesQueryParams): Promise<PaginatedResult<Message>> {
-    return this._makeAuthorizedPaginatedRequest<Message>(`/chat/v1/rooms/${roomId}/messages`, params).then((data) => {
+    return this._makeAuthorizedPaginatedRequest<Message>(`/chat/v2/rooms/${roomId}/messages`, params).then((data) => {
       data.items = data.items.map((message) => {
         const metadata = message.metadata as MessageMetadata | undefined;
         const headers = message.headers as MessageHeaders | undefined;
@@ -57,6 +57,11 @@ export class ChatApi {
           new Date(message.createdAt),
           metadata ?? {},
           headers ?? {},
+          message.latestAction,
+          message.latestActionSerial,
+          message.deletedAt ? new Date(message.deletedAt) : undefined,
+          message.updatedAt ? new Date(message.updatedAt) : undefined,
+          message.latestActionDetails,
         );
       });
       return data;
@@ -76,7 +81,7 @@ export class ChatApi {
       body.headers = params.headers;
     }
 
-    return this._makeAuthorizedRequest<CreateMessageResponse>(`/chat/v1/rooms/${roomId}/messages`, 'POST', body);
+    return this._makeAuthorizedRequest<CreateMessageResponse>(`/chat/v2/rooms/${roomId}/messages`, 'POST', body);
   }
 
   async getOccupancy(roomId: string): Promise<OccupancyEvent> {

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -4,6 +4,46 @@
 export enum MessageEvents {
   /** Fires when a new chat message is received. */
   Created = 'message.created',
+
+  /** Fires when a chat message is updated. */
+  Updated = 'message.updated',
+
+  /** Fires when a chat message is deleted. */
+  Deleted = 'message.deleted',
+}
+
+/**
+ * Realtime chat message names.
+ */
+export enum RealtimeMessageNames {
+  /** Represents a regular chat message. */
+  ChatMessage = 'chat.message',
+}
+
+/**
+ * Chat Message Actions.
+ */
+export enum ChatMessageActions {
+  /** Represents a message with no action set. */
+  MessageUnset = 'message.unset',
+
+  /** Action applied to a new message. */
+  MessageCreate = 'message.create',
+
+  /** Action applied to an updated message. */
+  MessageUpdate = 'message.update',
+
+  /** Action applied to a deleted message. */
+  MessageDelete = 'message.delete',
+
+  /** Action applied to a new annotation. */
+  MessageAnnotationCreate = 'annotation.create',
+
+  /** Action applied to a deleted annotation. */
+  MessageAnnotationUpdate = 'annotation.delete',
+
+  /** Action applied to a meta occupancy message. */
+  MessageMetaOccupancy = 'meta.occupancy',
 }
 
 /**

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -1,6 +1,6 @@
 import * as Ably from 'ably';
 
-import { MessageEvents, RoomReactionEvents } from './events.js';
+import { RealtimeMessageNames, RoomReactionEvents } from './events.js';
 import { Message } from './message.js';
 import { parseMessage } from './message-parser.js';
 import { Reaction } from './reaction.js';
@@ -89,7 +89,7 @@ export async function reactionFromEncoded(encoded: unknown): Promise<Reaction> {
  */
 export function getEntityTypeFromAblyMessage(message: Ably.InboundMessage): ChatEntityType {
   switch (message.name) {
-    case MessageEvents.Created: {
+    case RealtimeMessageNames.ChatMessage: {
       return ChatEntityType.ChatMessage;
     }
     case RoomReactionEvents.Reaction: {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -2,6 +2,7 @@
  * @module chat-js
  */
 
+export type { ActionMetadata } from './action-metadata.js';
 export { ChatClient } from './chat.js';
 export type { ClientOptions } from './config.js';
 export type {
@@ -13,7 +14,7 @@ export type {
 export { ConnectionStatus } from './connection.js';
 export type { DiscontinuityListener, OnDiscontinuitySubscriptionResponse } from './discontinuity.js';
 export { ErrorCodes, errorInfoIs } from './errors.js';
-export { MessageEvents, PresenceEvents } from './events.js';
+export { ChatMessageActions, MessageEvents, PresenceEvents } from './events.js';
 export type { Headers } from './headers.js';
 export {
   ChatEntityType,
@@ -26,7 +27,7 @@ export {
 } from './helpers.js';
 export type { LogContext, Logger, LogHandler } from './logger.js';
 export { LogLevel } from './logger.js';
-export type { Message, MessageHeaders, MessageMetadata } from './message.js';
+export type { Message, MessageActionDetails, MessageHeaders, MessageMetadata } from './message.js';
 export type {
   MessageEventPayload,
   MessageListener,

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -1,3 +1,7 @@
+import { ErrorInfo } from 'ably';
+
+import { ActionMetadata } from './action-metadata.js';
+import { ChatMessageActions } from './events.js';
 import { Headers } from './headers.js';
 import { Metadata } from './metadata.js';
 import { DefaultTimeserial, Timeserial } from './timeserial.js';
@@ -11,6 +15,29 @@ export type MessageHeaders = Headers;
  * {@link Metadata} type for chat messages.
  */
 export type MessageMetadata = Metadata;
+
+/**
+ * {@link ActionMetadata} type for a chat message {@link MessageActionDetails}.
+ */
+export type MessageActionMetadata = ActionMetadata;
+
+/**
+ * Represents the detail of a message deletion or update.
+ */
+export interface MessageActionDetails {
+  /**
+   * The optional clientId of the user who performed the update or deletion.
+   */
+  clientId?: string;
+  /**
+   * The optional description for the update or deletion.
+   */
+  description?: string;
+  /**
+   * The optional {@link MessageActionMetadata} associated with the update or deletion.
+   */
+  metadata?: MessageActionMetadata;
+}
 
 /**
  * Represents a single message in a chat room.
@@ -71,6 +98,75 @@ export interface Message {
   readonly headers: MessageHeaders;
 
   /**
+   * The latest action of the message. This can be used to determine if the message was created, updated, or deleted.
+   */
+  readonly latestAction: ChatMessageActions;
+
+  /**
+   * A unique identifier for the latest action that updated the message. This is only set for update and deletes.
+   */
+  readonly latestActionSerial: string;
+
+  /**
+   * The details of the latest action that updated the message. This is only set for update and delete actions.
+   */
+  readonly latestActionDetails?: MessageActionDetails;
+
+  /**
+   * Indicates if the message has been updated.
+   */
+  readonly isUpdated: boolean;
+
+  /**
+   * Indicates if the message has been deleted.
+   */
+  readonly isDeleted: boolean;
+
+  /**
+   * The clientId of the user who deleted the message.
+   */
+  readonly deletedBy?: string;
+
+  /**
+   * The clientId of the user who updated the message.
+   */
+  readonly updatedBy?: string;
+
+  /**
+   * The timestamp at which the message was deleted.
+   */
+  readonly deletedAt?: Date;
+
+  /**
+   * The timestamp at which the message was updated.
+   */
+  readonly updatedAt?: Date;
+
+  /**
+   * Determines if the action of this message is before the action of the given message.
+   * @param message The message to compare against.
+   * @returns true if the action of this message is before the given message.
+   * @throws {@link ErrorInfo} if both message timeserials do not match, or if {@link latestActionSerial} of either is invalid.
+   */
+  actionBefore(message: Message): boolean;
+
+  /**
+   * Determines if the action of this message is after the action of the given message.
+   * @param message The message to compare against.
+   * @returns true if the action of this message is after the given message.
+   * @throws {@link ErrorInfo} if both message timeserials do not match, or if {@link latestActionSerial} of either is invalid.
+   */
+  actionAfter(message: Message): boolean;
+
+  /**
+   * Determines if the action of this message is equal to the action of the given message.
+   * @param message The message to compare against.
+   * @returns true if the action of this message is equal to the given message.
+   * @throws {@link ErrorInfo} if both message timeserials do not match, or if {@link latestActionSerial} of either is invalid.
+   */
+  actionEqual(message: Message): boolean;
+
+  /**
    * Determines if this message was created before the given message. This comparison is based on
    * global order, so does not necessarily represent the order that messages are received in realtime
    * from the backend.
@@ -105,7 +201,8 @@ export interface Message {
  * Allows for comparison of messages based on their timeserials.
  */
 export class DefaultMessage implements Message {
-  private readonly _calculatedTimeserial: Timeserial;
+  private readonly _calculatedOriginTimeserial: Timeserial;
+  private readonly _calculatedActionSerial: Timeserial;
 
   constructor(
     public readonly timeserial: string,
@@ -115,22 +212,73 @@ export class DefaultMessage implements Message {
     public readonly createdAt: Date,
     public readonly metadata: MessageMetadata,
     public readonly headers: MessageHeaders,
+
+    public readonly latestAction: ChatMessageActions,
+    // the latestActionSerial will be set to the original timeserial for new messages,
+    // else it will be set to the serial corresponding to whatever action
+    // (update/delete) that was just performed.
+    public readonly latestActionSerial: string,
+
+    public readonly deletedAt?: Date,
+    public readonly updatedAt?: Date,
+    public readonly latestActionDetails?: MessageActionDetails,
   ) {
-    this._calculatedTimeserial = DefaultTimeserial.calculateTimeserial(timeserial);
+    this._calculatedOriginTimeserial = DefaultTimeserial.calculateTimeserial(timeserial);
+    this._calculatedActionSerial = DefaultTimeserial.calculateTimeserial(latestActionSerial);
 
     // The object is frozen after constructing to enforce readonly at runtime too
     Object.freeze(this);
   }
 
+  get isUpdated(): boolean {
+    return this.updatedAt !== undefined;
+  }
+
+  get isDeleted(): boolean {
+    return this.deletedAt !== undefined;
+  }
+
+  get updatedBy(): string | undefined {
+    return this.latestAction === ChatMessageActions.MessageUpdate ? this.latestActionDetails?.clientId : undefined;
+  }
+
+  get deletedBy(): string | undefined {
+    return this.latestAction === ChatMessageActions.MessageDelete ? this.latestActionDetails?.clientId : undefined;
+  }
+
+  actionBefore(message: Message): boolean {
+    // Check to ensure the messages are the same before comparing operation order
+    if (!this.equal(message)) {
+      throw new ErrorInfo('actionBefore(): Cannot compare actions, message timeserials must be equal', 50000, 500);
+    }
+    return this._calculatedActionSerial.before(message.latestActionSerial);
+  }
+
+  actionAfter(message: Message): boolean {
+    // Check to ensure the messages are the same before comparing operation order
+    if (!this.equal(message)) {
+      throw new ErrorInfo('actionAfter(): Cannot compare actions, message timeserials must be equal', 50000, 500);
+    }
+    return this._calculatedActionSerial.after(message.latestActionSerial);
+  }
+
+  actionEqual(message: Message): boolean {
+    // Check to ensure the messages are the same before comparing operation order
+    if (!this.equal(message)) {
+      throw new ErrorInfo('actionEqual(): Cannot compare actions, message timeserials must be equal', 50000, 500);
+    }
+    return this._calculatedActionSerial.equal(message.latestActionSerial);
+  }
+
   before(message: Message): boolean {
-    return this._calculatedTimeserial.before(message.timeserial);
+    return this._calculatedOriginTimeserial.before(message.timeserial);
   }
 
   after(message: Message): boolean {
-    return this._calculatedTimeserial.after(message.timeserial);
+    return this._calculatedOriginTimeserial.after(message.timeserial);
   }
 
   equal(message: Message): boolean {
-    return this._calculatedTimeserial.equal(message.timeserial);
+    return this._calculatedOriginTimeserial.equal(message.timeserial);
   }
 }

--- a/test/core/helpers.test.ts
+++ b/test/core/helpers.test.ts
@@ -1,7 +1,7 @@
 import * as Ably from 'ably';
 import { describe, expect, it } from 'vitest';
 
-import { MessageEvents } from '../../src/core/events.js';
+import { ChatMessageActions, RealtimeMessageNames } from '../../src/core/events.js';
 import { RoomReactionEvents } from '../../src/core/events.ts';
 import { chatMessageFromEncoded, getEntityTypeFromEncoded, reactionFromEncoded } from '../../src/core/helpers.js';
 import { DefaultMessage } from '../../src/core/message.js';
@@ -12,12 +12,13 @@ const TEST_ENVELOPED_MESSAGE = {
   clientId: 'user1',
   timestamp: 1719948956834,
   encoding: 'json',
+  action: 1,
+  serial: '108TeGZDQBderu97202638@1719948956834-0',
   extras: {
-    timeserial: '108TeGZDQBderu97202638@1719948956834-0',
     headers: {},
   },
   data: '{"text":"I have the high ground now","metadata":{}}',
-  name: 'message.created',
+  name: 'chat.message',
 };
 
 const TEST_ENVELOPED_ROOM_REACTION = {
@@ -28,6 +29,8 @@ const TEST_ENVELOPED_ROOM_REACTION = {
   encoding: 'json',
   data: '{"type":"like"}',
   name: 'roomReaction',
+  serial: '108TeGZDQBderu97202638@1719948956834-0',
+  action: 1,
 };
 
 describe('helpers', () => {
@@ -43,6 +46,8 @@ describe('helpers', () => {
           new Date(1719948956834),
           {},
           {},
+          ChatMessageActions.MessageCreate,
+          '108TeGZDQBderu97202638@1719948956834-0',
         ),
       );
     });
@@ -54,11 +59,12 @@ describe('helpers', () => {
           clientId: 'user1',
           timestamp: 1719948956834,
           encoding: 'json',
+          action: 1,
+          serial: '108TeGZDQBderu97202638@1719948956834-0',
           extras: {
-            timeserial: '108TeGZDQBderu97202638@1719948956834-0',
             headers: {},
           },
-          name: 'message.created',
+          name: 'chat.message',
         });
       }).rejects.toBeErrorInfo({
         code: 50000,
@@ -81,7 +87,8 @@ describe('helpers', () => {
           connectionId: 'NtORcEMDdH',
           timestamp: 1719948877991,
           encoding: 'json',
-          name: 'message.created',
+          action: 1,
+          name: 'chat.message',
         });
       }).rejects.toBeErrorInfo({
         code: 50000,
@@ -129,13 +136,13 @@ describe('helpers', () => {
     });
 
     it('should return "chatMessage" for MessageEvents.created', () => {
-      const message = { name: MessageEvents.Created as string } as Ably.InboundMessage;
+      const message = { name: RealtimeMessageNames.ChatMessage } as Ably.InboundMessage;
       const result = getEntityTypeFromEncoded(message);
       expect(result).toBe('chatMessage');
     });
 
     it('should return "roomReaction" for RoomReactionEvents.reaction', () => {
-      const message = { name: RoomReactionEvents.Reaction as string } as Ably.InboundMessage;
+      const message = { name: RoomReactionEvents.Reaction } as Ably.InboundMessage;
       const result = getEntityTypeFromEncoded(message);
       expect(result).toBe('reaction');
     });

--- a/test/core/message-parser.test.ts
+++ b/test/core/message-parser.test.ts
@@ -1,7 +1,8 @@
 import * as Ably from 'ably';
 import { describe, expect, it } from 'vitest';
 
-import { DefaultMessage } from '../../src/core/message.js';
+import { ChatMessageActions } from '../../src/core/events.ts';
+import { DefaultMessage } from '../../src/core/message.ts';
 import { parseMessage } from '../../src/core/message-parser.js';
 
 describe('parseMessage', () => {
@@ -15,7 +16,13 @@ describe('parseMessage', () => {
     {
       description: 'message.data is undefined',
       roomId: 'room1',
-      message: { clientId: 'client1', timestamp: 1234567890, extras: { timeserial: 'abcdefghij@1672531200000-123' } },
+      message: {
+        clientId: 'client1',
+        timestamp: 1234567890,
+        extras: {},
+        serial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+        action: ChatMessageActions.MessageCreate,
+      },
       expectedError: 'received incoming message without data',
     },
     {
@@ -24,7 +31,9 @@ describe('parseMessage', () => {
       message: {
         data: { text: 'hello' },
         timestamp: 1234567890,
-        extras: { timeserial: 'abcdefghij@1672531200000-123' },
+        extras: {},
+        serial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+        action: ChatMessageActions.MessageCreate,
       },
       expectedError: 'received incoming message without clientId',
     },
@@ -34,7 +43,9 @@ describe('parseMessage', () => {
       message: {
         data: { text: 'hello' },
         clientId: 'client1',
-        extras: { timeserial: 'abcdefghij@1672531200000-123' },
+        extras: {},
+        serial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+        action: ChatMessageActions.MessageCreate,
       },
       expectedError: 'received incoming message without timestamp',
     },
@@ -45,21 +56,108 @@ describe('parseMessage', () => {
         data: {},
         clientId: 'client1',
         timestamp: 1234567890,
-        extras: { timeserial: 'abcdefghij@1672531200000-123' },
+        extras: {},
+        serial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+        action: ChatMessageActions.MessageCreate,
       },
       expectedError: 'received incoming message without text',
     },
     {
       description: 'message.extras is undefined',
       roomId: 'room1',
-      message: { data: { text: 'hello' }, clientId: 'client1', timestamp: 1234567890 },
+      message: {
+        data: { text: 'hello' },
+        clientId: 'client1',
+        timestamp: 1234567890,
+        serial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+        action: ChatMessageActions.MessageCreate,
+      },
       expectedError: 'received incoming message without extras',
     },
     {
-      description: 'message.extras.timeserial is undefined',
+      description: 'message.serial is undefined',
       roomId: 'room1',
-      message: { data: { text: 'hello' }, clientId: 'client1', timestamp: 1234567890, extras: {} },
-      expectedError: 'received incoming message without timeserial',
+      message: {
+        data: { text: 'hello' },
+        clientId: 'client1',
+        timestamp: 1234567890,
+        extras: {},
+        action: ChatMessageActions.MessageCreate,
+      },
+      expectedError: 'received incoming message without serial',
+    },
+    {
+      description: 'message.action is unhandled',
+      roomId: 'room1',
+      message: {
+        data: { text: 'hello' },
+        clientId: 'client1',
+        timestamp: 1234567890,
+        extras: {},
+        serial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+        action: 'unhandled.action',
+      },
+      expectedError: 'received incoming message with unhandled action; unhandled.action',
+    },
+    {
+      description: 'message.updateAt is undefined for update',
+      roomId: 'room1',
+      message: {
+        data: { text: 'hello' },
+        clientId: 'client1',
+        timestamp: 1234567890,
+        extras: {},
+        serial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+        action: ChatMessageActions.MessageUpdate,
+        updatedAt: undefined,
+        updateSerial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+      },
+      expectedError: 'received incoming message.update without updatedAt',
+    },
+    {
+      description: 'message.updateSerial is undefined for update',
+      roomId: 'room1',
+      message: {
+        data: { text: 'hello' },
+        clientId: 'client1',
+        timestamp: 1234567890,
+        extras: {},
+        serial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+        action: ChatMessageActions.MessageUpdate,
+        updatedAt: 1234567890,
+        updateSerial: undefined,
+      },
+      expectedError: 'received incoming message.update without updateSerial',
+    },
+    {
+      description: 'message.updatedAt is undefined for deletion',
+      roomId: 'room1',
+      message: {
+        data: { text: 'hello' },
+        clientId: 'client1',
+        timestamp: 1234567890,
+        extras: {},
+        serial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+        updatedAt: undefined,
+        updateSerial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+        action: ChatMessageActions.MessageDelete,
+      },
+      expectedError: 'received incoming message.delete without updatedAt',
+    },
+    {
+      description: 'message.updateSerial is undefined for deletion',
+      roomId: 'room1',
+      message: {
+        data: { text: 'hello' },
+        clientId: 'client1',
+        timestamp: 1234567890,
+        extras: {},
+        serial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+        updatedAt: 1234567890,
+        updateSerial: undefined,
+        action: ChatMessageActions.MessageDelete,
+      },
+      expectedError: 'received incoming message.delete without updateSerial',
     },
   ])('should throw an error ', ({ description, roomId, message, expectedError }) => {
     it(`should throw an error if ${description}`, () => {
@@ -72,23 +170,125 @@ describe('parseMessage', () => {
     });
   });
 
-  it('should return a DefaultMessage instance for a valid message', () => {
+  it('should return a DefaultMessage instance for a valid new message', () => {
     const message = {
       data: { text: 'hello', metadata: { key: 'value' } },
       clientId: 'client1',
       timestamp: 1234567890,
-      extras: { timeserial: 'abcdefghij@1672531200000-123', headers: { headerKey: 'headerValue' } },
+      extras: {
+        headers: { headerKey: 'headerValue' },
+      },
+      updatedAt: 1234567890,
+      updateSerial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+      action: ChatMessageActions.MessageCreate,
+      serial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
     } as Ably.InboundMessage;
 
     const result = parseMessage('room1', message);
 
     expect(result).toBeInstanceOf(DefaultMessage);
-    expect(result.timeserial).toBe('abcdefghij@1672531200000-123');
+    expect(result.timeserial).toBe('cbfkKvEYgBhDaZ38195418@1728402074206-0:0');
     expect(result.clientId).toBe('client1');
     expect(result.roomId).toBe('room1');
     expect(result.text).toBe('hello');
     expect(result.createdAt).toEqual(new Date(1234567890));
     expect(result.metadata).toEqual({ key: 'value' });
     expect(result.headers).toEqual({ headerKey: 'headerValue' });
+
+    // deletion related fields should be undefined
+    expect(result.deletedAt).toBeUndefined();
+    expect(result.deletedBy).toBeUndefined();
+
+    // update related fields should be undefined
+    expect(result.updatedAt).toBeUndefined();
+    expect(result.updatedBy).toBeUndefined();
+
+    expect(result.latestAction).toEqual(ChatMessageActions.MessageCreate);
+    expect(result.latestActionDetails).toBeUndefined();
+  });
+
+  it('should return a DefaultMessage instance for a valid updated message', () => {
+    const message = {
+      id: 'message-id',
+      data: { text: 'hello', metadata: { key: 'value' } },
+      clientId: 'client1',
+      timestamp: 1234567890,
+      extras: {
+        headers: { headerKey: 'headerValue' },
+      },
+      action: ChatMessageActions.MessageUpdate,
+      serial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+      updatedAt: 1234567890,
+      updateSerial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+      operation: { clientId: 'client2', description: 'update message', metadata: { 'custom-update': 'some flag' } },
+    } as Ably.InboundMessage;
+
+    const result = parseMessage('room1', message);
+
+    expect(result).toBeInstanceOf(DefaultMessage);
+    expect(result.timeserial).toBe('cbfkKvEYgBhDaZ38195418@1728402074206-0:0');
+    expect(result.clientId).toBe('client1');
+    expect(result.roomId).toBe('room1');
+    expect(result.text).toBe('hello');
+    expect(result.createdAt).toEqual(new Date(1234567890));
+    expect(result.metadata).toEqual({ key: 'value' });
+    expect(result.headers).toEqual({ headerKey: 'headerValue' });
+    expect(result.updatedAt).toEqual(new Date(1234567890));
+    expect(result.updatedBy).toBe('client2');
+    expect(result.latestAction).toEqual(ChatMessageActions.MessageUpdate);
+    expect(result.latestActionSerial).toEqual('cbfkKvEYgBhDaZ38195418@1728402074206-0:0');
+    expect(result.latestActionDetails).toEqual({
+      clientId: 'client2',
+      description: 'update message',
+      metadata: { 'custom-update': 'some flag' },
+    });
+
+    // deletion related fields should be undefined
+    expect(result.deletedAt).toBeUndefined();
+    expect(result.deletedBy).toBeUndefined();
+  });
+
+  it('should return a DefaultMessage instance for a valid deleted message', () => {
+    const message = {
+      id: 'message-id',
+      data: { text: 'hello', metadata: { key: 'value' } },
+      clientId: 'client1',
+      timestamp: 1234567890,
+      extras: {
+        headers: { headerKey: 'headerValue' },
+      },
+      action: ChatMessageActions.MessageDelete,
+      serial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+      updatedAt: 1234567890,
+      updateSerial: 'cbfkKvEYgBhDaZ38195418@1728402074206-0:0',
+      operation: {
+        clientId: 'client2',
+        description: 'delete message',
+        metadata: { 'custom-warning': 'this is a warning' },
+      },
+    } as Ably.InboundMessage;
+
+    const result = parseMessage('room1', message);
+
+    expect(result).toBeInstanceOf(DefaultMessage);
+    expect(result.timeserial).toBe('cbfkKvEYgBhDaZ38195418@1728402074206-0:0');
+    expect(result.clientId).toBe('client1');
+    expect(result.roomId).toBe('room1');
+    expect(result.text).toBe('hello');
+    expect(result.createdAt).toEqual(new Date(1234567890));
+    expect(result.metadata).toEqual({ key: 'value' });
+    expect(result.headers).toEqual({ headerKey: 'headerValue' });
+    expect(result.deletedAt).toEqual(new Date(1234567890));
+    expect(result.deletedBy).toBe('client2');
+    expect(result.latestActionSerial).toEqual('cbfkKvEYgBhDaZ38195418@1728402074206-0:0');
+    expect(result.latestActionDetails).toEqual({
+      clientId: 'client2',
+      description: 'delete message',
+      metadata: { 'custom-warning': 'this is a warning' },
+    });
+
+    // update related fields should be undefined
+    expect(result.updatedAt).toBeUndefined();
+    expect(result.updatedBy).toBeUndefined();
   });
 });

--- a/test/core/message.test.ts
+++ b/test/core/message.test.ts
@@ -1,5 +1,7 @@
+import { Message } from '@ably/chat';
 import { describe, expect, it } from 'vitest';
 
+import { ChatMessageActions } from '../../src/core/events.ts';
 import { DefaultMessage } from '../../src/core/message.ts';
 
 describe('ChatMessage', () => {
@@ -15,6 +17,8 @@ describe('ChatMessage', () => {
       new Date(1672531200000),
       {},
       {},
+      ChatMessageActions.MessageCreate,
+      firstTimeserial,
     );
     const secondMessage = new DefaultMessage(
       secondTimeserial,
@@ -24,6 +28,8 @@ describe('ChatMessage', () => {
       new Date(1672531200000),
       {},
       {},
+      ChatMessageActions.MessageCreate,
+      secondTimeserial,
     );
 
     expect(firstMessage.equal(secondMessage)).toBe(true);
@@ -41,6 +47,8 @@ describe('ChatMessage', () => {
       new Date(1672531200000),
       {},
       {},
+      ChatMessageActions.MessageCreate,
+      firstTimeserial,
     );
     const secondMessage = new DefaultMessage(
       secondTimeserial,
@@ -50,6 +58,8 @@ describe('ChatMessage', () => {
       new Date(1672531200000),
       {},
       {},
+      ChatMessageActions.MessageCreate,
+      secondTimeserial,
     );
 
     expect(firstMessage.equal(secondMessage)).toBe(false);
@@ -67,6 +77,8 @@ describe('ChatMessage', () => {
       new Date(1672531200000),
       {},
       {},
+      ChatMessageActions.MessageCreate,
+      firstTimeserial,
     );
     const secondMessage = new DefaultMessage(
       secondTimeserial,
@@ -76,6 +88,8 @@ describe('ChatMessage', () => {
       new Date(1672531200000),
       {},
       {},
+      ChatMessageActions.MessageCreate,
+      secondTimeserial,
     );
 
     expect(firstMessage.before(secondMessage)).toBe(true);
@@ -92,6 +106,8 @@ describe('ChatMessage', () => {
       new Date(1672531200000),
       {},
       {},
+      ChatMessageActions.MessageCreate,
+      firstTimeserial,
     );
     const secondMessage = new DefaultMessage(
       secondTimeserial,
@@ -101,6 +117,8 @@ describe('ChatMessage', () => {
       new Date(1672531200000),
       {},
       {},
+      ChatMessageActions.MessageCreate,
+      secondTimeserial,
     );
 
     expect(firstMessage.after(secondMessage)).toBe(true);
@@ -116,10 +134,166 @@ describe('ChatMessage', () => {
         new Date(1672531200000),
         {},
         {},
+        ChatMessageActions.MessageCreate,
+        'not a valid timeserial',
       );
     }).toThrowErrorInfo({
       code: 50000,
       message: 'invalid timeserial',
+    });
+  });
+
+  describe('message actions', () => {
+    it('is deleted', () => {
+      const firstTimeserial = 'abcdefghij@1672531200000-124:0';
+      const firstMessage = new DefaultMessage(
+        firstTimeserial,
+        'clientId',
+        'roomId',
+        'hello there',
+        new Date(1672531200000),
+        {},
+        {},
+        ChatMessageActions.MessageDelete,
+        'abcdefghij@1672531200000-123:0',
+        new Date(1672531300000),
+        undefined,
+        {
+          clientId: 'clientId2',
+        },
+      );
+      expect(firstMessage.isDeleted).toBe(true);
+      expect(firstMessage.deletedBy).toBe('clientId2');
+    });
+
+    it('is updated', () => {
+      const firstTimeserial = 'abcdefghij@1672531200000-124';
+      const firstMessage = new DefaultMessage(
+        firstTimeserial,
+        'clientId',
+        'roomId',
+        'hello there',
+        new Date(1672531200000),
+        {},
+        {},
+        ChatMessageActions.MessageUpdate,
+        'abcdefghij@1672531200000-123:0',
+        undefined,
+        new Date(1672531300000),
+        { clientId: 'clientId2' },
+      );
+      expect(firstMessage.isUpdated).toBe(true);
+      expect(firstMessage.updatedBy).toBe('clientId2');
+    });
+
+    it(`throws an error when trying to compare actions belonging to different origin messages`, () => {
+      const firstTimeserial = 'abcdefghij@1672531200000-124';
+      const secondTimeserial = 'abcdefghij@1672531200000-123';
+
+      const firstActionSerial = 'abcdefghij@1672531200000-123:0';
+      const secondActionSerial = 'abcdefghij@1672531200000-123:0';
+
+      const firstMessage = new DefaultMessage(
+        firstTimeserial,
+        'clientId',
+        'roomId',
+        'hello there',
+        new Date(1672531200000),
+        {},
+        {},
+        ChatMessageActions.MessageUpdate,
+        firstActionSerial,
+      );
+      const secondMessage = new DefaultMessage(
+        secondTimeserial,
+        'clientId',
+        'roomId',
+        'hello there',
+        new Date(1672531200000),
+        {},
+        {},
+        ChatMessageActions.MessageUpdate,
+        secondActionSerial,
+      );
+
+      expect(() => firstMessage.actionEqual(secondMessage)).toThrowErrorInfo({
+        code: 50000,
+        message: 'actionEqual(): Cannot compare actions, message timeserials must be equal',
+      });
+    });
+
+    describe.each([
+      [
+        'returns true when this message action is the same as another',
+        {
+          firstActionSerial: 'abcdefghij@1672531200000-123:0',
+          secondActionSerial: 'abcdefghij@1672531200000-123:0',
+          action: 'actionEqual',
+          expected: (firstMessage: Message, secondMessage: Message) => {
+            expect(firstMessage.actionEqual(secondMessage)).toBe(true);
+          },
+        },
+      ],
+      [
+        'returns false when this message action is not same as another message action',
+        {
+          firstActionSerial: 'abcdefghij@1672531200000-123:0',
+          secondActionSerial: 'abcdefghij@1672531200000-124:0',
+          action: 'actionEqual',
+          expected: (firstMessage: Message, secondMessage: Message) => {
+            expect(firstMessage.actionEqual(secondMessage)).toBe(false);
+          },
+        },
+      ],
+      [
+        'returns true when this message action is before another message action',
+        {
+          firstActionSerial: 'abcdefghij@1672531200000-123:0',
+          secondActionSerial: 'abcdefghij@1672531200000-124:0',
+          action: 'actionBefore',
+          expected: (firstMessage: Message, secondMessage: Message) => {
+            expect(firstMessage.actionBefore(secondMessage)).toBe(true);
+          },
+        },
+      ],
+      [
+        'returns true when this message action is after another message action',
+        {
+          firstActionSerial: 'abcdefghij@1672531200000-124:0',
+          secondActionSerial: 'abcdefghij@1672531200000-123:0',
+          action: 'actionAfter',
+          expected: (firstMessage: Message, secondMessage: Message) => {
+            expect(firstMessage.actionAfter(secondMessage)).toBe(true);
+          },
+        },
+      ],
+    ])('compare message action serials', (name, { firstActionSerial, secondActionSerial, expected }) => {
+      it(name, () => {
+        const messageTimeserial = 'abcdefghij@1672531200000-123';
+        const firstMessage = new DefaultMessage(
+          messageTimeserial,
+          'clientId',
+          'roomId',
+          'hello there',
+          new Date(1672531200000),
+          {},
+          {},
+          ChatMessageActions.MessageUpdate,
+          firstActionSerial,
+        );
+        const secondMessage = new DefaultMessage(
+          messageTimeserial,
+          'clientId',
+          'roomId',
+          'hello there',
+          new Date(1672531200000),
+          {},
+          {},
+          ChatMessageActions.MessageUpdate,
+          secondActionSerial,
+        );
+        expected(firstMessage, secondMessage);
+      });
     });
   });
 });

--- a/test/helper/channel.ts
+++ b/test/helper/channel.ts
@@ -18,7 +18,6 @@ export const channelEventEmitter = (
     if (!arg.name) {
       throw new Error('Event name is required');
     }
-
     channelWithEmitter.subscriptions.emit(arg.name, arg);
   };
 };

--- a/test/react/hooks/use-messages.test.tsx
+++ b/test/react/hooks/use-messages.test.tsx
@@ -11,6 +11,7 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import * as Ably from 'ably';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ChatMessageActions } from '../../../src/core/events.ts';
 import { PaginatedResult } from '../../../src/core/query.ts';
 import { useMessages } from '../../../src/react/hooks/use-messages.ts';
 import { makeTestLogger } from '../../helper/logger.ts';
@@ -103,9 +104,17 @@ describe('useMessages', () => {
         timestamp: new Date(),
         text: 'test message',
         timeserial: '123',
+        action: ChatMessageActions.MessageCreate,
         clientId: '123',
         roomId: '123',
         createdAt: new Date(),
+        latestAction: ChatMessageActions.MessageCreate,
+        latestActionSerial: '122',
+        isUpdated: false,
+        isDeleted: false,
+        actionBefore: vi.fn(),
+        actionAfter: vi.fn(),
+        actionEqual: vi.fn(),
         before: vi.fn(),
         after: vi.fn(),
         equal: vi.fn(),


### PR DESCRIPTION
### Context

* As part of the support work for materialization, changes to the DefaultMessage class are needed. Primarily, this involves adding new fields to support deletes and edits, as well as moving to the new `message.actions` field.
* With the addition of `message.actions`, we will now use this to filter chat messages, the old `message.name` will still be used to filter things like `[meta]occupancy`

### Description

* Adds the new fields to the DefaultMessage class.
* Updates the message parser to handle the new fields.
* Adds the support for the new `message.name` name filter.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced message handling with new properties and actions for chat messages.
	- Added support for updated and deleted message events.
	- Introduced new enumerations for message actions and types.
	- New type definition for action metadata associated with chat messages.

- **Bug Fixes**
	- Improved error handling in event emitters for better validation.

- **Tests**
	- Expanded test coverage for message actions and event subscriptions.
	- Updated tests to reflect the new message structure and properties.

- **Documentation**
	- Clarified changes in the test cases to align with new message formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->