### PR TITLE
Add message.with(event) method for applying message events to a Message

### DIFF
--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+a {
+  color: rgb(37 99 235);
+}
+
+a:hover {
+  color: rgb(66, 126, 255);
+  text-decoration: underline;
+}
+
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -52,10 +61,12 @@ body {
   padding: 5px;
   margin-right: 2px;
   transition: all 100ms;
+  text-decoration: none;
 }
 
 .reactions-picker > a:hover {
   scale: 1.5;
+  text-decoration: none;
 }
 
 .reactions-picker > a:active {
@@ -85,4 +96,12 @@ body {
 
 .chat-message:hover .buttons {
   display: block;
+}
+
+.deleted-message {
+  color: gray;
+  margin: 10px;
+  padding: 5px;
+  border-radius: 5px;
+  background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -1,3 +1,5 @@
+import { Message } from './message.js';
+
 /**
  * All chat message events.
  */
@@ -84,4 +86,19 @@ export enum RoomReactionEvents {
    * Event triggered when a room reaction was received.
    */
   Reaction = 'roomReaction',
+}
+
+/**
+ * Payload for a message event.
+ */
+export interface MessageEventPayload {
+  /**
+   * The type of the message event.
+   */
+  type: MessageEvents;
+
+  /**
+   * The message that was received.
+   */
+  message: Message;
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -13,6 +13,7 @@ export type {
 export { ConnectionStatus } from './connection.js';
 export type { DiscontinuityListener, OnDiscontinuitySubscriptionResponse } from './discontinuity.js';
 export { ErrorCodes, errorInfoIs } from './errors.js';
+export type { MessageEventPayload } from './events.js';
 export { ChatMessageActions, MessageEvents, PresenceEvents } from './events.js';
 export type { Headers } from './headers.js';
 export {
@@ -29,7 +30,6 @@ export { LogLevel } from './logger.js';
 export type { Message, MessageHeaders, MessageMetadata, MessageOperationMetadata, Operation } from './message.js';
 export type {
   DeleteMessageParams,
-  MessageEventPayload,
   MessageListener,
   Messages,
   MessageSubscriptionResponse,

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -12,7 +12,7 @@ import {
   OnDiscontinuitySubscriptionResponse,
 } from './discontinuity.js';
 import { ErrorCodes } from './errors.js';
-import { ChatMessageActions, MessageEvents, RealtimeMessageNames } from './events.js';
+import { ChatMessageActions, MessageEventPayload, MessageEvents, RealtimeMessageNames } from './events.js';
 import { Logger } from './logger.js';
 import { DefaultMessage, Message, MessageHeaders, MessageMetadata, MessageOperationMetadata } from './message.js';
 import { parseMessage } from './message-parser.js';
@@ -165,21 +165,6 @@ export interface SendMessageParams {
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface UpdateMessageParams extends SendMessageParams {}
-
-/**
- * Payload for a message event.
- */
-export interface MessageEventPayload {
-  /**
-   * The type of the message event.
-   */
-  type: MessageEvents;
-
-  /**
-   * The message that was received.
-   */
-  message: Message;
-}
 
 /**
  * A listener for message events in a chat room.

--- a/test/core/messages.test.ts
+++ b/test/core/messages.test.ts
@@ -3,9 +3,9 @@ import { RealtimeChannel } from 'ably';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatApi, GetMessagesQueryParams } from '../../src/core/chat-api.ts';
-import { ChatMessageActions, MessageEvents } from '../../src/core/events.ts';
+import { ChatMessageActions, MessageEventPayload, MessageEvents } from '../../src/core/events.ts';
 import { Message } from '../../src/core/message.ts';
-import { DefaultMessages, MessageEventPayload, OrderBy } from '../../src/core/messages.ts';
+import { DefaultMessages, OrderBy } from '../../src/core/messages.ts';
 import { Room } from '../../src/core/room.ts';
 import {
   channelEventEmitter,

--- a/test/react/hooks/use-messages.test.tsx
+++ b/test/react/hooks/use-messages.test.tsx
@@ -126,6 +126,7 @@ describe('useMessages', () => {
         before: vi.fn(),
         after: vi.fn(),
         equal: vi.fn(),
+        with: vi.fn(),
         headers: {},
         metadata: {},
       },


### PR DESCRIPTION
### Context

[CHA-702]

### Description

Add a new method `with()` on `Message`. `message.with(event)` is a convenience method that produces a new Message with the event applied to it. It can be used to easily apply update and delete events to a message.

Usage example

```typescript
let messages : Message[] = []; // my messages

// when receiving an update or delete event:
const idx = message.findIndex(m => m.serial == event.message.serial);
if (idx !== -1) {
  messages[idx] = messages[idx].with(event);
}
```

When message reactions arrive, this method will also correctly apply reactions events to a message.

---

Another change is that the demo app now shows deleted messages with an "Edit" button. Since we have always supported what I'll call "restore by edit" it makes sense to show it in the UI, as well as to correctly support showing the messages that have been updated after a delete (previously those update events were ignored, considered out of scope for the chat window).

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [ ] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

Read the code including demo app for how it's used.


[CHA-702]: https://ably.atlassian.net/browse/CHA-702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ