### PR TITLE
core/test: revert occupancy test changes

### DIFF
--- a/test/core/occupancy.integration.test.ts
+++ b/test/core/occupancy.integration.test.ts
@@ -86,9 +86,8 @@ describe('occupancy', () => {
     await subscriberRealtimeChannel.presence.enter({ foo: 'bar' });
 
     // Wait for the occupancy to reach the expected occupancy
-    // We get an extra 1 from inside Realtime, so expect 3
     await waitForExpectedInstantaneousOccupancy(room, {
-      connections: 3,
+      connections: 2,
       presenceMembers: 1,
     });
 
@@ -99,9 +98,9 @@ describe('occupancy', () => {
     await subscriberRealtimeChannel.detach();
     await realtimeChannel.detach();
 
-    // We'll get 1 connection from the channel until resources clean up in realtime, so expect that and end here
+    // Everything should be back to 0
     await waitForExpectedInstantaneousOccupancy(room, {
-      connections: 1,
+      connections: 0,
       presenceMembers: 0,
     });
   });
@@ -141,7 +140,7 @@ describe('occupancy', () => {
     await waitForExpectedInbandOccupancy(
       occupancyUpdates,
       {
-        connections: 3,
+        connections: 2,
         presenceMembers: 1,
       },
       TEST_TIMEOUT,

--- a/test/react/hooks/use-occupancy.integration.test.tsx
+++ b/test/react/hooks/use-occupancy.integration.test.tsx
@@ -61,16 +61,16 @@ describe('useOccupancy', () => {
     render(<TestProvider />);
 
     // if we already have expected occupancy, then we don't need to wait for the event
-    const expectedOccupancy = { connections: 4, presenceMembers: 2 };
+    const expectedOccupancy = { connections: 3, presenceMembers: 2 };
     if (dequal(expectedOccupancy, occupancyState)) {
       return;
     }
 
     // we don't have the requested occupancy yet, so wait for the occupancy events to be received
-    await waitForExpectedInbandOccupancy(occupancyEvents, { connections: 4, presenceMembers: 2 }, 20000);
+    await waitForExpectedInbandOccupancy(occupancyEvents, { connections: 3, presenceMembers: 2 }, 20000);
 
     // check the occupancy metrics
-    expect(occupancyState.connections).toBe(4);
+    expect(occupancyState.connections).toBe(3);
     expect(occupancyState.presenceMembers).toBe(2);
   });
 });


### PR DESCRIPTION
### Context

N/A

### Description

Now that underlying changes have been effected on the server, we no longer need to account for the +1 in occupancy, so these tests can be revereted to their previous state.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted expected occupancy values in integration tests for chat room functionality to reflect accurate connection counts.
	- Updated metrics for the `useOccupancy` hook to ensure correct assertions and waiting conditions for occupancy events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->