### PR TITLE
Message reactions POC

### DIFF
--- a/demo/src/components/MessageComponent/MessageComponent.tsx
+++ b/demo/src/components/MessageComponent/MessageComponent.tsx
@@ -10,6 +10,8 @@ interface MessageProps {
   onMessageUpdate?(message: Message): void;
 
   onMessageDelete?(msg: Message): void;
+
+  onMessageReact?(message: Message, reaction: string): void;
 }
 
 const shortDateTimeFormatter = new Intl.DateTimeFormat('default', {
@@ -37,6 +39,7 @@ export const MessageComponent: React.FC<MessageProps> = ({
   message,
   onMessageUpdate,
   onMessageDelete,
+  onMessageReact,
 }) => {
   const handleMessageUpdate = useCallback(
     (e: React.UIEvent) => {
@@ -52,6 +55,57 @@ export const MessageComponent: React.FC<MessageProps> = ({
       onMessageDelete?.(message);
     },
     [message, onMessageDelete],
+  );
+
+  const handleReaction = useCallback(
+    (reaction: string) => {
+      onMessageReact?.(message, reaction);
+    },
+    [message, onMessageReact],
+  );
+
+  const currentReactions = message.reactions;
+  const reactionsWithCounts = ['👍', '🚀', '🔥', '❤️'].map((emoji) => {
+    const count = currentReactions.get(emoji)?.count || 0;
+    return { emoji, count};
+  })
+
+  const messageReactionsUI = (
+    <span className="message-reactions">
+      {reactionsWithCounts.map((rwc) => (
+        <a
+          key={rwc.emoji}
+          onClick={(e) => {
+            e.preventDefault();
+            handleReaction(rwc.emoji);
+          }}
+          href="#"
+        >
+          {rwc.emoji}
+          {rwc.count > 0 ? "(" + rwc.count + ")" : ""}
+        </a>
+      ))}
+    </span>
+  );
+  const messageActionsUI = (
+    <div
+      className="buttons"
+      role="group"
+      aria-label="Message actions"
+    >
+      {!self && <>{messageReactionsUI} | </>}
+      <FaPencil
+        className="cursor-pointer text-gray-100 m-1 hover:text-gray-500 inline-block"
+        onClick={handleMessageUpdate}
+        aria-label="Edit message"
+      ></FaPencil>
+      <FaTrash
+        className="cursor-pointer text-red-500 m-1 hover:text-red-700 inline-block"
+        onClick={handleMessageDelete}
+        aria-label="Delete message"
+      />
+      {self && <> | {messageReactionsUI} </>}
+    </div>
   );
 
   return (
@@ -85,28 +139,13 @@ export const MessageComponent: React.FC<MessageProps> = ({
           </div>
           <div
             className={clsx('px-4 py-2 rounded-lg inline-block', {
-              ['rounded-br bg-blue-600 text-white']: self,
-              ['rounded-bl justify-start bg-gray-300 text-gray-600']: !self,
+              ['rounded-br bg-blue-600 text-white ml-4']: self,
+              ['rounded-bl justify-start bg-gray-300 text-gray-600 mr-4']: !self,
             })}
           >
             {message.text}
           </div>
-          <div
-            className="buttons"
-            role="group"
-            aria-label="Message actions"
-          >
-            <FaPencil
-              className="cursor-pointer text-gray-100 m-1 hover:text-gray-500 inline-block"
-              onClick={handleMessageUpdate}
-              aria-label="Edit message"
-            ></FaPencil>
-            <FaTrash
-              className="cursor-pointer text-red-500 m-1 hover:text-red-700 inline-block"
-              onClick={handleMessageDelete}
-              aria-label="Delete message"
-            />
-          </div>
+          {messageActionsUI}
         </div>
       </div>
     </div>

--- a/demo/src/components/MessageComponent/MessageComponent.tsx
+++ b/demo/src/components/MessageComponent/MessageComponent.tsx
@@ -1,4 +1,4 @@
-import { Message } from '@ably/chat';
+import { Message, MessageReactionMode } from '@ably/chat';
 import React, { useCallback } from 'react';
 import clsx from 'clsx';
 import { FaPencil, FaTrash } from 'react-icons/fa6';
@@ -11,7 +11,7 @@ interface MessageProps {
 
   onMessageDelete?(msg: Message): void;
 
-  onAddReaction?(message: Message, reaction: string, score?: number, unique?: boolean): void;
+  onAddReaction?(message: Message, reaction: string, score?: number, mode?: MessageReactionMode): void;
   
   onRemoveReaction?(message: Message, reaction: string): void;
 }
@@ -86,39 +86,59 @@ export const MessageComponent: React.FC<MessageProps> = ({
         >
           <a href="#" onClick={(e) => {
             e.preventDefault();
-            onAddReaction?.(message, rwc.emoji, 1, false);
+            onAddReaction?.(message, rwc.emoji, 1, MessageReactionMode.Add);
           }}>{rwc.emoji}</a>
           {rwc.data?.score && rwc.data?.score > 0 ? "(" + rwc.data.score + ")" : ""}
           <div className="message-reaction-menu">
             <ul>
               <li><a href="#" onClick={(e) => {
                 e.preventDefault();
-                onAddReaction?.(message, rwc.emoji, 1, false);
-              }}>Add reaction (default)</a></li>
+                onAddReaction?.(message, rwc.emoji, 1, MessageReactionMode.Add);
+              }}>Add {rwc.emoji} reaction (default)</a></li>
+              
               <li><a href="#" onClick={(e) => {
                 e.preventDefault();
-                onAddReaction?.(message, rwc.emoji, 1, true);
-              }}>Add unique reaction</a></li>
+                onAddReaction?.(message, rwc.emoji, 1, MessageReactionMode.Unique);
+              }}>Add unique {rwc.emoji} reaction</a></li>
+
+              <li><a href="#" onClick={(e) => {
+                e.preventDefault();
+                onAddReaction?.(message, rwc.emoji, 1, MessageReactionMode.Replace);
+              }}>Replace {rwc.emoji} reaction</a></li>
+
+
               <li><a href="#" onClick={(e) => {
                 e.preventDefault();
                 let scoreStr = prompt("Enter score");
                 if (!scoreStr) return;
                 let score = parseInt(scoreStr);
                 if (!score || score <= 0) return;
-                onAddReaction?.(message, rwc.emoji, score, false);
-              }}>Add reaction with score</a></li>
+                onAddReaction?.(message, rwc.emoji, score, MessageReactionMode.Add);
+              }}>Add {rwc.emoji} reaction with score</a></li>
+              
               <li><a href="#" onClick={(e) => {
                 e.preventDefault();
                 let scoreStr = prompt("Enter score");
                 if (!scoreStr) return;
                 let score = parseInt(scoreStr);
                 if (!score || score <= 0) return;
-                onAddReaction?.(message, rwc.emoji, score, true);
-              }}>Add unique reaction with score</a></li>
+                onAddReaction?.(message, rwc.emoji, score, MessageReactionMode.Unique);
+              }}>Add unique {rwc.emoji} reaction with score</a></li>
+
+              <li><a href="#" onClick={(e) => {
+                e.preventDefault();
+                let scoreStr = prompt("Enter score");
+                if (!scoreStr) return;
+                let score = parseInt(scoreStr);
+                if (!score || score <= 0) return;
+                onAddReaction?.(message, rwc.emoji, score, MessageReactionMode.Replace);
+              }}>Replace {rwc.emoji} reaction with score</a></li>
+
+              
               <li><a href="#" onClick={(e) => {
                 e.preventDefault();
                 onRemoveReaction?.(message, rwc.emoji);
-              }}>Remove reaction</a></li>
+              }}>Remove {rwc.emoji} reaction</a></li>
             </ul>
             <div>
               <p>

--- a/demo/src/components/MessageComponent/MessageComponent.tsx
+++ b/demo/src/components/MessageComponent/MessageComponent.tsx
@@ -81,7 +81,7 @@ export const MessageComponent: React.FC<MessageProps> = ({
     <div className="message-reactions">
       {reactionsWithCounts.map((rwc) => (
         <div
-        className="message-reaction"
+        className={"message-reaction "+(self ? "message-reaction-self" : "message-reaction-other")}
           key={rwc.emoji}
         >
           <a href="#" onClick={(e) => {

--- a/demo/src/containers/Chat/Chat.tsx
+++ b/demo/src/containers/Chat/Chat.tsx
@@ -46,7 +46,9 @@ export const Chat = (props: { roomId: string; setRoomId: (roomId: string) => voi
     send: sendMessage,
     deleteMessage,
     update,
-    react: reactToMessage,
+    addReaction,
+    removeReaction,
+    removeAllReactions,
     messages: untypedMessagesObject,
   } = useMsgResponse;
 
@@ -243,7 +245,8 @@ export const Chat = (props: { roomId: string; setRoomId: (roomId: string) => voi
               message={msg}
               onMessageDelete={onDeleteMessage}
               onMessageUpdate={onUpdateMessage}
-              onMessageReact={reactToMessage}
+              onAddReaction={addReaction}
+              onRemoveReaction={removeReaction}
             ></MessageComponent>
           ))}
           <div ref={messagesEndRef} />

--- a/demo/src/containers/Chat/Chat.tsx
+++ b/demo/src/containers/Chat/Chat.tsx
@@ -68,7 +68,8 @@ export const Chat = (props: { roomId: string; setRoomId: (roomId: string) => voi
       setSnapshot(snapshot);
     });
 
-    const s = messagesObj.subscribe(msgWindow);
+    const s = messagesObj.subscribe(msgWindow.messagesListener);
+    const rs = messagesObj.reactions.subscribeSummaries(msgWindow.summariesListener);
     msgWindow
       .backfillHistory(
         s.getPreviousMessages({ limit: 50 }).then((result) => {
@@ -86,6 +87,7 @@ export const Chat = (props: { roomId: string; setRoomId: (roomId: string) => voi
     return () => {
       mounted = false;
       s.unsubscribe();
+      rs.unsubscribe();
       windowSub.unsubscribe();
     };
   }, [messagesObj]);

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -57,9 +57,26 @@ body {
 }
 
 .chat-message .buttons {
-  display: none;
+  display: inline-block;
+  opacity: 0;
+  transition: all 0.1s ease-in-out;
 }
 
 .chat-message:hover .buttons {
-  display: block;
+  display: inline-block;
+  opacity: 1;
+}
+
+.chat-message .message-reactions > a {
+  opacity: 0.8;
+  transition: all 0.1s ease-in-out;
+  display: inline-block;
+  padding-left: 2px;
+  padding-right: 2px;
+  filter: grayscale(100%);
+}
+.chat-message .message-reactions > a:hover {
+  transform: scale(1.3);
+  opacity: 1;
+  filter: none;
 }

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -86,7 +86,7 @@ body {
 }
 
 .message-reaction-self .message-reaction-menu {
-  right: 10%;
+  right: -30px;
 }
 
 .message-reaction-other .message-reaction-menu {

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -67,6 +67,41 @@ body {
   opacity: 1;
 }
 
+
+.message-reactions {
+  display: inline-block;
+}
+
+.message-reaction-menu {
+  display: none;
+}
+
+.message-reaction {
+  display: inline-block;
+  position: relative;
+}
+
+.message-reaction:hover .message-reaction-menu {
+  display: block;
+  position: absolute;
+  right: 10%;
+  width: 200px;
+  z-index: 10000;
+  background: black;
+}
+
+.message-reaction-menu a {
+  display: block;
+  padding: 5px;
+}
+
+.message-reaction-menu a:hover {
+  display: block;
+  padding: 5px;
+  background: red;
+}
+
+
 .chat-message .message-reactions > a {
   opacity: 0.8;
   transition: all 0.1s ease-in-out;

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -81,10 +81,22 @@ body {
   position: relative;
 }
 
+.message-reaction:hover {
+  background: black;
+}
+
+.message-reaction-self .message-reaction-menu {
+  right: 10%;
+}
+
+.message-reaction-other .message-reaction-menu {
+  left: 10%;
+}
+
+
 .message-reaction:hover .message-reaction-menu {
   display: block;
   position: absolute;
-  right: 10%;
   width: 200px;
   z-index: 10000;
   background: black;

--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -141,6 +141,7 @@ export class ChatApi {
         (message.createdAt as Date | undefined) ? new Date(message.createdAt) : new Date(message.timestamp),
         new Date(message.timestamp),
         message.operation,
+        message.reactions,
       );
     };
 

--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -202,15 +202,40 @@ export class ChatApi {
     );
   }
 
-  async reactToMessage(roomId: string, serial: string, reaction: string): Promise<void> {
+  async addMessageReaction(roomId: string, serial: string, reaction: string, score : number = 1, unique : boolean = false): Promise<void> {
     roomId = encodeURIComponent(roomId);
     return this._makeAuthorizedRequest(`/channels/${roomId}::$chat::$chatMessages/messages`, 'POST', {
-      action: 4,
-      data: reaction,
+      action: 5,
+      data: JSON.stringify({emoji: reaction, score: score, unique: unique}),
       refType: 'reaction:emoji.v1',
       refSerial: serial,
     }).then((response) => {
       console.log('response from sending reaction:', response);
+    });
+  }
+
+  async removeAllMessageReactions(roomId: string, serial: string): Promise<void> {
+    roomId = encodeURIComponent(roomId);
+    return this._makeAuthorizedRequest(`/channels/${roomId}::$chat::$chatMessages/messages`, 'POST', {
+      action: 6,
+      data: "",
+      refType: 'reaction:emoji.v1',
+      refSerial: serial,
+    }).then((response) => {
+      console.log('response from removing all reactions:', response);
+    });
+  }
+
+
+  async removeMessageReaction(roomId: string, serial: string, reaction: string): Promise<void> {
+    roomId = encodeURIComponent(roomId);
+    return this._makeAuthorizedRequest(`/channels/${roomId}::$chat::$chatMessages/messages`, 'POST', {
+      action: 6,
+      data: JSON.stringify({emoji: reaction}),
+      refType: 'reaction:emoji.v1',
+      refSerial: serial,
+    }).then((response) => {
+      console.log(`response from removing '${reaction}' reaction:`, response);
     });
   }
 

--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -2,7 +2,7 @@ import * as Ably from 'ably';
 
 import { Logger } from './logger.js';
 import { DefaultMessage, Message, MessageHeaders, MessageMetadata, MessageOperationMetadata } from './message.js';
-import { OrderBy } from './messages.js';
+import { MessageReactionMode, OrderBy } from './messages.js';
 import { OccupancyEvent } from './occupancy.js';
 import { PaginatedResult } from './query.js';
 
@@ -202,11 +202,11 @@ export class ChatApi {
     );
   }
 
-  async addMessageReaction(roomId: string, serial: string, reaction: string, score : number = 1, unique : boolean = false): Promise<void> {
+  async addMessageReaction(roomId: string, serial: string, reaction: string, score : number = 1, mode : MessageReactionMode = MessageReactionMode.Add): Promise<void> {
     roomId = encodeURIComponent(roomId);
     return this._makeAuthorizedRequest(`/channels/${roomId}::$chat::$chatMessages/messages`, 'POST', {
       action: 5,
-      data: JSON.stringify({emoji: reaction, score: score, unique: unique}),
+      data: JSON.stringify({emoji: reaction, score: score, mode: mode}),
       refType: 'reaction:emoji.v1',
       refSerial: serial,
     }).then((response) => {

--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -202,6 +202,18 @@ export class ChatApi {
     );
   }
 
+  async reactToMessage(roomId: string, serial: string, reaction: string): Promise<void> {
+    roomId = encodeURIComponent(roomId);
+    return this._makeAuthorizedRequest(`/channels/${roomId}::$chat::$chatMessages/messages`, 'POST', {
+      action: 4,
+      data: reaction,
+      refType: 'reaction:emoji.v1',
+      refSerial: serial,
+    }).then((response) => {
+      console.log('response from sending reaction:', response);
+    });
+  }
+
   async getOccupancy(roomId: string): Promise<OccupancyEvent> {
     roomId = encodeURIComponent(roomId);
     return this._makeAuthorizedRequest<OccupancyEvent>(`/chat/v1/rooms/${roomId}/occupancy`, 'GET');

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -55,7 +55,7 @@ export enum ChatMessageActions {
   MessageMetaOccupancy = 'meta.occupancy',
 
   /** Action applied to an annotation summary message. */
-  MessageAnnotationSummary = 7,
+  MessageAnnotationSummary = 'message.summary',
 }
 
 /**

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -10,6 +10,15 @@ export enum MessageEvents {
 
   /** Fires when a chat message is deleted. */
   Deleted = 'message.deleted',
+
+  /** Fires when a chat message reaction is created. */
+  ReactionCreated = 'reaction.created',
+
+  /** Fires when a chat message reaction is deleted. */
+  ReactionDeleted = 'reaction.deleted',
+
+  /** Fires when a message reaction summary is received. */
+  ReactionSummary = 'reaction.summary',
 }
 
 /**
@@ -44,6 +53,9 @@ export enum ChatMessageActions {
 
   /** Action applied to a meta occupancy message. */
   MessageMetaOccupancy = 'meta.occupancy',
+
+  /** Action applied to an annotation summary message. */
+  MessageAnnotationSummary = 7,
 }
 
 /**

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -28,12 +28,12 @@ export type { LogContext, Logger, LogHandler } from './logger.js';
 export { LogLevel } from './logger.js';
 export type { Message, MessageHeaders, MessageMetadata, MessageOperationMetadata, Operation } from './message.js';
 export type {
-  MessageEventPayload,
+  MessageEvent as MessageEventPayload,
   MessageListener,
-  MessageReactionPayload,
-  MessageReactionSummaryPayload,
+  MessageReactionEvent as MessageReactionPayload,
+  MessageReactionSummaryEvent as MessageReactionSummaryPayload,
   ReactionsListener,
-  SummariesListener,
+  ReactionSummaryListener as SummariesListener,
 } from './message-events.js';
 export type { Snapshot } from './message-window.js';
 export { MessageWindow } from './message-window.js';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -28,9 +28,17 @@ export type { LogContext, Logger, LogHandler } from './logger.js';
 export { LogLevel } from './logger.js';
 export type { Message, MessageHeaders, MessageMetadata, MessageOperationMetadata, Operation } from './message.js';
 export type {
-  DeleteMessageParams,
   MessageEventPayload,
   MessageListener,
+  MessageReactionPayload,
+  MessageReactionSummaryPayload,
+  ReactionsListener,
+  SummariesListener,
+} from './message-events.js';
+export type { Snapshot } from './message-window.js';
+export { MessageWindow } from './message-window.js';
+export type {
+  DeleteMessageParams,
   Messages,
   MessageSubscriptionResponse,
   OperationDetails,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -47,6 +47,7 @@ export type {
   SendMessageParams,
   UpdateMessageParams,
 } from './messages.js';
+export { MessageReactionMode } from './messages.js';
 export type { Metadata } from './metadata.js';
 export type { Occupancy, OccupancyEvent, OccupancyListener, OccupancySubscriptionResponse } from './occupancy.js';
 export type { OperationMetadata } from './operation-metadata.js';

--- a/src/core/message-events.ts
+++ b/src/core/message-events.ts
@@ -1,25 +1,15 @@
 import { ChatMessageActions, MessageEvents } from './events';
 import { Message, MessageReactionSummary } from './message';
 
-export interface EventPayload {
-  /**
-   * The type of the message event.
-   */
-  type: MessageEvents;
-
-  /**
-   * A shorthand to get the relevant message serial. For message events like
-   * create, update and delete this is the message serial. For annotations
-   * (eg. reactions) this is the `serial` of the relevant chat message, usually
-   * found under `refSerial`.
-   */
-  get messageSerial(): string;
-}
-
 /**
  * Payload for a message event.
  */
-export interface MessageEventPayload extends EventPayload {
+export interface MessageEvent {
+  /**
+   * The type of the message event.
+   */
+  type: MessageEvents.Created | MessageEvents.Updated | MessageEvents.Deleted;
+
   /**
    * The message that was received.
    */
@@ -30,6 +20,7 @@ export interface MessageEventPayload extends EventPayload {
  * Payload representing a single message reaction.
  */
 export interface MessageReaction {
+
   /**
    * Serial of the message this reaction is for.
    */
@@ -64,14 +55,24 @@ export interface MessageReactionSummaries {
   reactions: Map<string, MessageReactionSummary>;
 }
 
-export interface MessageReactionPayload extends EventPayload {
+export interface MessageReactionEvent{
+  /**
+   * The type of the message reaction event.
+   */
+  type: MessageEvents.ReactionCreated | MessageEvents.ReactionDeleted;
+
   /**
    * The message that was received.
    */
   reaction: MessageReaction;
 }
 
-export interface MessageReactionSummaryPayload extends EventPayload {
+export interface MessageReactionSummaryEvent {
+  /**
+   * The type of the message reaction summary event.
+   */
+  type: MessageEvents.ReactionSummary;
+  
   /**
    * The message that was received.
    */
@@ -82,38 +83,27 @@ export interface MessageReactionSummaryPayload extends EventPayload {
  * A listener for message events in a chat room.
  * @param event The message event that was received.
  */
-export type MessageListener = (event: MessageEventPayload) => void;
+export type MessageListener = (event: MessageEvent) => void;
 
-export type ReactionsListener = (event: MessageReactionPayload) => void;
+export type ReactionsListener = (event: MessageReactionEvent) => void;
 
-export type SummariesListener = (event: MessageReactionSummaryPayload) => void;
-
-export interface MessageListenerObject {
-  messages?: MessageListener;
-  reactions?: ReactionsListener;
-  summaries?: SummariesListener;
-}
+export type ReactionSummaryListener = (event: MessageReactionSummaryEvent) => void;
 
 /**
  * Event names and their respective payloads emitted by the messages feature.
  */
 export interface MessageEventsMap {
-  [MessageEvents.Created]: MessageEventPayload;
-  [MessageEvents.Updated]: MessageEventPayload;
-  [MessageEvents.Deleted]: MessageEventPayload;
-  [MessageEvents.ReactionCreated]: MessageReactionPayload;
-  [MessageEvents.ReactionDeleted]: MessageReactionPayload;
-  [MessageEvents.ReactionSummary]: MessageReactionSummaryPayload;
+  [MessageEvents.Created]: MessageEvent;
+  [MessageEvents.Updated]: MessageEvent;
+  [MessageEvents.Deleted]: MessageEvent;
 }
-
-export type AnyMessageEvent = MessageEventsMap[keyof MessageEventsMap];
 
 /**
  * Mapping of chat message actions to message events.
  */
-export const MessageActionsToEventsMap: Map<ChatMessageActions, MessageEvents> = new Map<
+export const MessageActionsToEventsMap = new Map<
   ChatMessageActions,
-  MessageEvents
+  MessageEvents.Created | MessageEvents.Updated | MessageEvents.Deleted
 >([
   [ChatMessageActions.MessageCreate, MessageEvents.Created],
   [ChatMessageActions.MessageUpdate, MessageEvents.Updated],

--- a/src/core/message-events.ts
+++ b/src/core/message-events.ts
@@ -1,0 +1,121 @@
+import { ChatMessageActions, MessageEvents } from './events';
+import { Message, MessageReactionSummary } from './message';
+
+export interface EventPayload {
+  /**
+   * The type of the message event.
+   */
+  type: MessageEvents;
+
+  /**
+   * A shorthand to get the relevant message serial. For message events like
+   * create, update and delete this is the message serial. For annotations
+   * (eg. reactions) this is the `serial` of the relevant chat message, usually
+   * found under `refSerial`.
+   */
+  get messageSerial(): string;
+}
+
+/**
+ * Payload for a message event.
+ */
+export interface MessageEventPayload extends EventPayload {
+  /**
+   * The message that was received.
+   */
+  message: Message;
+}
+
+/**
+ * Payload representing a single message reaction.
+ */
+export interface MessageReaction {
+  /**
+   * Serial of the message this reaction is for.
+   */
+  refSerial: string;
+
+  /**
+   * The reaction (ie. the emoji).
+   */
+  reaction: string;
+
+  /**
+   * The client ID of the user who added the reaction.
+   */
+  clientId: string;
+}
+
+/** Payload representing a message reaction summary event. */
+export interface MessageReactionSummaries {
+  /**
+   * Timestamp of the summary.
+   */
+  timestamp: Date;
+
+  /**
+   * Serial of the message this summary references.
+   */
+  refSerial: string;
+
+  /**
+   * Summary Record for each reaction, keyed by the reaction.
+   */
+  reactions: Map<string, MessageReactionSummary>;
+}
+
+export interface MessageReactionPayload extends EventPayload {
+  /**
+   * The message that was received.
+   */
+  reaction: MessageReaction;
+}
+
+export interface MessageReactionSummaryPayload extends EventPayload {
+  /**
+   * The message that was received.
+   */
+  summary: MessageReactionSummaries;
+}
+
+/**
+ * A listener for message events in a chat room.
+ * @param event The message event that was received.
+ */
+export type MessageListener = (event: MessageEventPayload) => void;
+
+export type ReactionsListener = (event: MessageReactionPayload) => void;
+
+export type SummariesListener = (event: MessageReactionSummaryPayload) => void;
+
+export interface MessageListenerObject {
+  messages?: MessageListener;
+  reactions?: ReactionsListener;
+  summaries?: SummariesListener;
+}
+
+/**
+ * Event names and their respective payloads emitted by the messages feature.
+ */
+export interface MessageEventsMap {
+  [MessageEvents.Created]: MessageEventPayload;
+  [MessageEvents.Updated]: MessageEventPayload;
+  [MessageEvents.Deleted]: MessageEventPayload;
+  [MessageEvents.ReactionCreated]: MessageReactionPayload;
+  [MessageEvents.ReactionDeleted]: MessageReactionPayload;
+  [MessageEvents.ReactionSummary]: MessageReactionSummaryPayload;
+}
+
+export type AnyMessageEvent = MessageEventsMap[keyof MessageEventsMap];
+
+/**
+ * Mapping of chat message actions to message events.
+ */
+export const MessageActionsToEventsMap: Map<ChatMessageActions, MessageEvents> = new Map<
+  ChatMessageActions,
+  MessageEvents
+>([
+  [ChatMessageActions.MessageCreate, MessageEvents.Created],
+  [ChatMessageActions.MessageUpdate, MessageEvents.Updated],
+  [ChatMessageActions.MessageDelete, MessageEvents.Deleted],
+]);

--- a/src/core/message-window.ts
+++ b/src/core/message-window.ts
@@ -1,0 +1,187 @@
+import { PaginatedResult } from 'ably';
+
+import { MessageEvents } from './events';
+import { Message } from './message';
+import {
+  AnyMessageEvent,
+  MessageEventPayload,
+  MessageListenerObject,
+  MessageReaction,
+  MessageReactionPayload,
+  MessageReactionSummaries,
+  MessageReactionSummaryPayload,
+} from './message-events';
+import { MessageSubscriptionResponse } from './messages';
+import { Room } from './room';
+import EventEmitter from './utils/event-emitter';
+
+// Snapshots share the same Message[] array to save memory and copy time
+// the snapshots themselves are immutable, so they are guaranteed to change
+// reference when any message is added, updated or deleted, or reactions changed
+export interface Snapshot {
+  messages: Message[];
+}
+
+interface Subscription {
+  unsubscribe(): void;
+}
+
+export class MessageWindow implements MessageListenerObject {
+  private _snapshot: Snapshot;
+  private _emitter = new EventEmitter<{ snapshot: Snapshot }>();
+
+  constructor() {
+    this._snapshot = { messages: [] };
+
+
+    // this.messages = this.messages.bind(this);
+    // this.reactions = this.reactions.bind(this);
+    // this.summaries = this.summaries.bind(this);
+  }
+
+  public subscribe(listener: (snapshot: Snapshot) => void): Subscription {
+    listener(this._snapshot); // instantly publish current state on subscribe
+    this._emitter.on((snap) => {
+      listener(snap);
+    });
+    return { unsubscribe: () => { this._emitter.off(listener); } };
+  }
+
+  public backfillHistory(history: Promise<PaginatedResult<Message> | null>): Promise<void> {
+    const p = history.then((result) => {
+      if (result === null) {
+        return;
+      }
+
+      if (result.items.length === 0) {
+        return;
+      }
+
+      const messages = this._snapshot.messages;
+      messages.push(...result.items);
+
+      messages.sort((a, b) => {
+        // by serial first, oldest first
+        if (a.serial > b.serial) {
+          return 1;
+        }
+        if (a.serial < b.serial) {
+          return -1;
+        }
+        // then by version, newest first
+        if (a.version > b.version) {
+          return -1;
+        }
+        if (a.version < b.version) {
+          return 1;
+        }
+        return 0;
+      });
+
+      // filter out duplicates
+      messages.filter((msg, idx, arr) => {
+        if (idx === 0) {
+          return true;
+        }
+        return msg.serial !== (arr[idx - 1]!).serial;
+      });
+
+      this._updateSnapshot();
+      if (result.hasNext()) {
+        return this.backfillHistory(result.next());
+      }
+    });
+    p.catch((error) => {}); // avoid global errors if users don't catch history fetch errors
+    return p;
+  }
+
+  /**
+   * This method is called by room.messages.subscribe. Not part of the public API for this class.
+   */
+  public messages = (event: MessageEventPayload) => {
+    if (event.type === MessageEvents.Created) {
+      this._processNewMessage(event);
+      return;
+    }
+    this._processEvent(event);
+  };
+
+  /**
+   * This method is called by room.messages.subscribe. Not part of the public API for this class.
+   */
+  public reactions = (event: MessageReactionPayload) => {
+    // rely on summaries only, ignore individual reactions
+  };
+
+  /**
+   * This method is called by room.messages.subscribe. Not part of the public API for this class.
+   */
+  public summaries = (event: MessageReactionSummaryPayload) => {
+    this._processEvent(event);
+  };
+
+  private _processNewMessage(event: MessageEventPayload) {
+    const message = event.message;
+    const idx = this._snapshot.messages.findLastIndex((m) => m.serial === message.serial);
+    if (idx !== -1) {
+      // message already exists, do nothing
+      return;
+    }
+
+    const messages = this._snapshot.messages;
+    messages.push(message);
+
+    // sort message at the right place
+    // (please excuse the `as Message` faff, pleasing the linter)
+    for (let i = messages.length - 1; i > 1; i--) {
+      if ((messages[i]!).before(messages[i - 1]!)) {
+        const temp = messages[i]!;
+        messages[i] = messages[i - 1]!;
+        messages[i - 1] = temp;
+      }
+    }
+
+    this._updateSnapshot();
+  }
+
+  private _processEvent(event: AnyMessageEvent) {
+    const messageSerial = event.messageSerial;
+    const idx = this._snapshot.messages.findIndex((m) => m.serial === messageSerial);
+    if (idx === -1) {
+      // message doesn't exist, if it's an update or delete and within scope, add to list
+      if (event.type === MessageEvents.Updated || event.type === MessageEvents.Deleted) {
+        event = event as MessageEventPayload;
+        if (this._snapshot.messages.length === 0) {
+          this._snapshot.messages.push(event.message);
+          this._updateSnapshot();
+        } else {
+          // if the message is newer than the first message in the list, add it
+          // use message create processing to ensure it'll be added in the right place
+          const firstSerial = this._snapshot.messages[0]?.serial!;
+          if (event.messageSerial > firstSerial) {
+            this._processNewMessage(event);
+          }
+        }
+      }
+
+      // otherwise do nothing
+      return;
+    }
+
+    // update message in messages list
+    const foundMessage = this._snapshot.messages[idx]!;
+    const newMessage = foundMessage.apply(event);
+
+    // if the message has changed, update and publish the new snapshot
+    if (newMessage !== foundMessage) {
+      this._snapshot.messages[idx] = foundMessage.apply(event);
+      this._updateSnapshot();
+    }
+  }
+
+  // make a new shallow copy of the snapshot object and publish it
+  private _updateSnapshot() {
+    this._snapshot = { messages: this._snapshot.messages };
+    this._emitter.emit('snapshot', this._snapshot);
+  }
+}

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -274,6 +274,12 @@ export interface Messages extends EmitsDiscontinuities {
   get channel(): Ably.RealtimeChannel;
 }
 
+export enum MessageReactionMode {
+  Add = "add",
+  Replace = "replace",
+  Unique = "unique",
+}
+
 export class DefaultMessageReactions {
   private readonly _chatApi: ChatApi;
 
@@ -281,8 +287,8 @@ export class DefaultMessageReactions {
     this._chatApi = chatApi;
   }
 
-  add(message : Message, reaction : string, score : number = 1, unique : boolean = false) {
-    return this._chatApi.addMessageReaction(message.roomId, message.serial, reaction, score, unique);
+  add(message : Message, reaction : string, score : number = 1, mode : MessageReactionMode = MessageReactionMode.Add) {
+    return this._chatApi.addMessageReaction(message.roomId, message.serial, reaction, score, mode);
   }
 
   remove(message : Message, reaction : string) {

--- a/src/core/utils/event-emitter.ts
+++ b/src/core/utils/event-emitter.ts
@@ -14,6 +14,7 @@ import * as Ably from 'ably';
  * InterfaceEventEmitter.
  */
 type Callback<EventsMap> = (arg: EventsMap[keyof EventsMap]) => void;
+type CallbackSingle<K> = (arg: K) => void;
 
 /**
  * This interface extends the Ably.EventEmitter interface to add a type-safe
@@ -22,6 +23,24 @@ type Callback<EventsMap> = (arg: EventsMap[keyof EventsMap]) => void;
  */
 interface InterfaceEventEmitter<EventsMap> extends Ably.EventEmitter<Callback<EventsMap>, void, keyof EventsMap> {
   emit<K extends keyof EventsMap>(event: K, arg: EventsMap[K]): void;
+
+  on<K extends keyof EventsMap>(event: K, callback: CallbackSingle<EventsMap[K]>): void;
+  on<K1 extends keyof EventsMap, K2 extends keyof EventsMap>(
+    events: [K1, K2],
+    callback: CallbackSingle<EventsMap[K1] | EventsMap[K2]>,
+  ): void;
+  on<K1 extends keyof EventsMap, K2 extends keyof EventsMap, K3 extends keyof EventsMap>(
+    events: [K1, K2, K3],
+    callback: CallbackSingle<EventsMap[K1] | EventsMap[K2] | EventsMap[K3]>,
+  ): void;
+  on(events: (keyof EventsMap)[], callback: Callback<EventsMap>): void;
+  on(callback: Callback<EventsMap>): void;
+
+  off<K extends keyof EventsMap>(event: K, listener: CallbackSingle<EventsMap[K]>): void;
+  off(listener: Callback<EventsMap>): void;
+  off<K extends EventsMap[keyof EventsMap]>(listener: CallbackSingle<K>): void;
+
+  off(): void;
 }
 
 /**

--- a/src/react/hooks/use-messages.ts
+++ b/src/react/hooks/use-messages.ts
@@ -10,6 +10,7 @@ import {
   SendMessageParams,
   SummariesListener,
   UpdateMessageParams,
+  MessageReactionMode
 } from '@ably/chat';
 import * as Ably from 'ably';
 import { useCallback, useEffect, useState } from 'react';
@@ -146,8 +147,8 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
     [context],
   );
 
-  const addReaction = useCallback(
-    (message: Message, reaction: string, score: number = 1, unique : boolean = false) => context.room.then((room) => room.messages.reactions.add(message, reaction, score, unique)),
+  const addReaction : Messages["reactions"]["add"] = useCallback(
+    (message, reaction, score = 1, mode = MessageReactionMode.Add) => context.room.then((room) => room.messages.reactions.add(message, reaction, score, mode)),
     [context],
   );
 

--- a/src/react/hooks/use-messages.ts
+++ b/src/react/hooks/use-messages.ts
@@ -50,9 +50,19 @@ export interface UseMessagesResponse extends ChatStatusResponse {
   readonly deleteMessage: Messages['delete'];
 
   /**
-   * A shortcut to the {@link Messages.react} method.
+   * A shortcut to the {@link Messages.reactions.add} method.
    */
-  readonly react: Messages['react'];
+  readonly addReaction: Messages["reactions"]["add"];
+
+  /**
+   * A shortcut to the {@link Messages.reactions.remove} method.
+   */
+  readonly removeReaction: Messages["reactions"]["remove"];
+
+  /**
+   * A shortcut to the {@link Messages.reactions.removeAll} method.
+   */
+  readonly removeAllReactions: Messages["reactions"]["removeAll"];
 
   /**
    * Provides access to the underlying {@link Messages} instance of the room.
@@ -135,10 +145,22 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
       context.room.then((room) => room.messages.update(message, update, details)),
     [context],
   );
-  const react = useCallback(
-    (message: Message, reaction: string) => context.room.then((room) => room.messages.react(message, reaction)),
+
+  const addReaction = useCallback(
+    (message: Message, reaction: string, score: number = 1, unique : boolean = false) => context.room.then((room) => room.messages.reactions.add(message, reaction, score, unique)),
     [context],
   );
+
+  const removeReaction = useCallback(
+    (message: Message, reaction: string) => context.room.then((room) => room.messages.reactions.remove(message, reaction)),
+    [context],
+  );
+
+  const removeAllReactions = useCallback(
+    (message: Message) => context.room.then((room) => room.messages.reactions.removeAll(message)),
+    [context],
+  );
+
 
   const [getPreviousMessages, setGetPreviousMessages] = useState<MessageSubscriptionResponse['getPreviousMessages']>();
 
@@ -214,7 +236,9 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
     get,
     deleteMessage,
     getPreviousMessages,
-    react,
+    addReaction,
+    removeReaction,
+    removeAllReactions,
     connectionStatus,
     connectionError,
     roomStatus,


### PR DESCRIPTION
### Context

- POC for message reactions
- For the POC, this uses the realtime HTTP endpoint instead of a chat-specific one



This allows
- Adding a reaction, and allows for multiple reactions of any type
- Adding a new reaction and at the same time removing all other reactions (to facilitate "react only once" behaviour)
- Scores for each reaction. Scores are added up in summaries.
- Summaries give you total score, total number of reactions, number of users who reacted, and the score and total for each clientId that has reacted.
- Removing all reactions for a message for the current user (not in demo app but supported)
- Removing all reactions for a single emoji for a message for the current user (in demo app as well)


The UI in the demo app shows all options explicitly. In a real application different features will be showed differently. E.g. adding scores might be a through a long-press on the emoji.

<img width="280" alt="image" src="https://github.com/user-attachments/assets/2d905740-6ea5-4338-8543-feea47a4aaff" />


### Likely will be extracted in different PRs
- Introduction of a Message Window abstraction to simplify keeping a list of messages up to date
- `message.with(event)` method for applying an event to get a new message version

### Does not yet have:
- fetching reactions from history, you only see reactions if you/someone reacts while you're online
- the correct way to subscribe to reaction summaries via `room.messages.reactions.subscribeSummaries` or individual reactions via `room.messages.reactions.subscribe()`. It still goes through `room.messages.subscribe()`.

JIRA:
- https://ably.atlassian.net/browse/CHA-635
- https://ably.atlassian.net/browse/CHA-636
- https://ably.atlassian.net/browse/CHA-619
- https://ably.atlassian.net/browse/CHA-702

### Checklist

* [ ] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [ ] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] (Optional) Update documentation for new features.
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

### Testing Instructions

- React to messages
- MessageWindow is used in demo app so you can see it in action

