### PR TITLE
Refactor Ably client initialization in the demo app

### DIFF
--- a/demo/.env.example
+++ b/demo/.env.example
@@ -1,5 +1,8 @@
 # Your Ably API key
 VITE_ABLY_CHAT_API_KEY=
 
+# Your environment, set to 'production' by default.
+VITE_ABLY_CHAT_ENV=
+
 # Optional if you're using a custom domain for Ably
 #VITE_ABLY_HOST=my-personal-domain.ably-realtime.com


### PR DESCRIPTION
Small PR to make it easier to switch between local and non-local environments in the demo app. Saves us constantly commenting out code and potentially missing it in a PR.

