### PR TITLE
core: change direction to orderBy for history, use enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,17 +287,20 @@ To update an existing message, call `update` on the `room.messages` property, wi
 the updated fields, and optional operation details to provide extra context for the update.
 
 The optional operation details are:
-* `description`: a string that can be used to inform others as to why the message was updated.
-* `metadata`: a map of extra information that can be attached to the update operation.
+
+- `description`: a string that can be used to inform others as to why the message was updated.
+- `metadata`: a map of extra information that can be attached to the update operation.
 
 Example
+
 ```typescript
-const updatedMessage = await room.messages.update(message,
+const updatedMessage = await room.messages.update(
+  message,
   {
-    text: "hello, this is edited",
+    text: 'hello, this is edited',
   },
   {
-    description: "edit example",
+    description: 'edit example',
   },
 );
 ```
@@ -317,10 +320,11 @@ In rare occasions updates might arrive over realtime out of order. To keep a cor
 The same out-of-order situation can happen between updates received over realtime and HTTP responses. In the situation where two concurrent updates happen, both might be received via realtime before the HTTP response of the first one arrives. Always compare the message `version` to determine which instance of a `Message` is newer.
 
 Example for handling updates:
-```typescript
-const messages : Message[] = []; // assuming this is where state is kept
 
-room.messages.subscribe(event => {
+```typescript
+const messages: Message[] = []; // assuming this is where state is kept
+
+room.messages.subscribe((event) => {
   switch (event.type) {
     case MessageEvents.Updated: {
       const serial = event.message.serial;
@@ -342,18 +346,19 @@ To delete a message, call `delete` on the `room.messages` property, with the ori
 You can supply optional parameters to the `delete` method to provide additional context for the deletion.
 
 These additional parameters are:
-* `description`: a string that can be used to inform others as to why the message was deleted.
-* `metadata`: a map of extra information that can be attached to the deletion message.
+
+- `description`: a string that can be used to inform others as to why the message was deleted.
+- `metadata`: a map of extra information that can be attached to the deletion message.
 
 The return of this call will be the deleted message, as it would appear to other subscribers of the room.
 This is a _soft delete_ and the message will still be available in the history.
 
 Example
+
 ```ts
-const deletedMessage = await room.messages.delete(message,
-        { 
-          description: 'This message was deleted for ...'
-        });
+const deletedMessage = await room.messages.delete(message, {
+  description: 'This message was deleted for ...',
+});
 ```
 
 `deletedMessage` is a Message object with the deletion applied. As with sending, the promise may resolve after the deletion message is received via the messages subscription.
@@ -386,10 +391,11 @@ In short, always use `actionAfter()`,
 `actionBefore()`, or `actionEqual()` to determine the global ordering of two `Message` actions.
 
 Example for handling deletes:
-```typescript
-const messages : Message[] = []; // assuming this is where state is kept
 
-room.messages.subscribe(event => {
+```typescript
+const messages: Message[] = []; // assuming this is where state is kept
+
+room.messages.subscribe((event) => {
   switch (event.type) {
     case MessageEvents.Deleted: {
       const serial = event.message.serial;
@@ -401,8 +407,9 @@ room.messages.subscribe(event => {
     }
     // other event types (ie. created and updated) omitted
   }
-})
+});
 ```
+
 ### Subscribing to incoming messages
 
 To subscribe to incoming messages, call `subscribe` with your listener.
@@ -431,7 +438,7 @@ The messages object also exposes the `get` method which can be used to request h
 to the given criteria. It returns a paginated response that can be used to request more messages.
 
 ```typescript
-const historicalMessages = await room.messages.get({ direction: 'backwards', limit: 50 });
+const historicalMessages = await room.messages.get({ orderBy: OrderBy.NewestFirst, limit: 50 });
 console.log(historicalMessages.items);
 if (historicalMessages.hasNext()) {
   const next = await historicalMessages.next();

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -34,6 +34,7 @@ export type {
   Messages,
   MessageSubscriptionResponse,
   OperationDetails,
+  OrderBy,
   QueryOptions,
   SendMessageParams,
   UpdateMessageParams,

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -225,7 +225,7 @@ const MyComponent = () => {
   const [message, setMessage] = useState<Message>();
   const handleGetMessages = () => {
     // fetch the last 3 messages, oldest to newest
-    get({ limit: 3, direction: 'forwards' }).then((result) => console.log('Previous messages: ', result.items));
+    get({ limit: 3, orderBy: OrderBy.oldestFirst }).then((result) => console.log('Previous messages: ', result.items));
   };
 
   const handleMessageSend = () => {

--- a/src/react/hooks/use-messages.ts
+++ b/src/react/hooks/use-messages.ts
@@ -145,7 +145,7 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
             return;
           }
 
-          return (params: Omit<QueryOptions, 'direction'>) => {
+          return (params: Omit<QueryOptions, 'orderBy'>) => {
             // If we've unmounted, then the subscription is gone and we can't call getPreviousMessages
             // So return a dummy object that should be thrown away anyway
             logger.debug('useMessages(); getPreviousMessages called', { roomId: context.roomId });

--- a/test/core/chat-api.test.ts
+++ b/test/core/chat-api.test.ts
@@ -70,4 +70,20 @@ describe('config', () => {
       statusCode: 400,
     });
   });
+
+  it('throws errors if invalid OrderBy used on history request', async () => {
+    const realtime = new Ably.Realtime({ clientId: 'test' });
+    const chatApi = new ChatApi(realtime, makeTestLogger());
+
+    vi.spyOn(realtime, 'request');
+
+    // @ts-expect-error Testing invalid OrderBy
+    await expect(chatApi.getMessages('test', { orderBy: 'foo' })).rejects.toBeErrorInfo({
+      message: 'invalid orderBy value: foo',
+      code: 40000,
+      statusCode: 400,
+    });
+
+    expect(realtime.request).not.toHaveBeenCalled();
+  });
 });

--- a/test/core/messages.integration.test.ts
+++ b/test/core/messages.integration.test.ts
@@ -1,9 +1,10 @@
-import { ChatMessageActions, Message } from '@ably/chat';
 import * as Ably from 'ably';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { ChatClient } from '../../src/core/chat.ts';
-import { MessageEvents } from '../../src/core/events.ts';
+import { ChatMessageActions, MessageEvents } from '../../src/core/events.ts';
+import { Message } from '../../src/core/message.ts';
+import { OrderBy } from '../../src/core/messages.ts';
 import { RealtimeChannelWithOptions } from '../../src/core/realtime-extensions.ts';
 import { RoomOptionsDefaults } from '../../src/core/room-options.ts';
 import { RoomStatus } from '../../src/core/room-status.ts';
@@ -230,7 +231,7 @@ describe('messages integration', { timeout: 10000 }, () => {
 
     // Do a history request to get all 3 messages
     await new Promise((resolve) => setTimeout(resolve, 3000)); // wait for persistence - this will not be necessary in the future
-    const history = await room.messages.get({ limit: 3, direction: 'forwards' });
+    const history = await room.messages.get({ limit: 3, orderBy: OrderBy.OldestFirst });
 
     expect(history.items).toEqual([
       expect.objectContaining({
@@ -267,7 +268,7 @@ describe('messages integration', { timeout: 10000 }, () => {
 
     // Do a history request to get the deleted message
     await new Promise((resolve) => setTimeout(resolve, 3000)); // wait for persistence - this will not be necessary in the future
-    const history = await room.messages.get({ limit: 3, direction: 'forwards' });
+    const history = await room.messages.get({ limit: 3, orderBy: OrderBy.OldestFirst });
 
     expect(history.items).toEqual([
       expect.objectContaining({
@@ -308,7 +309,7 @@ describe('messages integration', { timeout: 10000 }, () => {
 
     // Do a history request to get the update message
     await new Promise((resolve) => setTimeout(resolve, 3000)); // wait for persistence - this will not be necessary in the future
-    const history = await room.messages.get({ limit: 3, direction: 'forwards' });
+    const history = await room.messages.get({ limit: 3, orderBy: OrderBy.OldestFirst });
 
     expect(history.items).toEqual([
       expect.objectContaining({
@@ -345,7 +346,7 @@ describe('messages integration', { timeout: 10000 }, () => {
 
     // Do a history request to get the first 3 messages
     await new Promise((resolve) => setTimeout(resolve, 3000)); // wait for persistence - this will not be necessary in the future
-    const history1 = await room.messages.get({ limit: 3, direction: 'forwards' });
+    const history1 = await room.messages.get({ limit: 3, orderBy: OrderBy.OldestFirst });
 
     expect(history1.items).toEqual([
       expect.objectContaining({
@@ -451,7 +452,7 @@ describe('messages integration', { timeout: 10000 }, () => {
 
     // Do a history request to get the first 3 messages
     await new Promise((resolve) => setTimeout(resolve, 3000)); // wait for persistence - this will not be necessary in the future
-    const history1 = await room.messages.get({ limit: 3, direction: 'forwards' });
+    const history1 = await room.messages.get({ limit: 3, orderBy: OrderBy.OldestFirst });
 
     expect(history1.items).toEqual([
       expect.objectContaining({
@@ -502,7 +503,7 @@ describe('messages integration', { timeout: 10000 }, () => {
 
     // Do a history request to get the last 3 messages
     await new Promise((resolve) => setTimeout(resolve, 3000)); // wait for persistence - this will not be necessary in the future
-    const history1 = await room.messages.get({ limit: 3, direction: 'backwards' });
+    const history1 = await room.messages.get({ limit: 3, orderBy: OrderBy.NewestFirst });
 
     expect(history1.items).toEqual([
       expect.objectContaining({
@@ -591,7 +592,7 @@ describe('messages integration', { timeout: 10000 }, () => {
     ]);
 
     await new Promise((resolve) => setTimeout(resolve, 3000)); // wait for persistence - this will not be necessary in the future
-    const history = await room.messages.get({ limit: 2, direction: 'forwards' });
+    const history = await room.messages.get({ limit: 2, orderBy: OrderBy.OldestFirst });
 
     expect(history.items.length).toEqual(2);
     expect(history.items, 'history messages to match').toEqual([

--- a/test/core/messages.test.ts
+++ b/test/core/messages.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatApi, GetMessagesQueryParams } from '../../src/core/chat-api.ts';
 import { ChatMessageActions, MessageEvents } from '../../src/core/events.ts';
 import { Message } from '../../src/core/message.ts';
-import { DefaultMessages, MessageEventPayload } from '../../src/core/messages.ts';
+import { DefaultMessages, MessageEventPayload, OrderBy } from '../../src/core/messages.ts';
 import { Room } from '../../src/core/room.ts';
 import {
   channelEventEmitter,
@@ -672,14 +672,14 @@ describe('Messages', () => {
 
   it<TestContext>('should query listener history with the attachment serial after attaching', async (context) => {
     const testAttachSerial = '01672531200000-123@abcdefghij';
-    const testDirection = 'backwards';
+    const testOrderBy = OrderBy.NewestFirst;
     const testLimit = 50;
 
     const { room, chatApi } = context;
 
     vi.spyOn(chatApi, 'getMessages').mockImplementation((roomId, params): Promise<Ably.PaginatedResult<Message>> => {
       expect(roomId).toEqual(room.roomId);
-      expect(params.direction).toEqual(testDirection);
+      expect(params.orderBy).toEqual(testOrderBy);
       expect(params.limit).toEqual(testLimit);
       expect(params.fromSerial).toEqual(testAttachSerial);
       return Promise.resolve(mockPaginatedResultWithItems([]));
@@ -732,14 +732,14 @@ describe('Messages', () => {
   it<TestContext>('should query listener history with latest channel serial if already attached to the channel', async (context) => {
     // We should use the latest channel serial if we are already attached to the channel
     const latestChannelSerial = '01672531200000-123@abcdefghij';
-    const testDirection = 'backwards';
+    const testOrderBy = OrderBy.NewestFirst;
     const testLimit = 50;
 
     const { room, chatApi } = context;
 
     vi.spyOn(chatApi, 'getMessages').mockImplementation((roomId, params): Promise<Ably.PaginatedResult<Message>> => {
       expect(roomId).toEqual(room.roomId);
-      expect(params.direction).toEqual(testDirection);
+      expect(params.orderBy).toEqual(testOrderBy);
       expect(params.limit).toEqual(testLimit);
       expect(params.fromSerial).toEqual(latestChannelSerial);
       return Promise.resolve(mockPaginatedResultWithItems([]));
@@ -770,7 +770,7 @@ describe('Messages', () => {
 
   it<TestContext>('when attach occurs, should query with correct params if listener registered before attach', async (context) => {
     const firstAttachmentSerial = '01772531200000-001@108uyDJAgBOihn12345678';
-    const testDirection = 'backwards';
+    const testOrderBy = OrderBy.NewestFirst;
     const testLimit = 50;
 
     let expectFunction: (roomId: string, params: GetMessagesQueryParams) => void = () => {};
@@ -815,7 +815,7 @@ describe('Messages', () => {
     // Check we are using the attachSerial
     expectFunction = (roomId: string, params: GetMessagesQueryParams) => {
       expect(roomId).toEqual(room.roomId);
-      expect(params.direction).toEqual(testDirection);
+      expect(params.orderBy).toEqual(testOrderBy);
       expect(params.limit).toEqual(testLimit);
       expect(params.fromSerial).toEqual(firstAttachmentSerial);
     };
@@ -867,7 +867,7 @@ describe('Messages', () => {
     // Testing the case where the channel is already attached and we have a channel serial set
     const firstChannelSerial = '01992531200000-001@abghhDJ2dBOihn12345678';
     const firstAttachSerial = '01992531200000-001@ackhhDJ2dBOihn12345678';
-    const testDirection = 'backwards';
+    const testOrderBy = OrderBy.NewestFirst;
     const testLimit = 50;
 
     let expectFunction: (roomId: string, params: GetMessagesQueryParams) => void = () => {};
@@ -904,7 +904,7 @@ describe('Messages', () => {
     // Check we are using the channel serial
     expectFunction = (roomId: string, params: GetMessagesQueryParams) => {
       expect(roomId).toEqual(room.roomId);
-      expect(params.direction).toEqual(testDirection);
+      expect(params.orderBy).toEqual(testOrderBy);
       expect(params.limit).toEqual(testLimit);
       expect(params.fromSerial).toEqual(firstChannelSerial);
     };
@@ -955,7 +955,7 @@ describe('Messages', () => {
 
     const firstChannelSerial = '01992531200000-001@108hhDJ2hpInKn12345678';
     const firstAttachSerial = '01992531200000-001@108hhDJBiKOihn12345678';
-    const testDirection = 'backwards';
+    const testOrderBy = OrderBy.NewestFirst;
     const testLimit = 50;
 
     let expectFunction: (roomId: string, params: GetMessagesQueryParams) => void = () => {};
@@ -993,7 +993,7 @@ describe('Messages', () => {
     // Check we are using the channel serial
     expectFunction = (roomId: string, params: GetMessagesQueryParams) => {
       expect(roomId).toEqual(room.roomId);
-      expect(params.direction).toEqual(testDirection);
+      expect(params.orderBy).toEqual(testOrderBy);
       expect(params.limit).toEqual(testLimit);
       expect(params.fromSerial).toEqual(firstChannelSerial);
     };


### PR DESCRIPTION
### Description

As already done for Swift/Kotlin, this change renames the direction parameter of the history parameters to orderBy. Instead of using string values, we now use an enum.

The ChatApi now does a mapping to the backend format (which itself will change at a later date).

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A
