### PR TITLE
core/room: transition immediately to released if room is initialized

### DIFF
--- a/src/core/room-lifecycle-manager.ts
+++ b/src/core/room-lifecycle-manager.ts
@@ -789,8 +789,8 @@ export class RoomLifecycleManager {
         return;
       }
 
-      // If we're already detached, then we can transition to released immediately
-      if (this._lifecycle.status === RoomStatus.Detached) {
+      // If we're already detached, or we never attached in the first place, then we can transition to released immediately
+      if (this._lifecycle.status === RoomStatus.Detached || this._lifecycle.status === RoomStatus.Initialized) {
         this._lifecycle.setStatus({ status: RoomStatus.Released });
         return;
       }

--- a/test/core/room-lifecycle-manager.test.ts
+++ b/test/core/room-lifecycle-manager.test.ts
@@ -2510,6 +2510,23 @@ describe('room lifecycle manager', () => {
       await waitForRoomLifecycleStatus(status, RoomStatus.Released);
     });
 
+    it<TestContext>('resolves immediately and transitions to released if the room is initialized', async (context) => {
+      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
+      context.firstContributor.emulateStateChange({
+        current: AblyChannelState.Detached,
+        previous: 'initialized',
+        resumed: false,
+        reason: baseError,
+      });
+      status.setStatus({ status: RoomStatus.Initialized });
+
+      const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
+
+      await expect(monitor.release()).resolves.toBeUndefined();
+
+      await waitForRoomLifecycleStatus(status, RoomStatus.Released);
+    });
+
     it<TestContext>('resolves to released if existing attempt completes', (context) =>
       new Promise<void>((resolve, reject) => {
         vi.useFakeTimers();


### PR DESCRIPTION
### Context

Resolves #398
[CHA-716]
Spec PR: https://github.com/ably/specification/pull/224

### Description

If room is in the initialized state, we can skip the detach process and skip straight to release.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A


[CHA-716]: https://ably.atlassian.net/browse/CHA-716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ