### PR TITLE
Test operation fields in chat history

### DIFF
--- a/test/core/messages.integration.test.ts
+++ b/test/core/messages.integration.test.ts
@@ -284,8 +284,8 @@ describe('messages integration', { timeout: 10000 }, () => {
     expect(history.items[0]?.isUpdated).toBe(false);
     expect(history.items[0]?.isDeleted).toBe(true);
     expect(history.items[0]?.deletedAt).toEqual(deletedMessage1.deletedAt);
-    // todo: uncomment when operation is returned correctly in history endpoint
-    // expect(history.items[0]?.deletedBy).toEqual(deletedMessage1.deletedBy);
+    expect(history.items[0]?.deletedBy).toEqual(deletedMessage1.deletedBy);
+    expect(history.items[0]?.operation?.description).toEqual('Deleted message');
 
     // We shouldn't have a "next" link in the response
     expect(history.hasNext()).toBe(false);
@@ -325,8 +325,8 @@ describe('messages integration', { timeout: 10000 }, () => {
     expect(history.items[0]?.isUpdated).toBe(true);
     expect(history.items[0]?.isDeleted).toBe(false);
     expect(history.items[0]?.updatedAt).toEqual(updatedMessage1.updatedAt);
-    // todo: uncomment when operation is returned correctly in history endpoint
-    // expect(history.items[0]?.updatedBy).toEqual(updatedMessage1.updatedBy);
+    expect(history.items[0]?.updatedBy).toEqual(updatedMessage1.updatedBy);
+    expect(history.items[0]?.operation?.description).toEqual('updated message');
 
     // We shouldn't have a "next" link in the response
     expect(history.hasNext()).toBe(false);


### PR DESCRIPTION
This PR enables the integration testing of `operation` fields in chat history. The fields inside `operation` are used for updates and deletes and give access to the clientId of user who updated or deleted, an optional user-provided `description`, and an optional user-provided `metadata`.

Part of [CHA-734](https://ably.atlassian.net/browse/CHA-734)

[CHA-734]: https://ably.atlassian.net/browse/CHA-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ