### PR TITLE
Fix: Stop logging the result object.

### DIFF
--- a/demo/src/containers/Chat/Chat.tsx
+++ b/demo/src/containers/Chat/Chat.tsx
@@ -3,7 +3,7 @@ import { MessageComponent } from '../../components/MessageComponent';
 import { MessageInput } from '../../components/MessageInput';
 import { useChatClient, useChatConnection, useMessages, useRoomReactions, useTyping } from '@ably/chat/react';
 import { ReactionInput } from '../../components/ReactionInput';
-import { ConnectionStatusComponent } from '../../components/ConnectionStatusComponent/ConnectionStatusComponent.tsx';
+import { ConnectionStatusComponent } from '../../components/ConnectionStatusComponent';
 import { ConnectionStatus, Message, MessageEventPayload, MessageEvents, PaginatedResult, Reaction } from '@ably/chat';
 
 export const Chat = (props: { roomId: string; setRoomId: (roomId: string) => void }) => {
@@ -20,7 +20,7 @@ export const Chat = (props: { roomId: string; setRoomId: (roomId: string) => voi
     if (getPreviousMessages) {
       getPreviousMessages({ limit: 50 })
         .then((result: PaginatedResult<Message>) => {
-          chatClient.logger.debug('backfilled messages', result);
+          chatClient.logger.debug('backfilled messages', result.items);
           setMessages(result.items.filter((m) => !m.isDeleted).reverse());
           setLoading(false);
         })


### PR DESCRIPTION
### Context

* The log was attempting to dump the whole results object. This would cause a type error `Converting circular structure to JSON` and then stop the messages from being populated.

### Description

* Updated the log to correctly dump only the items in the result.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [ ] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] (Optional) Update documentation for new features.
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

* Load up the demo with DEBUG enable, ensure the logs don't contain the type error when getting previous messages.
