### PR TITLE
react/presence: fix flakey test with usePresence

### DIFF
--- a/test/core/messages.integration.test.ts
+++ b/test/core/messages.integration.test.ts
@@ -69,12 +69,12 @@ describe('messages integration', () => {
       expect.objectContaining({
         text: 'Hello there!',
         clientId: chat.clientId,
-        timeserial: message1.timeserial,
+        timeserial: message1.timeserial.slice(0, -2),
       }),
       expect.objectContaining({
         text: 'I have the high ground!',
         clientId: chat.clientId,
-        timeserial: message2.timeserial,
+        timeserial: message2.timeserial.slice(0, -2),
       }),
     ]);
   });
@@ -222,7 +222,10 @@ describe('messages integration', () => {
     // Subscribe to messages and add them to a list when they arrive
     const messages: Message[] = [];
     room.messages.subscribe((messageEvent) => {
-      messages.push(messageEvent.message);
+      messages.push({
+        ...messageEvent.message,
+        timeserial: messageEvent.message.timeserial + ':0',
+      });
     });
 
     await room.attach();


### PR DESCRIPTION
### Context

N/A

### Description

This change fixes the usePresence integration test. It was flaking because a leave and detach in quick succession (as the test does via unmounting) can lead to duplicate presence events as realtime will do an implicit leave for any detachments it deems still in presence.

This would lead to the presence events array having 4 events (instead of the expected 3).

The fix is to assert on seeing specific presence events we expect to see, showing that we get the desired behaviour, but without falling over because of potential race conditions.

It also fixes the messages.integration.test during the transitional period to using per-message serials.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

Run the test with many repeats and observe the lack of flakeyness!
