### PR TITLE
core/room: add channel manager, fix bug where channel options not applied

### DIFF
--- a/src/core/channel-manager.ts
+++ b/src/core/channel-manager.ts
@@ -1,0 +1,46 @@
+import * as Ably from 'ably';
+
+import { Logger } from './logger.js';
+import { DEFAULT_CHANNEL_OPTIONS } from './version.js';
+
+export type ChannelOptionsMerger = (options: Ably.ChannelOptions) => Ably.ChannelOptions;
+
+export class ChannelManager {
+  private readonly _realtime: Ably.Realtime;
+  private readonly _logger: Logger;
+  private readonly _registeredOptions = new Map<string, Ably.ChannelOptions>();
+  private readonly _requestedChannels = new Set<string>();
+
+  constructor(realtime: Ably.Realtime, logger: Logger) {
+    logger.trace('ChannelManager();');
+    this._realtime = realtime;
+    this._logger = logger;
+  }
+
+  mergeOptions(channelName: string, merger: ChannelOptionsMerger): void {
+    this._logger.trace('ChannelManager.registerOptions();', { channelName });
+    if (this._requestedChannels.has(channelName)) {
+      this._logger.error('channel options cannot be modified after the channel has been requested', { channelName });
+      throw new Ably.ErrorInfo('channel options cannot be modified after the channel has been requested', 40000, 400);
+    }
+
+    const currentOpts = this._registeredOptions.get(channelName) ?? DEFAULT_CHANNEL_OPTIONS;
+    this._registeredOptions.set(channelName, merger(currentOpts));
+  }
+
+  get(channelName: string): Ably.RealtimeChannel {
+    this._logger.trace('ChannelManager.get();', { channelName });
+    this._requestedChannels.add(channelName);
+    return this._realtime.channels.get(
+      channelName,
+      this._registeredOptions.get(channelName) ?? DEFAULT_CHANNEL_OPTIONS,
+    );
+  }
+
+  release(channelName: string): void {
+    this._logger.trace('ChannelManager.release();', { channelName });
+    this._requestedChannels.delete(channelName);
+    this._registeredOptions.delete(channelName);
+    this._realtime.channels.release(channelName);
+  }
+}

--- a/src/core/channel.ts
+++ b/src/core/channel.ts
@@ -1,19 +1,3 @@
-import * as Ably from 'ably';
-
-import { DEFAULT_CHANNEL_OPTIONS } from './version.js';
-
-export const getChannel = (name: string, realtime: Ably.Realtime, opts?: Ably.ChannelOptions): Ably.RealtimeChannel => {
-  const resolvedOptions = {
-    ...opts,
-    params: {
-      ...opts?.params,
-      ...DEFAULT_CHANNEL_OPTIONS.params,
-    },
-  };
-
-  return realtime.channels.get(name, resolvedOptions);
-};
-
 /**
  * Get the channel name for the chat messages channel.
  * @param roomId The room ID.

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -1,6 +1,7 @@
 import * as Ably from 'ably';
 
-import { getChannel, messagesChannelName } from './channel.js';
+import { messagesChannelName } from './channel.js';
+import { ChannelManager } from './channel-manager.js';
 import { ChatApi } from './chat-api.js';
 import {
   DiscontinuityEmitter,
@@ -300,16 +301,16 @@ export class DefaultMessages
   /**
    * Constructs a new `DefaultMessages` instance.
    * @param roomId The unique identifier of the room.
-   * @param realtime An instance of the Ably Realtime client.
+   * @param channelManager An instance of the ChannelManager.
    * @param chatApi An instance of the ChatApi.
    * @param clientId The client ID of the user.
    * @param logger An instance of the Logger.
    */
-  constructor(roomId: string, realtime: Ably.Realtime, chatApi: ChatApi, clientId: string, logger: Logger) {
+  constructor(roomId: string, channelManager: ChannelManager, chatApi: ChatApi, clientId: string, logger: Logger) {
     super();
     this._roomId = roomId;
 
-    this._channel = this._makeChannel(roomId, realtime);
+    this._channel = this._makeChannel(roomId, channelManager);
 
     this._chatApi = chatApi;
     this._clientId = clientId;
@@ -320,8 +321,8 @@ export class DefaultMessages
   /**
    * Creates the realtime channel for messages.
    */
-  private _makeChannel(roomId: string, realtime: Ably.Realtime): Ably.RealtimeChannel {
-    const channel = getChannel(messagesChannelName(roomId), realtime);
+  private _makeChannel(roomId: string, channelManager: ChannelManager): Ably.RealtimeChannel {
+    const channel = channelManager.get(messagesChannelName(roomId));
 
     addListenerToChannelWithoutAttach({
       listener: this._processEvent.bind(this),

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -1,6 +1,6 @@
 import * as Ably from 'ably';
 
-import { getChannel } from './channel.js';
+import { ChannelManager } from './channel-manager.js';
 import {
   DiscontinuityEmitter,
   DiscontinuityListener,
@@ -143,14 +143,14 @@ export class DefaultRoomReactions
   /**
    * Constructs a new `DefaultRoomReactions` instance.
    * @param roomId The unique identifier of the room.
-   * @param realtime An instance of the Ably Realtime client.
+   * @param channelManager The ChannelManager instance.
    * @param clientId The client ID of the user.
    * @param logger An instance of the Logger.
    */
-  constructor(roomId: string, realtime: Ably.Realtime, clientId: string, logger: Logger) {
+  constructor(roomId: string, channelManager: ChannelManager, clientId: string, logger: Logger) {
     super();
 
-    this._channel = this._makeChannel(roomId, realtime);
+    this._channel = this._makeChannel(roomId, channelManager);
     this._clientId = clientId;
     this._logger = logger;
   }
@@ -158,8 +158,8 @@ export class DefaultRoomReactions
   /**
    * Creates the realtime channel for room reactions.
    */
-  private _makeChannel(roomId: string, realtime: Ably.Realtime): Ably.RealtimeChannel {
-    const channel = getChannel(`${roomId}::$chat::$reactions`, realtime);
+  private _makeChannel(roomId: string, channelManager: ChannelManager): Ably.RealtimeChannel {
+    const channel = channelManager.get(`${roomId}::$chat::$reactions`);
     addListenerToChannelWithoutAttach({
       listener: this._forwarder.bind(this),
       events: [RoomReactionEvents.Reaction],

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -1,7 +1,7 @@
 import * as Ably from 'ably';
 import { dequal } from 'dequal';
 
-import { getChannel } from './channel.js';
+import { ChannelManager } from './channel-manager.js';
 import {
   DiscontinuityEmitter,
   DiscontinuityListener,
@@ -133,14 +133,20 @@ export class DefaultTyping
    * Constructs a new `DefaultTyping` instance.
    * @param roomId The unique identifier of the room.
    * @param options The options for typing in the room.
-   * @param realtime An instance of the Ably Realtime client.
+   * @param channelManager The channel manager for the room.
    * @param clientId The client ID of the user.
    * @param logger An instance of the Logger.
    */
-  constructor(roomId: string, options: TypingOptions, realtime: Ably.Realtime, clientId: string, logger: Logger) {
+  constructor(
+    roomId: string,
+    options: TypingOptions,
+    channelManager: ChannelManager,
+    clientId: string,
+    logger: Logger,
+  ) {
     super();
     this._clientId = clientId;
-    this._channel = this._makeChannel(roomId, realtime);
+    this._channel = this._makeChannel(roomId, channelManager);
 
     // Timeout for typing
     this._typingTimeoutMs = options.timeoutMs;
@@ -150,8 +156,8 @@ export class DefaultTyping
   /**
    * Creates the realtime channel for typing indicators.
    */
-  private _makeChannel(roomId: string, realtime: Ably.Realtime): Ably.RealtimeChannel {
-    const channel = getChannel(`${roomId}::$chat::$typingIndicators`, realtime);
+  private _makeChannel(roomId: string, channelManager: ChannelManager): Ably.RealtimeChannel {
+    const channel = channelManager.get(`${roomId}::$chat::$typingIndicators`);
     addListenerToChannelPresenceWithoutAttach({
       listener: this._internalSubscribeToEvents.bind(this),
       channel: channel,

--- a/test/core/channel-manager.test.ts
+++ b/test/core/channel-manager.test.ts
@@ -1,0 +1,103 @@
+import * as Ably from 'ably';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChannelManager, ChannelOptionsMerger } from '../../src/core/channel-manager.ts';
+import { DEFAULT_CHANNEL_OPTIONS } from '../../src/core/version.ts';
+import { randomClientId } from '../helper/identifier.ts';
+import { makeTestLogger } from '../helper/logger.ts';
+
+interface TestContext {
+  mockRealtime: Ably.Realtime;
+  channelManager: ChannelManager;
+}
+
+vi.mock('ably');
+
+describe('ChannelManager', () => {
+  beforeEach<TestContext>((context) => {
+    context.mockRealtime = new Ably.Realtime({ clientId: randomClientId() });
+    context.channelManager = new ChannelManager(context.mockRealtime, makeTestLogger());
+
+    vi.spyOn(context.mockRealtime.channels, 'get').mockReturnValue({} as Ably.RealtimeChannel);
+    vi.spyOn(context.mockRealtime.channels, 'release');
+  });
+
+  it<TestContext>('requests channel with default options', (context) => {
+    const channelName = 'test-channel';
+    context.channelManager.get(channelName);
+
+    expect(context.mockRealtime.channels.get).toHaveBeenCalledWith(channelName, DEFAULT_CHANNEL_OPTIONS);
+  });
+
+  it<TestContext>('should merge options correctly', (context) => {
+    const channelName = 'test-channel';
+    const merger: ChannelOptionsMerger = (options) => ({ ...options, mode: 'presence' });
+
+    context.channelManager.mergeOptions(channelName, merger);
+
+    context.channelManager.get(channelName);
+    expect(context.mockRealtime.channels.get).toHaveBeenCalledWith(channelName, {
+      ...DEFAULT_CHANNEL_OPTIONS,
+      mode: 'presence',
+    });
+  });
+
+  it<TestContext>('should merge options multiple times over', (context) => {
+    const channelName = 'test-channel';
+    const merger: ChannelOptionsMerger = (options) => ({ ...options, mode: 'presence' });
+    const merger2: ChannelOptionsMerger = (options) => ({ ...options, presence: 'enter' });
+
+    context.channelManager.mergeOptions(channelName, merger);
+    context.channelManager.mergeOptions(channelName, merger2);
+
+    context.channelManager.get(channelName);
+    expect(context.mockRealtime.channels.get).toHaveBeenCalledWith(channelName, {
+      ...DEFAULT_CHANNEL_OPTIONS,
+      mode: 'presence',
+      presence: 'enter',
+    });
+  });
+
+  it<TestContext>('should throw error if trying to merge options for a requested channel', (context) => {
+    const channelName = 'test-channel';
+    const merger: ChannelOptionsMerger = (options) => ({ ...options, mode: 'presence' });
+    const merger2: ChannelOptionsMerger = (options) => ({ ...options, presence: 'enter' });
+
+    context.channelManager.mergeOptions(channelName, merger);
+    context.channelManager.get(channelName);
+
+    // Should have been called once
+    expect(context.mockRealtime.channels.get).toHaveBeenCalledTimes(1);
+    expect(context.mockRealtime.channels.get).toHaveBeenCalledWith(channelName, {
+      ...DEFAULT_CHANNEL_OPTIONS,
+      mode: 'presence',
+    });
+
+    // Now try to merge again, should error
+    expect(() => {
+      context.channelManager.mergeOptions(channelName, merger2);
+    }).toThrowErrorInfo({ code: 40000, statusCode: 400 });
+
+    // And we shouldn't have called get again
+    expect(context.mockRealtime.channels.get).toHaveBeenCalledTimes(1);
+  });
+
+  it<TestContext>('should get a channel singleton', (context) => {
+    const channelName = 'test-channel';
+    const merger: ChannelOptionsMerger = (options) => ({ ...options, mode: 'presence' });
+
+    context.channelManager.mergeOptions(channelName, merger);
+    const channel1 = context.channelManager.get(channelName);
+    const channel2 = context.channelManager.get(channelName);
+
+    expect(channel1).toBe(channel2);
+  });
+
+  it<TestContext>('should release a channel', (context) => {
+    const channelName = 'test-channel';
+    context.channelManager.get(channelName);
+
+    context.channelManager.release(channelName);
+    expect(context.mockRealtime.channels.release).toHaveBeenCalledWith(channelName);
+  });
+});


### PR DESCRIPTION
### Context

Closes #411
[CHA-738].

### Description

This change fixes the bug described in #411 whereby channel options are overwritten by successive uses of the same channel, rather than merged together.

In doing this, we also fix the bug in relation to newly introduce spec point CHA-RC3. We were previously depending on the soft-deprecated behaviour in RTS3c which would allow you to update channel options via setOptions.

The change is achieved by adding a channel manager, whose job it is to register all the options for a given channel prior to the first channels.get() call, and call channels.get with the amalgamated options.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A

[CHA-738]: https://ably.atlassian.net/browse/CHA-738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ