### PR TITLE
Materialisation: Add message deletion functionality to Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,23 @@ const message = await room.messages.send({
 });
 ```
 
+### Deleting messages
+
+To delete a message, call `delete` on the `room.messages` property, with the original message you want to delete.
+
+You can supply optional parameters to the `delete` method to provide additional context for the deletion.
+
+These additional parameters are:
+* `description`: a string that can be used to inform others as to why the message was deleted.
+* `metadata`: a map of extra information that can be attached to the deletion message.
+
+The return of this call will be the deleted message, as it would appear to other subscribers of the room.
+This is a _soft delete_ and the message will still be available in the history, but with the `deletedAt` property set.
+
+```ts
+const deletedMessage = await room.messages.delete(message, { description: 'This message was deleted for ...' });
+```
+
 ### Subscribing to incoming messages
 
 To subscribe to incoming messages, call `subscribe` with your listener.

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -13,7 +13,8 @@
         "clsx": "^2.1.1",
         "nanoid": "^5.0.7",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-icons": "^5.3.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -19847,6 +19848,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -18,7 +18,8 @@
     "clsx": "^2.1.1",
     "nanoid": "^5.0.7",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-icons": "^5.3.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/demo/src/components/MessageComponent/MessageComponent.tsx
+++ b/demo/src/components/MessageComponent/MessageComponent.tsx
@@ -1,6 +1,7 @@
 import { Message } from '@ably/chat';
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import clsx from 'clsx';
+import { FaTrash } from 'react-icons/fa6';
 
 function twoDigits(input: number): string {
   if (input === 0) {
@@ -18,12 +19,22 @@ interface MessageProps {
   message: Message;
 
   onMessageClick?(id: string): void;
+
+  onMessageDelete?(msg: Message): void;
 }
 
-export const MessageComponent: React.FC<MessageProps> = ({ id, self = false, message, onMessageClick }) => {
+export const MessageComponent: React.FC<MessageProps> = ({
+  id,
+  self = false,
+  message,
+  onMessageClick,
+  onMessageDelete,
+}) => {
   const handleMessageClick = useCallback(() => {
     onMessageClick?.(id);
   }, [id, onMessageClick]);
+
+  const [hovered, setHovered] = useState(false);
 
   let displayCreatedAt: string;
   if (Date.now() - message.createdAt.getTime() < 1000 * 60 * 60 * 24) {
@@ -43,14 +54,21 @@ export const MessageComponent: React.FC<MessageProps> = ({ id, self = false, mes
       twoDigits(message.createdAt.getMinutes());
   }
 
+  const handleDelete = useCallback(() => {
+    // Add your delete handling logic here
+    onMessageDelete?.(message);
+  }, [message, onMessageDelete]);
+
   return (
     <div
       className="chat-message"
       onClick={handleMessageClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
     >
       <div className={clsx('flex items-end', { ['justify-end']: self, ['justify-start']: !self })}>
         <div
-          className={clsx('flex flex-col text max-w-xs mx-2', {
+          className={clsx('flex flex-col text max-w-xs mx-2 relative', {
             ['items-end order-1']: self,
             ['items-start order-2']: !self,
           })}
@@ -69,6 +87,15 @@ export const MessageComponent: React.FC<MessageProps> = ({ id, self = false, mes
             })}
           >
             {message.text}
+            {hovered && (
+              <FaTrash
+                className="ml-2 cursor-pointer text-red-500"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleDelete();
+                }}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -27,8 +27,15 @@ export {
 } from './helpers.js';
 export type { LogContext, Logger, LogHandler } from './logger.js';
 export { LogLevel } from './logger.js';
-export type { Message, MessageActionDetails, MessageHeaders, MessageMetadata } from './message.js';
 export type {
+  Message,
+  MessageActionDetails,
+  MessageActionMetadata,
+  MessageHeaders,
+  MessageMetadata,
+} from './message.js';
+export type {
+  DeleteMessageParams,
   MessageEventPayload,
   MessageListener,
   Messages,

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -17,7 +17,7 @@ export type MessageHeaders = Headers;
 export type MessageMetadata = Metadata;
 
 /**
- * {@link ActionMetadata} type for a chat message {@link MessageActionDetails}.
+ * {@link ActionMetadata} type for a chat messages {@link MessageActionDetails}.
  */
 export type MessageActionMetadata = ActionMetadata;
 
@@ -34,7 +34,7 @@ export interface MessageActionDetails {
    */
   description?: string;
   /**
-   * The optional {@link MessageActionMetadata} associated with the update or deletion.
+   * The optional metadata associated with the update or deletion.
    */
   metadata?: MessageActionMetadata;
 }

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -184,30 +184,38 @@ This hook allows you to access the `Messages` instance of a `Room` from your Rea
 
 **To use this hook, the component calling it must be a child of a `ChatRoomProvider`.**
 
-### Sending And Getting Messages
+### Sending, Deleting And Getting Messages
 
 The hook will provide the `Messages` instance, should you wish to interact with it directly, a `send` method
-that can be used to send a messages to the room, and a `get` method that can be used to retrieve messages from the room.
+that can be used to send a message to the room,
+a `deleteMessage` method that can be used to delete a message from the room,
+and a `get` method that can be used to retrieve messages from the room.
 
 ```tsx
 import { useMessages } from '@ably/chat/react';
+import { Message } from '@ably/chat';
 
 const MyComponent = () => {
-  const { send, get } = useMessages();
-
+  const { send, get, deleteMessage } = useMessages();
+  const [message, setMessage] = useState<Message>();
   const handleGetMessages = () => {
     // fetch the last 3 messages, oldest to newest
     get({ limit: 3, direction: 'forwards' }).then((result) => console.log('Previous messages: ', result.items));
   };
 
   const handleMessageSend = () => {
-    send({ text: 'Hello, World!' });
+    send({ text: 'Hello, World!' }).then((sentMessage) => setMessage(sentMessage));
+  };
+
+  const handleMessageDelete = (message: Message) => {
+    deleteMessage(message, { description: 'deleted by user' });
   };
 
   return (
     <div>
       <button onClick={handleMessageSend}>Send Message</button>
       <button onClick={handleGetMessages}>Get Messages</button>
+      <button onClick={handleMessageDelete}>Delete Message</button>
     </div>
   );
 };

--- a/src/react/hooks/use-messages.ts
+++ b/src/react/hooks/use-messages.ts
@@ -1,4 +1,5 @@
 import {
+  DeleteMessageParams,
   Message,
   MessageListener,
   Messages,
@@ -30,6 +31,11 @@ export interface UseMessagesResponse extends ChatStatusResponse {
    * A shortcut to the {@link Messages.get} method.
    */
   readonly get: Messages['get'];
+
+  /**
+   * A shortcut to the {@link Messages.delete} method.
+   */
+  readonly deleteMessage: Messages['delete'];
 
   /**
    * Provides access to the underlying {@link Messages} instance of the room.
@@ -89,6 +95,11 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
   const onDiscontinuityRef = useEventListenerRef(params?.onDiscontinuity);
 
   const send = useCallback((params: SendMessageParams) => room.messages.send(params), [room]);
+
+  const deleteMessage = useCallback(
+    (message: Message, deleteMessageParams?: DeleteMessageParams) => room.messages.delete(message, deleteMessageParams),
+    [room],
+  );
   const get = useCallback((options: QueryOptions) => room.messages.get(options), [room]);
 
   const [getPreviousMessages, setGetPreviousMessages] = useState<MessageSubscriptionResponse['getPreviousMessages']>();
@@ -142,6 +153,7 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
   return {
     send,
     get,
+    deleteMessage,
     messages: room.messages,
     getPreviousMessages,
     connectionStatus,

--- a/test/core/chat-api.test.ts
+++ b/test/core/chat-api.test.ts
@@ -27,7 +27,7 @@ describe('config', () => {
         statusCode: 400,
       })
       .then(() => {
-        expect(realtime.request).toHaveBeenCalledWith('GET', '/chat/v1/rooms/test/occupancy', 3, {}, undefined);
+        expect(realtime.request).toHaveBeenCalledWith('GET', '/chat/v1/rooms/test/occupancy', 3, undefined, undefined);
       });
   });
 

--- a/test/core/chat.integration.test.ts
+++ b/test/core/chat.integration.test.ts
@@ -22,7 +22,7 @@ const waitForConnectionStatus = (chat: ChatClient, state: ConnectionStatus) => {
     // Set a timeout to reject the promise if the status is not reached
     setInterval(() => {
       off();
-      reject(new Error(`Connection status ${state} not reached`));
+      reject(new Error(`Connection state ${state} not reached`));
     }, 5000);
   });
 };


### PR DESCRIPTION
### Context

* [CHA-516]

### Description

These changes are dependant on both ably-js changes to support the new fields (updated in this [PR](https://github.com/ably/ably-js/pull/1888)), and additional realtime work that has not yet been completed.

Once the above is done, the tests should be able to pass, as such, please do not merge this PR until the above is done.

* Added the ability to delete a chat message to the Messages feature.
* Updated the Chat React hooks to support the new feature.
* Updated the demo app to allow deletion of messages in a chat room.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

* Explain how to test the changes in this PR.
* Provide specific steps or commands to execute.


[CHA-516]: https://ably.atlassian.net/browse/CHA-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced message deletion functionality in the Ably Chat SDK, allowing users to delete messages with optional parameters for context and metadata.
	- Enhanced the `MessageComponent` to support message deletion with an interactive trash icon.
	- Updated the `useMessages` hook to include a `deleteMessage` method for easier message management.

- **Bug Fixes**
	- Improved error handling in message event processing and tests related to message deletion and retrieval.

- **Documentation**
	- Updated the README and documentation for the `useMessages` hook to reflect the new message deletion capabilities, including example code.

- **Tests**
	- Added comprehensive tests for message deletion and retrieval scenarios to ensure robust functionality, including error handling for unexpected message types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->