### PR TITLE
dev: dont run docs upload step on forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,13 +33,17 @@ jobs:
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
+        # Only run this step if it's a PR from the main repository, as forks won't have the necessary secrets
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-chat-js
-          role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
+          role-session-name: '${{ github.run_id }}-${{ github.run_number }}'
 
       - name: Upload Documentation
         uses: ably/sdk-upload-action@v2
+        # Only run this step if it's a PR from the main repository, as forks won't have the necessary secrets
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           sourcePath: typedoc/generated
           githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Context

Example on this PR: https://github.com/ably/ably-chat-js/pull/460

### Description

External contributors can't get a CI green at the moment because the docs upload step requires a secret in Actions that's not available on forked repos.

This change makes it so that these steps are skipped on forks, whilst still building the docs to show that they do.

This will require a process change for Ablyan reviewers on forked PRs - docs will have to be built and viewed locally, but that's a small price to pay for allowing contributors to get green CI.
