### PR TITLE
docs: fix default history ordering annotation

### DIFF
--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -70,9 +70,9 @@ export interface QueryOptions {
    * The direction to query messages in.
    * If `forwards`, the response will include messages from the start of the time window to the end.
    * If `backwards`, the response will include messages from the end of the time window to the start.
-   * If not provided, the default is `forwards`.
+   * If not provided, the default is `backwards`.
    *
-   * @defaultValue forwards
+   * @defaultValue backwards
    */
   direction?: 'forwards' | 'backwards';
 }


### PR DESCRIPTION
### Description

We say its forwards, but it's actually backwards.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

- Send 2 messages
- Call history with no options
- Convince yourself that it's correct.
