### PR TITLE
react-native: add alternative installation for react native

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,10 @@
       - The second number represents a minor release, which lets users know new functionality or features have been added.
       - The third number represents a patch release, which represents bug-fixes and may be used when no action should be required from users.
    2. The commit should update `package.json` and `package-lock.json`. Running `npm install` after changing `package.json` will update `package-lock.json`.
-   3. The commit should also update `version.ts` to set the agent headers.
-   4. Update the `CHANGELOG.md` with any customer-affecting changes since the last release.
-   5. Update the README.md for any references to the new version.
+   3. The commit should also update `react-native/package.json` to the appropriate version.
+   4. The commit should also update `version.ts` to set the agent headers.
+   5. Update the `CHANGELOG.md` with any customer-affecting changes since the last release.
+   6. Update the README.md for any references to the new version.
 3. Merge the commit into main.
 4. Tag a release using [Github releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release). The version needs to match the one from the commit. Use the "Generate release notes" button to
    add changelog notes and update as required.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   },
   "files": [
     "dist/**",
-    "src/**"
+    "src/**",
+    "react-native/**"
   ],
   "repository": {
     "type": "git",

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@ably/chat-react-native",
+  "version": "0.3.0",
+  "main": "../chat/dist/react/ably-chat-react.umd.cjs",
+  "types": "../chat/dist/react/index.d.ts"
+}

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -9,7 +9,9 @@ If you're using **React Native**, you may need to perform extra steps to use the
 The React package is exported as an ESM module `@ably/chat/react`, making use of the `exports` field in `package.json`.
 The Metro bundler used by React Native does not by default utilize this field, leading to imports not being found.
 
-To use Chat with React Native, first set the `type` field of your React Native project to `module` and update your `tsconfig.json`
+### Option 1: Enable Package Exports
+
+React Native has started to support the `exports` field of `package.json`. To use Chat with React Native in this way, first set the `type` field of your React Native project to `module` and update your `tsconfig.json`
 to set `"moduleResolution": "Bundler"`. Finally, include the `unstable_enablePackageExports` field in
 your `metro.config.cjs`, which will enable `exports` resolution. For example:
 
@@ -26,6 +28,22 @@ module.exports = {
   },
 };
 ```
+
+### Option 2: Use Pseudo-package
+
+If the above isn't an option for you, you can instead use the `@ably/chat-react-native` pseudo-package with the Metro/Expo defaults.
+
+To do this, add the following to your `package.json`:
+
+```json
+{
+  "dependencies": {
+    "@ably/chat-react-native": "file:./node_modules/@ably/chat/react-native"
+  }
+}
+```
+
+Then, replace any imports of `@ably/chat/react` with `@ably/chat-react-native`.
 
 ## ChatClientProvider
 


### PR DESCRIPTION
### Description

To avoid having to change module resolution settings in Expo, this change introduces a pseudo-package `@ably/chat-react-native` which can then be used instead of `@ably/chat/react`.

Also includes README/CONTRIBUTING changes as required.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [ ] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [x] (Optional) Update documentation for new features.
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

- Create an `expo` app using the default settings.
- Follow Option 2 in the React Readme,
- Try using Chat in the expo app and things should work fine.