### PR TITLE
docs: Update room-level reactions in readme for clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,8 @@ const occupancy = await room.occupancy.get();
 
 You can subscribe to and send ephemeral room-level reactions by using the `room.reactions` objects.
 
+To send room-level reactions, you must be [attached](#attaching-to-a-room) to the room.
+
 ### Sending a reaction
 
 To send a reaction such as `"like"`:


### PR DESCRIPTION
Small improvement to the README to ensure it's obvious that you must be attached before sending room-level reactions.