### PR TITLE
feature-change: Remove reserved keyname space in headers and metadata.

### DIFF
--- a/src/core/headers.ts
+++ b/src/core/headers.ts
@@ -11,7 +11,5 @@
  * server-side validation. When reading the headers treat them like user
  * input.
  *
- * The key prefix `ably-chat` is reserved and cannot be used. Ably may add
- * headers prefixed with `ably-chat` in the future.
  */
 export type Headers = Record<string, number | string | boolean | null | undefined>;

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -87,8 +87,6 @@ export interface SendMessageParams {
    * Do not use metadata for authoritative information. There is no server-side
    * validation. When reading the metadata treat it like user input.
    *
-   * The key `ably-chat` is reserved and cannot be used. Ably may populate
-   * this with different values in the future.
    */
   metadata?: MessageMetadata;
 
@@ -105,8 +103,6 @@ export interface SendMessageParams {
    * server-side validation. When reading the headers treat them like user
    * input.
    *
-   * The key prefix `ably-chat` is reserved and cannot be used. Ably may add
-   * headers prefixed with `ably-chat` in the future.
    */
   headers?: MessageHeaders;
 }
@@ -444,22 +440,6 @@ export class DefaultMessages
     this._logger.trace('Messages.send();');
 
     const { text, metadata, headers } = params;
-
-    if (metadata && metadata['ably-chat'] !== undefined) {
-      throw new Ably.ErrorInfo("unable to send message; metadata cannot use reserved key 'ably-chat'", 40001, 400);
-    }
-
-    if (headers) {
-      for (const key of Object.keys(headers)) {
-        if (key.startsWith('ably-chat')) {
-          throw new Ably.ErrorInfo(
-            "unable to send message; headers cannot have any key starting with reserved prefix 'ably-chat'",
-            40001,
-            400,
-          );
-        }
-      }
-    }
 
     const response = await this._chatApi.sendMessage(this._roomId, { text, headers, metadata });
 

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -8,7 +8,5 @@
  * Do not use metadata for authoritative information. There is no server-side
  * validation. When reading the metadata treat it like user input.
  *
- * The key `ably-chat` is reserved and cannot be used. Ably may populate
- * this with different values in the future.
  */
 export type Metadata = Record<string, unknown>;

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -40,8 +40,6 @@ export interface SendReactionParams {
    * Do not use metadata for authoritative information. There is no server-side
    * validation. When reading the metadata treat it like user input.
    *
-   * The key `ably-chat` is reserved and cannot be used. Ably may populate this
-   * with different values in the future.
    */
   metadata?: ReactionMetadata;
 
@@ -58,8 +56,6 @@ export interface SendReactionParams {
    * server-side validation. When reading the headers treat them like user
    * input.
    *
-   * The key prefix `ably-chat` is reserved and cannot be used. Ably may add
-   * headers prefixed with `ably-chat` in the future.
    */
   headers?: ReactionHeaders;
 }
@@ -188,26 +184,6 @@ export class DefaultRoomReactions
 
     if (!type) {
       return Promise.reject(new Ably.ErrorInfo('unable to send reaction; type not set and it is required', 40001, 400));
-    }
-
-    if (metadata && metadata['ably-chat'] !== undefined) {
-      return Promise.reject(
-        new Ably.ErrorInfo("unable to send reaction; metadata cannot use reserved key 'ably-chat'", 40001, 400),
-      );
-    }
-
-    if (headers) {
-      for (const key of Object.keys(headers)) {
-        if (key.startsWith('ably-chat')) {
-          return Promise.reject(
-            new Ably.ErrorInfo(
-              "unable to send reaction; headers cannot have any key starting with reserved prefix 'ably-chat'",
-              40001,
-              400,
-            ),
-          );
-        }
-      }
     }
 
     const payload: ReactionPayload = {

--- a/test/core/messages.test.ts
+++ b/test/core/messages.test.ts
@@ -115,60 +115,6 @@ describe('Messages', () => {
         }),
       );
     });
-
-    it<TestContext>('should be not be able to set reserved header prefix', (context) => {
-      return new Promise<void>((accept, reject) => {
-        const { chatApi, realtime } = context;
-        const timestamp = Date.now();
-        vi.spyOn(chatApi, 'sendMessage').mockResolvedValue({
-          timeserial: 'abcdefghij@1672531200000-123',
-          createdAt: timestamp,
-        });
-
-        const room = makeRandomRoom({ chatApi, realtime });
-        const messagePromise = room.messages.send({
-          text: 'hello there',
-          headers: { 'ably-chat.you': 'shall not pass' },
-        });
-
-        messagePromise
-          .then(() => {
-            reject(new Error('message should have not been sent successfully'));
-          })
-          .catch((error: unknown) => {
-            expect(error).toBeTruthy();
-            expect((error as Error).message).toMatch(/reserved prefix/);
-            accept();
-          });
-      });
-    });
-
-    it<TestContext>('should be not be able to set reserved metadata key', (context) => {
-      return new Promise<void>((accept, reject) => {
-        const { chatApi, realtime } = context;
-        const timestamp = Date.now();
-        vi.spyOn(chatApi, 'sendMessage').mockResolvedValue({
-          timeserial: 'abcdefghij@1672531200000-123',
-          createdAt: timestamp,
-        });
-
-        const room = makeRandomRoom({ chatApi, realtime });
-        const messagePromise = room.messages.send({
-          text: 'hello there',
-          metadata: { 'ably-chat': 'shall not pass' },
-        });
-
-        messagePromise
-          .then(() => {
-            reject(new Error('message should have not been sent successfully'));
-          })
-          .catch((error: unknown) => {
-            expect(error).toBeTruthy();
-            expect((error as Error).message).toMatch(/reserved key/);
-            accept();
-          });
-      });
-    });
   });
 
   describe('subscribing to updates', () => {

--- a/test/core/room-reactions.test.ts
+++ b/test/core/room-reactions.test.ts
@@ -299,58 +299,6 @@ describe('Reactions', () => {
           headers: { action: 'strike back', number: 1980 },
         });
       }));
-
-    it<TestContext>('should not be able to use reserved prefix in reaction headers', (context) =>
-      new Promise<void>((done, reject) => {
-        const { room } = context;
-
-        room.reactions.subscribe(() => {
-          reject(new Error("should not receive reaction, sending must've failed"));
-        });
-
-        const sendPromise = room.reactions.send({
-          type: 'love',
-          headers: { 'ably-chat-hello': true }, // "ably-chat" prefix is the reserved
-        });
-
-        sendPromise
-          .then(() => {
-            reject(new Error('send should not succeed'));
-          })
-          .catch((error: unknown) => {
-            const errInfo = error as Ably.ErrorInfo;
-            expect(errInfo).toBeTruthy();
-            expect(errInfo.message).toMatch(/reserved prefix/);
-            expect(errInfo.code).toEqual(40001);
-            done();
-          });
-      }));
-
-    it<TestContext>('should not be able to use reserved key in reaction metadata', (context) =>
-      new Promise<void>((done, reject) => {
-        const { room } = context;
-
-        room.reactions.subscribe(() => {
-          reject(new Error("should not receive reaction, sending must've failed"));
-        });
-
-        const sendPromise = room.reactions.send({
-          type: 'love',
-          metadata: { 'ably-chat': { value: 1 } }, // "ably-chat" is reserved
-        });
-
-        sendPromise
-          .then(() => {
-            reject(new Error('send should not succeed'));
-          })
-          .catch((error: unknown) => {
-            const errInfo = error as Ably.ErrorInfo;
-            expect(errInfo).toBeTruthy();
-            expect(errInfo.message).toMatch(/reserved key/);
-            expect(errInfo.code).toEqual(40001);
-            done();
-          });
-      }));
   });
 
   it<TestContext>('has an attachment error code', (context) => {


### PR DESCRIPTION
### Context

* It was decided that we would no longer reserve any namespaces in headers or extras.
* [CHA-625]

### Description

* Removed restrictions on `ably-chat` in headers and metadata.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).


[CHA-625]: https://ably.atlassian.net/browse/CHA-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified message sending and reaction processes by removing validation checks for reserved keys, enhancing user experience.
  
- **Bug Fixes**
	- Eliminated warnings related to the reserved key `ably-chat` in documentation and validation, improving clarity.

- **Tests**
	- Updated test suites by removing obsolete test cases related to reserved keys, ensuring focus on core functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->