### PR TITLE
core/lifecycle: wind down contributors by channel during failure scenarios

### DIFF
--- a/src/core/room-lifecycle-manager.ts
+++ b/src/core/room-lifecycle-manager.ts
@@ -632,7 +632,7 @@ export class RoomLifecycleManager {
       this._contributors.map(async (contributor) => {
         // If its the contributor we want to wait for a conclusion on, then we should not detach it
         // Unless we're in a failed state, in which case we should detach it
-        if (contributor === except && this._lifecycle.status !== RoomStatus.Failed) {
+        if (contributor.channel === except?.channel && this._lifecycle.status !== RoomStatus.Failed) {
           return;
         }
 


### PR DESCRIPTION
### Context

Closes #407

[CHA-722]

### Description

At the moment, we wind down the contributor itself. This can lead to situations where if the contributor is a shared channel, another contributor will detach the channel and thus it will never recover.

This change fixes this issue by making the comparison on the channel objects themselves.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A


[CHA-722]: https://ably.atlassian.net/browse/CHA-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ