### PR TITLE
Refactor: Clean up type docs and exports

### DIFF
--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -61,7 +61,7 @@ export type DeleteMessageResponse = MessageOperationResponse;
 
 interface UpdateMessageParams {
   /**
-   * Message data to update. All fields are updated and if omitted they are
+   * Message data to update. All fields are updated and, if omitted, they are
    * set to empty.
    */
   message: {

--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -55,9 +55,9 @@ interface MessageOperationResponse {
   timestamp: number;
 }
 
-export type UpdateMessageResponse = MessageOperationResponse;
+type UpdateMessageResponse = MessageOperationResponse;
 
-export type DeleteMessageResponse = MessageOperationResponse;
+type DeleteMessageResponse = MessageOperationResponse;
 
 interface UpdateMessageParams {
   /**

--- a/src/core/headers.ts
+++ b/src/core/headers.ts
@@ -3,12 +3,12 @@
  *
  * The headers are a flat key-value map and are sent as part of the realtime
  * message's extras inside the `headers` property. They can serve similar
- * purposes as Metadata but as opposed to Metadata they are read by Ably and
+ * purposes as Metadata, but as opposed to Metadata they are read by Ably and
  * can be used for features such as
  * [subscription filters](https://faqs.ably.com/subscription-filters).
  *
  * Do not use the headers for authoritative information. There is no
- * server-side validation. When reading the headers treat them like user
+ * server-side validation. When reading the headers, treat them like user
  * input.
  *
  */

--- a/src/core/id.ts
+++ b/src/core/id.ts
@@ -1,5 +1,5 @@
 /**
- * Generates a random string that can be used as an identifier, for instance in identifying specific room
+ * Generates a random string that can be used as an identifier, for instance, in identifying specific room
  * objects.
  *
  * @returns A random string that can be used as an identifier.

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -92,7 +92,7 @@ export interface Message {
    * This value is always set. If there are no headers, this is an empty object.
    *
    * Do not use the headers for authoritative information. There is no server-side
-   * validation. When reading the headers treat them like user input.
+   * validation. When reading the headers, treat them like user input.
    */
   readonly headers: MessageHeaders;
 
@@ -112,7 +112,7 @@ export interface Message {
   readonly timestamp: Date;
 
   /**
-   * The details of the operation that updated the message. This is only set for update and delete actions. It contains
+   * The details of the operation that modified the message. This is only set for update and delete actions. It contains
    * information about the operation: the clientId of the user who performed the operation, a description, and metadata.
    */
   readonly operation?: Operation;

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -133,7 +133,7 @@ export interface SendMessageParams {
    * emojis, etc.
    *
    * Do not use metadata for authoritative information. There is no server-side
-   * validation. When reading the metadata treat it like user input.
+   * validation. When reading the metadata, treat it like user input.
    *
    */
   metadata?: MessageMetadata;
@@ -143,12 +143,12 @@ export interface SendMessageParams {
    *
    * The headers are a flat key-value map and are sent as part of the realtime
    * message's extras inside the `headers` property. They can serve similar
-   * purposes as the metadata but they are read by Ably and can be used for
+   * purposes as the metadata, but they are read by Ably and can be used for
    * features such as
    * [subscription filters](https://faqs.ably.com/subscription-filters).
    *
    * Do not use the headers for authoritative information. There is no
-   * server-side validation. When reading the headers treat them like user
+   * server-side validation. When reading the headers, treat them like user
    * input.
    *
    */
@@ -219,7 +219,7 @@ export interface Messages extends EmitsDiscontinuities {
   subscribe(listener: MessageListener): MessageSubscriptionResponse;
 
   /**
-   * Unsubscribe all listeners from new messages in from chat room.
+   * Unsubscribe all listeners from new messages in the chat room.
    */
   unsubscribeAll(): void;
 

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -6,7 +6,7 @@
  * emojis, etc.
  *
  * Do not use metadata for authoritative information. There is no server-side
- * validation. When reading the metadata treat it like user input.
+ * validation. When reading the metadata, treat it like user input.
  *
  */
 export type Metadata = Record<string, unknown>;

--- a/src/react/helper/room-promise.ts
+++ b/src/react/helper/room-promise.ts
@@ -69,10 +69,10 @@ class DefaultRoomPromise implements RoomPromise {
 
   /**
    * Wait for the room promise to resolve, then execute the onResolve callback, storing its response as an unmount function.
-   * If the component is unmounted before the promise resolves,then this will do nothing.
+   * If the component is unmounted before the promise resolves, then this will do nothing.
    *
    * @param promise The promise that resolves to a Room instance.
-   * @returns A promise that we simply resolve when its done.
+   * @returns A promise that we simply resolve when it's done.
    */
   async mount(promise: Promise<Room>): Promise<void> {
     this._logger.debug('DefaultRoomPromise(); mount', { roomId: this._roomId });

--- a/src/react/hooks/use-messages.ts
+++ b/src/react/hooks/use-messages.ts
@@ -57,7 +57,7 @@ export interface UseMessagesResponse extends ChatStatusResponse {
    *
    * This method is available only if a {@link MessageListener} has been provided in the {@link UseMessagesParams}.
    * Calling will return a promise that resolves to a paginated response of the previous messages received in the room,
-   * up until the listener was attached, in the oldest to newest order.
+   * up until the listener was attached, in newest-to-oldest order.
    *
    * It is advised to call this method after any discontinuity event; to retrieve messages that may have been missed
    * before the listener was re-attached.


### PR DESCRIPTION
### Description

* Clean up of some typedoc comments
* Corrected an error in the getPreviousMessages typedoc, it stated the incorrect direction of fetched messages
* Removed an unused export from a type

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [ ] (Optional) Update documentation for new features.
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).
