### PR TITLE
Renaming types for clarity

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -2,7 +2,7 @@ import { FC, useEffect, useState } from 'react';
 import { Chat } from './containers/Chat';
 import { OccupancyComponent } from './components/OccupancyComponent';
 import { UserPresenceComponent } from './components/UserPresenceComponent';
-import { DefaultRoomOptions, ChatRoomProvider } from '@ably/chat';
+import { AllFeaturesEnabled, ChatRoomProvider } from '@ably/chat';
 
 // We read the roomID from the URL query string and default to 'abcd' if none
 // provided. We make sure the URL is updated to always include the roomId. This
@@ -52,7 +52,7 @@ const App: FC<AppProps> = () => {
       id={roomIdState}
       release={true}
       attach={true}
-      options={DefaultRoomOptions}
+      options={AllFeaturesEnabled}
     >
       <div
         style={{ display: 'flex', justifyContent: 'space-between', width: '800px', margin: 'auto', height: '650px' }}

--- a/src/core/chat.ts
+++ b/src/core/chat.ts
@@ -1,6 +1,6 @@
 import * as Ably from 'ably';
 
-import { ClientOptions, normalizeClientOptions, NormalizedClientOptions } from './config.js';
+import { ChatClientOptions, normalizeClientOptions, NormalizedChatClientOptions } from './config.js';
 import { Connection, DefaultConnection } from './connection.js';
 import { Logger, makeLogger } from './logger.js';
 import { RealtimeWithOptions } from './realtime-extensions.js';
@@ -24,7 +24,7 @@ export class ChatClient {
   /**
    * @internal
    */
-  private readonly _clientOptions: NormalizedClientOptions;
+  private readonly _clientOptions: NormalizedChatClientOptions;
 
   /**
    * @internal
@@ -41,7 +41,7 @@ export class ChatClient {
    * @param realtime - The Ably Realtime client.
    * @param clientOptions - The client options.
    */
-  constructor(realtime: Ably.Realtime, clientOptions?: ClientOptions) {
+  constructor(realtime: Ably.Realtime, clientOptions?: ChatClientOptions) {
     this._realtime = realtime;
     this._clientOptions = normalizeClientOptions(clientOptions);
     this._logger = makeLogger(this._clientOptions);
@@ -91,7 +91,7 @@ export class ChatClient {
    * Returns the resolved client options for the client, including any defaults that have been set.
    * @returns The client options.
    */
-  get clientOptions(): ClientOptions {
+  get clientOptions(): ChatClientOptions {
     return this._clientOptions;
   }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,7 +3,7 @@ import { LogHandler, LogLevel } from './logger.js';
 /**
  * Configuration options for the chat client.
  */
-export interface ClientOptions {
+export interface ChatClientOptions {
   /**
    * A custom log handler that will be used to log messages from the client.
    * @defaultValue The client will log messages to the console.
@@ -33,14 +33,14 @@ type Modify<T, R> = Omit<T, keyof R> & R;
 /**
  * These are the normalized client options, with default values filled in for any missing properties.
  */
-export type NormalizedClientOptions = Modify<
-  ClientOptions,
+export type NormalizedChatClientOptions = Modify<
+  ChatClientOptions,
   {
     logLevel: LogLevel;
   }
 >;
 
-export const normalizeClientOptions = (options?: ClientOptions): NormalizedClientOptions => {
+export const normalizeClientOptions = (options?: ChatClientOptions): NormalizedChatClientOptions => {
   options = options ?? {};
 
   return {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,7 +3,7 @@
  */
 
 export { ChatClient } from './chat.js';
-export type { ClientOptions } from './config.js';
+export type { ChatClientOptions } from './config.js';
 export type {
   Connection,
   ConnectionStatusChange,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -51,7 +51,7 @@ export type {
   RoomReactionsOptions,
   TypingOptions,
 } from './room-options.js';
-export { DefaultRoomOptions } from './room-options.js';
+export { AllFeaturesEnabled } from './room-options.js';
 export type {
   RoomReactionListener,
   RoomReactions,

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,6 +1,6 @@
 import * as Ably from 'ably';
 
-import { NormalizedClientOptions } from './config.js';
+import { NormalizedChatClientOptions } from './config.js';
 
 /**
  * Interface for loggers.
@@ -131,7 +131,7 @@ const consoleLogger = (message: string, level: LogLevel, context?: LogContext) =
   }
 };
 
-export const makeLogger = (options: NormalizedClientOptions): Logger => {
+export const makeLogger = (options: NormalizedChatClientOptions): Logger => {
   const logHandler = options.logHandler ?? consoleLogger;
 
   return new DefaultLogger(logHandler, options.logLevel);

--- a/src/core/room-options.ts
+++ b/src/core/room-options.ts
@@ -1,9 +1,10 @@
 import * as Ably from 'ably';
 
 /**
- * Represents the default options for a chat room.
+ * A set of example options for a Chat room that enables all features, this is
+ * useful for testing and demonstration purposes.
  */
-export const DefaultRoomOptions = {
+export const AllFeaturesEnabled = {
   /**
    * The default presence options for a chat room.
    */
@@ -89,26 +90,26 @@ export type OccupancyOptions = object;
 export interface RoomOptions {
   /**
    * The presence options for the room. To enable presence in the room, set this property. You may
-   * use {@link DefaultRoomOptions.presence} to enable presence with default options.
+   * use {@link AllFeaturesEnabled.presence} to enable presence with default options.
    * @defaultValue undefined
    */
   presence?: PresenceOptions;
 
   /**
    * The typing options for the room. To enable typing in the room, set this property. You may use
-   * {@link DefaultRoomOptions.typing} to enable typing with default options.
+   * {@link AllFeaturesEnabled.typing} to enable typing with default options.
    */
   typing?: TypingOptions;
 
   /**
    * The reactions options for the room. To enable reactions in the room, set this property. You may use
-   * {@link DefaultRoomOptions.reactions} to enable reactions with default options.
+   * {@link AllFeaturesEnabled.reactions} to enable reactions with default options.
    */
   reactions?: RoomReactionsOptions;
 
   /**
    * The occupancy options for the room. To enable occupancy in the room, set this property. You may use
-   * {@link DefaultRoomOptions.occupancy} to enable occupancy with default options.
+   * {@link AllFeaturesEnabled.occupancy} to enable occupancy with default options.
    */
   occupancy?: OccupancyOptions;
 }

--- a/src/core/rooms.ts
+++ b/src/core/rooms.ts
@@ -2,7 +2,7 @@ import * as Ably from 'ably';
 import { dequal } from 'dequal';
 
 import { ChatApi } from './chat-api.js';
-import { ClientOptions, NormalizedClientOptions } from './config.js';
+import { ChatClientOptions, NormalizedChatClientOptions } from './config.js';
 import { ErrorCodes } from './errors.js';
 import { randomId } from './id.js';
 import { Logger } from './logger.js';
@@ -49,9 +49,9 @@ export interface Rooms {
 
   /**
    * Get the client options used to create the Chat instance.
-   * @returns ClientOptions
+   * @returns ChatClientOptions
    */
-  get clientOptions(): ClientOptions;
+  get clientOptions(): ChatClientOptions;
 }
 
 /**
@@ -85,7 +85,7 @@ interface RoomMapEntry {
 export class DefaultRooms implements Rooms {
   private readonly _realtime: Ably.Realtime;
   private readonly _chatApi: ChatApi;
-  private readonly _clientOptions: NormalizedClientOptions;
+  private readonly _clientOptions: NormalizedChatClientOptions;
   private readonly _rooms: Map<string, RoomMapEntry> = new Map<string, RoomMapEntry>();
   private readonly _releasing = new Map<string, Promise<void>>();
   private readonly _logger: Logger;
@@ -98,7 +98,7 @@ export class DefaultRooms implements Rooms {
    * @param clientOptions The client options from the chat instance.
    * @param logger An instance of the Logger.
    */
-  constructor(realtime: Ably.Realtime, clientOptions: NormalizedClientOptions, logger: Logger) {
+  constructor(realtime: Ably.Realtime, clientOptions: NormalizedChatClientOptions, logger: Logger) {
     this._realtime = realtime;
     this._chatApi = new ChatApi(realtime, logger);
     this._clientOptions = clientOptions;
@@ -187,7 +187,7 @@ export class DefaultRooms implements Rooms {
   /**
    * @inheritDoc
    */
-  get clientOptions(): ClientOptions {
+  get clientOptions(): ChatClientOptions {
     return this._clientOptions;
   }
 

--- a/src/react/providers/chat-room-provider.tsx
+++ b/src/react/providers/chat-room-provider.tsx
@@ -5,7 +5,7 @@ import { ChatClient } from '../../core/chat.js';
 import { Logger } from '../../core/logger.js';
 import { Room } from '../../core/room.js';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { type DefaultRoomOptions, RoomOptions } from '../../core/room-options.js';
+import { type AllFeaturesEnabled, RoomOptions } from '../../core/room-options.js';
 import { ChatRoomContext, ChatRoomContextType } from '../contexts/chat-room-context.js';
 import { useChatClient } from '../hooks/use-chat-client.js';
 import { useLogger } from '../hooks/use-logger.js';
@@ -19,15 +19,15 @@ export interface ChatRoomProviderProps {
 
   /**
    * The options to use when creating the room. A convenient default value is
-   * provided by {@link DefaultRoomOptions}, but it must explicitly be set
+   * provided by {@link AllFeaturesEnabled}, but it must explicitly be set
    * here.
    *
-   * {@link DefaultRoomOptions} can also be used partially, for example:
+   * {@link AllFeaturesEnabled} can also be used partially, for example:
    *
    * ```tsx
    * <ChatRoomProvider id="room-id" options={{
-   *   presence: DefaultRoomOptions.presence,
-   *   reactions: DefaultRoomOptions.reactions,
+   *   presence: AllFeaturesEnabled.presence,
+   *   reactions: AllFeaturesEnabled.reactions,
    * }} />
    * ```
    *

--- a/test/core/chat.integration.test.ts
+++ b/test/core/chat.integration.test.ts
@@ -6,7 +6,7 @@ import { ConnectionStatus } from '../../src/core/connection.ts';
 import { LogLevel } from '../../src/core/logger.ts';
 import { RealtimeWithOptions } from '../../src/core/realtime-extensions.ts';
 import { CHANNEL_OPTIONS_AGENT_STRING_REACT, VERSION } from '../../src/core/version.ts';
-import { DefaultRoomOptions } from '../../src/index.ts';
+import { AllFeaturesEnabled } from '../../src/index.ts';
 import { newChatClient } from '../helper/chat.ts';
 import { testClientOptions } from '../helper/options.ts';
 import { ablyRealtimeClient } from '../helper/realtime-client.ts';
@@ -48,7 +48,7 @@ describe('Chat', () => {
     const chat = newChatClient(testClientOptions());
     chat.addReactAgent();
 
-    const room = await chat.rooms.get('room', DefaultRoomOptions);
+    const room = await chat.rooms.get('room', AllFeaturesEnabled);
 
     const channelOptions = (room.messages.channel as unknown as { channelOptions: Ably.ChannelOptions }).channelOptions;
     expect(channelOptions.params).toEqual(

--- a/test/core/messages.integration.test.ts
+++ b/test/core/messages.integration.test.ts
@@ -6,7 +6,7 @@ import { ChatMessageActions, MessageEvents } from '../../src/core/events.ts';
 import { Message } from '../../src/core/message.ts';
 import { OrderBy } from '../../src/core/messages.ts';
 import { RealtimeChannelWithOptions } from '../../src/core/realtime-extensions.ts';
-import { DefaultRoomOptions } from '../../src/core/room-options.ts';
+import { AllFeaturesEnabled } from '../../src/core/room-options.ts';
 import { RoomStatus } from '../../src/core/room-status.ts';
 import { CHANNEL_OPTIONS_AGENT_STRING } from '../../src/core/version.ts';
 import { newChatClient } from '../helper/chat.ts';
@@ -781,7 +781,7 @@ describe('messages integration', { timeout: 10000 }, () => {
   it<TestContext>('handles the room being released before getPreviousMessages is called', async (context) => {
     const chat = context.chat;
     const roomId = randomRoomId();
-    const room = await chat.rooms.get(roomId, DefaultRoomOptions);
+    const room = await chat.rooms.get(roomId, AllFeaturesEnabled);
 
     // Create a subscription to messages
     room.messages.subscribe(() => {});

--- a/test/core/presence.integration.test.ts
+++ b/test/core/presence.integration.test.ts
@@ -8,7 +8,7 @@ import { ChatClient } from '../../src/core/chat.ts';
 import { PresenceEvents } from '../../src/core/events.ts';
 import { PresenceData, PresenceEvent } from '../../src/core/presence.ts';
 import { Room } from '../../src/core/room.ts';
-import { DefaultRoomOptions } from '../../src/core/room-options.ts';
+import { AllFeaturesEnabled } from '../../src/core/room-options.ts';
 import { RoomStatus } from '../../src/core/room-status.ts';
 import { newChatClient } from '../helper/chat.ts';
 import { randomRoomId } from '../helper/identifier.ts';
@@ -102,7 +102,7 @@ describe('UserPresence', { timeout: 30000 }, () => {
     const roomId = randomRoomId();
     context.chat = newChatClient(undefined, context.realtime);
     context.defaultTestClientId = context.realtime.auth.clientId;
-    context.chatRoom = await context.chat.rooms.get(roomId, { presence: DefaultRoomOptions.presence });
+    context.chatRoom = await context.chat.rooms.get(roomId, { presence: AllFeaturesEnabled.presence });
   });
 
   // Test for successful entering with clientId and custom user data

--- a/test/core/room.test.ts
+++ b/test/core/room.test.ts
@@ -5,7 +5,7 @@ import { ChatApi } from '../../src/core/chat-api.ts';
 import { randomId } from '../../src/core/id.ts';
 import { DefaultRoom, Room } from '../../src/core/room.ts';
 import { RoomLifecycleManager } from '../../src/core/room-lifecycle-manager.ts';
-import { DefaultRoomOptions, normalizeRoomOptions, RoomOptions } from '../../src/core/room-options.ts';
+import { AllFeaturesEnabled, normalizeRoomOptions, RoomOptions } from '../../src/core/room-options.ts';
 import { RoomStatus } from '../../src/core/room-status.ts';
 import { DefaultTyping } from '../../src/core/typing.ts';
 import {
@@ -17,7 +17,7 @@ import {
 import { randomRoomId } from '../helper/identifier.ts';
 import { makeTestLogger } from '../helper/logger.ts';
 import { ablyRealtimeClient } from '../helper/realtime-client.ts';
-import { defaultRoomOptions, waitForRoomStatus } from '../helper/room.ts';
+import { waitForRoomStatus } from '../helper/room.ts';
 
 vi.mock('ably');
 
@@ -56,10 +56,10 @@ describe('Room', () => {
 
   describe.each([
     ['messages', {}, (room: Room) => room.messages],
-    ['presence', { presence: DefaultRoomOptions.presence }, (room: Room) => room.presence],
-    ['occupancy', { occupancy: DefaultRoomOptions.occupancy }, (room: Room) => room.occupancy],
-    ['typing', { typing: DefaultRoomOptions.typing }, (room: Room) => room.typing],
-    ['reactions', { reactions: DefaultRoomOptions.reactions }, (room: Room) => room.reactions],
+    ['presence', { presence: AllFeaturesEnabled.presence }, (room: Room) => room.presence],
+    ['occupancy', { occupancy: AllFeaturesEnabled.occupancy }, (room: Room) => room.occupancy],
+    ['typing', { typing: AllFeaturesEnabled.typing }, (room: Room) => room.typing],
+    ['reactions', { reactions: AllFeaturesEnabled.reactions }, (room: Room) => room.reactions],
   ])('feature configured', (description: string, options: RoomOptions, featureLoader: (room: Room) => unknown) => {
     it<TestContext>(`should not throw an error when trying to access ${description} whilst enabled`, (context) => {
       const room = context.getRoom(options);
@@ -97,7 +97,7 @@ describe('Room', () => {
     (description: string, setReact: boolean, agentString: string, defaultOptions: unknown) => {
       it<TestContext>('applies the correct options', (context) => {
         vi.spyOn(context.realtime.channels, 'get');
-        const room = context.getRoom(defaultRoomOptions, setReact) as DefaultRoom;
+        const room = context.getRoom(AllFeaturesEnabled, setReact) as DefaultRoom;
 
         // Check that the shared channel for messages, occupancy and presence was called with the correct options
         const expectedMessagesChannelOptions = {
@@ -132,7 +132,7 @@ describe('Room', () => {
 
   describe('room status', () => {
     it<TestContext>('should have a room status and error', async (context) => {
-      const room = context.getRoom(defaultRoomOptions);
+      const room = context.getRoom(AllFeaturesEnabled);
       expect(room.status).toBe(RoomStatus.Initialized);
 
       // Wait for the room to be initialized
@@ -153,7 +153,7 @@ describe('Room', () => {
     });
 
     it<TestContext>('should allow subscriptions to status changes', async (context) => {
-      const room = context.getRoom(defaultRoomOptions);
+      const room = context.getRoom(AllFeaturesEnabled);
 
       const statuses: RoomStatus[] = [];
       const errors: Ably.ErrorInfo[] = [];
@@ -188,7 +188,7 @@ describe('Room', () => {
     });
 
     it<TestContext>('should allow all subscriptions to be removed', async (context) => {
-      const room = context.getRoom(defaultRoomOptions);
+      const room = context.getRoom(AllFeaturesEnabled);
 
       const statuses: RoomStatus[] = [];
       const errors: Ably.ErrorInfo[] = [];
@@ -235,7 +235,7 @@ describe('Room', () => {
 
   describe('room release', () => {
     it<TestContext>('should release the room', async (context) => {
-      const room = context.getRoom(defaultRoomOptions) as DefaultRoom;
+      const room = context.getRoom(AllFeaturesEnabled) as DefaultRoom;
       const lifecycleManager = (room as unknown as { _lifecycleManager: RoomLifecycleManager })._lifecycleManager;
 
       // Setup spies on the realtime client and the room lifecycle manager
@@ -268,7 +268,7 @@ describe('Room', () => {
     });
 
     it<TestContext>('should only release with enabled features', async (context) => {
-      const room = context.getRoom({ typing: DefaultRoomOptions.typing }) as DefaultRoom;
+      const room = context.getRoom({ typing: AllFeaturesEnabled.typing }) as DefaultRoom;
       const lifecycleManager = (room as unknown as { _lifecycleManager: RoomLifecycleManager })._lifecycleManager;
 
       // Setup spies on the realtime client and the room lifecycle manager
@@ -292,7 +292,7 @@ describe('Room', () => {
     });
 
     it<TestContext>('releasing multiple times is idempotent', async (context) => {
-      const room = context.getRoom(defaultRoomOptions) as DefaultRoom;
+      const room = context.getRoom(AllFeaturesEnabled) as DefaultRoom;
       const lifecycleManager = (room as unknown as { _lifecycleManager: RoomLifecycleManager })._lifecycleManager;
 
       // Setup spies on the realtime client and the room lifecycle manager
@@ -315,7 +315,7 @@ describe('Room', () => {
   });
 
   it<TestContext>('can be released immediately without unhandled rejections', async (context) => {
-    const room = context.getRoom(defaultRoomOptions);
+    const room = context.getRoom(AllFeaturesEnabled);
 
     // Release the room
     // Note that an unhandled rejection will not cause the test to fail, but it will cause the process to exit

--- a/test/core/rooms.integration.test.ts
+++ b/test/core/rooms.integration.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { LogLevel } from '../../src/core/logger.ts';
 import { RoomStatus } from '../../src/core/room-status.ts';
-import { DefaultRoomOptions } from '../../src/index.ts';
+import { AllFeaturesEnabled } from '../../src/index.ts';
 import { newChatClient } from '../helper/chat.ts';
 import { waitForRoomStatus } from '../helper/room.ts';
 
@@ -36,15 +36,15 @@ describe('Rooms', () => {
     // We include presence options here because that invokes a change to channel modes - which would flag up
     // an error if we were doing releases in the wrong order etc
     const chat = newChatClient();
-    const room1 = await chat.rooms.get('test', { typing: { timeoutMs: 1000 }, presence: DefaultRoomOptions.presence });
+    const room1 = await chat.rooms.get('test', { typing: { timeoutMs: 1000 }, presence: AllFeaturesEnabled.presence });
     await room1.attach();
     await chat.rooms.release('test');
 
-    const room2 = await chat.rooms.get('test', { typing: { timeoutMs: 2000 }, presence: DefaultRoomOptions.presence });
+    const room2 = await chat.rooms.get('test', { typing: { timeoutMs: 2000 }, presence: AllFeaturesEnabled.presence });
     await room2.attach();
     await chat.rooms.release('test');
 
-    await chat.rooms.get('test', { typing: { timeoutMs: 3000 }, presence: DefaultRoomOptions.presence });
+    await chat.rooms.get('test', { typing: { timeoutMs: 3000 }, presence: AllFeaturesEnabled.presence });
     await chat.rooms.release('test');
   });
 

--- a/test/core/rooms.test.ts
+++ b/test/core/rooms.test.ts
@@ -2,13 +2,12 @@ import * as Ably from 'ably';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { normalizeClientOptions } from '../../src/core/config.ts';
-import { RoomOptions } from '../../src/core/room-options.ts';
+import { AllFeaturesEnabled, RoomOptions } from '../../src/core/room-options.ts';
 import { DefaultRooms, Rooms } from '../../src/core/rooms.ts';
 import { ErrorCodes } from '../../src/index.ts';
 import { randomRoomId } from '../helper/identifier.ts';
 import { makeTestLogger } from '../helper/logger.ts';
 import { ablyRealtimeClient } from '../helper/realtime-client.ts';
-import { defaultRoomOptions } from '../helper/room.ts';
 
 vi.mock('ably');
 
@@ -27,8 +26,7 @@ describe('rooms', () => {
   describe('room get', () => {
     it<TestContext>('throws error if room with same ID but different options already exists', async (context) => {
       const roomId = randomRoomId();
-      const roomOptions: RoomOptions = defaultRoomOptions;
-      const room1 = context.rooms.get(roomId, roomOptions);
+      const room1 = context.rooms.get(roomId, AllFeaturesEnabled);
       const room2 = context.rooms.get(roomId, { reactions: {} });
       await expect(room1).resolves.toBeDefined();
       await expect(room2).rejects.toBeErrorInfo({
@@ -40,16 +38,15 @@ describe('rooms', () => {
 
     it<TestContext>('returns a fresh room instance if room does not exist', async (context) => {
       const roomId = randomRoomId();
-      const roomOptions: RoomOptions = defaultRoomOptions;
+      const roomOptions: RoomOptions = AllFeaturesEnabled;
       const room = context.rooms.get(roomId, roomOptions);
       await expect(room).resolves.toBeDefined();
     });
 
     it<TestContext>('returns the same room instance if room already exists', async (context) => {
       const roomId = randomRoomId();
-      const roomOptions: RoomOptions = defaultRoomOptions;
-      const room1 = await context.rooms.get(roomId, roomOptions);
-      const room2 = await context.rooms.get(roomId, roomOptions);
+      const room1 = await context.rooms.get(roomId, AllFeaturesEnabled);
+      const room2 = await context.rooms.get(roomId, AllFeaturesEnabled);
       expect(room1).toBe(room2);
     });
   });
@@ -57,27 +54,24 @@ describe('rooms', () => {
   describe('room get-release lifecycle', () => {
     it<TestContext>('should return a the same room if rooms.get called twice', async (context) => {
       const roomId = randomRoomId();
-      const roomOptions: RoomOptions = defaultRoomOptions;
-      const room1 = await context.rooms.get(roomId, roomOptions);
-      const room2 = await context.rooms.get(roomId, roomOptions);
+      const room1 = await context.rooms.get(roomId, AllFeaturesEnabled);
+      const room2 = await context.rooms.get(roomId, AllFeaturesEnabled);
       expect(room1).toBe(room2);
     });
 
     it<TestContext>('should return a fresh room in room.get if previous one is currently releasing', (context) => {
       const roomId = randomRoomId();
-      const roomOptions: RoomOptions = defaultRoomOptions;
-      const room1 = context.rooms.get(roomId, roomOptions);
+      const room1 = context.rooms.get(roomId, AllFeaturesEnabled);
       void context.rooms.release(roomId);
-      const room2 = context.rooms.get(roomId, roomOptions);
+      const room2 = context.rooms.get(roomId, AllFeaturesEnabled);
       expect(room1).not.toBe(room2);
     });
 
     it<TestContext>('releasing a room should abort any get operations', async (context) => {
       const roomId = randomRoomId();
-      const roomOptions: RoomOptions = defaultRoomOptions;
-      const room1 = context.rooms.get(roomId, roomOptions);
+      const room1 = context.rooms.get(roomId, AllFeaturesEnabled);
       const releasePromise1 = context.rooms.release(roomId);
-      const room2 = context.rooms.get(roomId, roomOptions);
+      const room2 = context.rooms.get(roomId, AllFeaturesEnabled);
       const releasedPromise2 = context.rooms.release(roomId);
 
       await expect(releasePromise1).resolves.toBeUndefined();
@@ -92,16 +86,15 @@ describe('rooms', () => {
 
     it<TestContext>('releasing a room should abort any get operations from previous get', async (context) => {
       const roomId = randomRoomId();
-      const roomOptions: RoomOptions = defaultRoomOptions;
-      const room1 = context.rooms.get(roomId, roomOptions);
+      const room1 = context.rooms.get(roomId, AllFeaturesEnabled);
       const releasePromise1 = context.rooms.release(roomId);
-      const room2 = context.rooms.get(roomId, roomOptions);
+      const room2 = context.rooms.get(roomId, AllFeaturesEnabled);
       const releasedPromise2 = context.rooms.release(roomId);
-      const room3 = context.rooms.get(roomId, roomOptions);
-      const room4 = context.rooms.get(roomId, roomOptions);
+      const room3 = context.rooms.get(roomId, AllFeaturesEnabled);
+      const room4 = context.rooms.get(roomId, AllFeaturesEnabled);
       const releasePromise3 = context.rooms.release(roomId);
       const releasePromise4 = context.rooms.release(roomId);
-      const finalRoom = context.rooms.get(roomId, roomOptions);
+      const finalRoom = context.rooms.get(roomId, AllFeaturesEnabled);
 
       await expect(room1).resolves.toBeDefined();
       await expect(releasePromise1).resolves.toBeUndefined();
@@ -132,12 +125,11 @@ describe('rooms', () => {
 
     it<TestContext>('multiple gets on a releasing room return the same room instance', async (context) => {
       const roomId = randomRoomId();
-      const roomOptions: RoomOptions = defaultRoomOptions;
-      const room1 = context.rooms.get(roomId, roomOptions);
+      const room1 = context.rooms.get(roomId, AllFeaturesEnabled);
       const releasePromise1 = context.rooms.release(roomId);
-      const room2 = context.rooms.get(roomId, roomOptions);
-      const room3 = context.rooms.get(roomId, roomOptions);
-      const room4 = context.rooms.get(roomId, roomOptions);
+      const room2 = context.rooms.get(roomId, AllFeaturesEnabled);
+      const room3 = context.rooms.get(roomId, AllFeaturesEnabled);
+      const room4 = context.rooms.get(roomId, AllFeaturesEnabled);
 
       await expect(room1).resolves.toBeDefined();
       await expect(releasePromise1).resolves.toBeUndefined();

--- a/test/core/typing.integration.test.ts
+++ b/test/core/typing.integration.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { normalizeClientOptions } from '../../src/core/config.ts';
 import { Room } from '../../src/core/room.ts';
-import { DefaultRoomOptions } from '../../src/core/room-options.ts';
+import { AllFeaturesEnabled } from '../../src/core/room-options.ts';
 import { RoomStatus } from '../../src/core/room-status.ts';
 import { DefaultRooms, Rooms } from '../../src/core/rooms.ts';
 import { TypingEvent } from '../../src/core/typing.ts';
@@ -174,7 +174,7 @@ describe('Typing', () => {
   it<TestContext>('handles discontinuities', async (context) => {
     const { chat } = context;
 
-    const room = await chat.get(randomRoomId(), { typing: DefaultRoomOptions.typing });
+    const room = await chat.get(randomRoomId(), { typing: AllFeaturesEnabled.typing });
 
     // Attach the room
     await room.attach();

--- a/test/helper/chat.ts
+++ b/test/helper/chat.ts
@@ -1,11 +1,11 @@
-import Ably from 'ably';
+import * as Ably from 'ably';
 
 import { ChatClient } from '../../src/core/chat.ts';
-import { ClientOptions, normalizeClientOptions } from '../../src/core/config.js';
+import { ChatClientOptions, normalizeClientOptions } from '../../src/core/config.js';
 import { testLoggingLevel } from './logger.js';
 import { ablyRealtimeClientWithToken } from './realtime-client.js';
 
-export const newChatClient = (options?: ClientOptions, realtimeClient?: Ably.Realtime): ChatClient => {
+export const newChatClient = (options?: ChatClientOptions, realtimeClient?: Ably.Realtime): ChatClient => {
   const normalizedOptions = normalizeClientOptions({
     ...options,
     logLevel: options?.logLevel ?? testLoggingLevel(),

--- a/test/helper/options.ts
+++ b/test/helper/options.ts
@@ -1,11 +1,11 @@
-import { ClientOptions, normalizeClientOptions, NormalizedClientOptions } from '../../src/core/config.js';
+import { ChatClientOptions, normalizeClientOptions, NormalizedChatClientOptions } from '../../src/core/config.js';
 import { LogLevel } from '../../src/core/logger.js';
 
-const defaults: NormalizedClientOptions = {
+const defaults: NormalizedChatClientOptions = {
   logLevel: LogLevel.Error,
 };
 
-export const testClientOptions = (options?: ClientOptions): NormalizedClientOptions => {
+export const testClientOptions = (options?: ChatClientOptions): NormalizedChatClientOptions => {
   options = options ?? defaults;
   return normalizeClientOptions(options);
 };

--- a/test/helper/room.ts
+++ b/test/helper/room.ts
@@ -6,7 +6,7 @@ import { ChatApi } from '../../src/core/chat-api.ts';
 import { ErrorCodes } from '../../src/core/errors.ts';
 import { randomId } from '../../src/core/id.ts';
 import { DefaultRoom, Room } from '../../src/core/room.ts';
-import { DefaultRoomOptions, normalizeRoomOptions, RoomOptions } from '../../src/core/room-options.ts';
+import { AllFeaturesEnabled, normalizeRoomOptions, RoomOptions } from '../../src/core/room-options.ts';
 import { RoomLifecycle, RoomStatus } from '../../src/core/room-status.ts';
 import { randomRoomId } from './identifier.ts';
 import { makeTestLogger } from './logger.ts';
@@ -28,12 +28,7 @@ export const waitForRoomError = async (status: RoomLifecycle, expected: ErrorCod
 
 // Gets a random room with default options from the chat client
 export const getRandomRoom = async (chat: ChatClient): Promise<Room> =>
-  chat.rooms.get(randomRoomId(), defaultRoomOptions);
-
-// Return a default set of room options
-export const defaultRoomOptions: RoomOptions = {
-  ...DefaultRoomOptions,
-};
+  chat.rooms.get(randomRoomId(), AllFeaturesEnabled);
 
 // Makes a room with the given (or default) options, as a standalone room aside from the chat client
 // Should be used in unit tests where the dependencies are mocked.
@@ -49,7 +44,7 @@ export const makeRandomRoom = (params: {
   return new DefaultRoom(
     randomRoomId(),
     randomId(),
-    normalizeRoomOptions(params.options ?? defaultRoomOptions, false),
+    normalizeRoomOptions(params.options ?? AllFeaturesEnabled, false),
     realtime,
     chatApi,
     logger,

--- a/test/react/helper/use-eventual-room.test.tsx
+++ b/test/react/helper/use-eventual-room.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Logger } from '../../../src/core/logger.ts';
 import { Room } from '../../../src/core/room.ts';
-import { DefaultRoomOptions } from '../../../src/core/room-options.ts';
+import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { useEventualRoom, useEventualRoomProperty } from '../../../src/react/helper/use-eventual-room.ts';
 import { makeTestLogger } from '../../helper/logger.ts';
 import { makeRandomRoom } from '../../helper/room.ts';
@@ -30,7 +30,7 @@ const updateMockRoom = (newRoom: Room) => {
 describe('eventual rooms', () => {
   beforeEach(() => {
     mockLogger = makeTestLogger();
-    updateMockRoom(makeRandomRoom({ options: DefaultRoomOptions }));
+    updateMockRoom(makeRandomRoom({ options: AllFeaturesEnabled }));
   });
 
   afterEach(() => {
@@ -62,7 +62,7 @@ describe('eventual rooms', () => {
       });
 
       // Now update the room and re-render
-      const newRoom = makeRandomRoom({ options: DefaultRoomOptions });
+      const newRoom = makeRandomRoom({ options: AllFeaturesEnabled });
       updateMockRoom(newRoom);
 
       rerender();
@@ -99,7 +99,7 @@ describe('eventual rooms', () => {
       });
 
       // Now update the room and re-render
-      const newRoom = makeRandomRoom({ options: DefaultRoomOptions });
+      const newRoom = makeRandomRoom({ options: AllFeaturesEnabled });
       updateMockRoom(newRoom);
 
       rerender();

--- a/test/react/helper/use-room-context.test.tsx
+++ b/test/react/helper/use-room-context.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { DefaultRoomOptions } from '../../../src/core/room-options.ts';
+import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { useRoomContext } from '../../../src/react/helper/use-room-context.ts';
 import { ChatRoomProvider } from '../../../src/react/index.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
@@ -39,7 +39,7 @@ describe('useRoom', () => {
       const context = useRoomContext('foo');
       expect(context).toBeDefined();
       expect(context.roomId).toBe('foo');
-      expect(context.options).toBe(DefaultRoomOptions);
+      expect(context.options).toBe(AllFeaturesEnabled);
       return null;
     };
 
@@ -47,7 +47,7 @@ describe('useRoom', () => {
       <ChatClientProvider client={chatClient}>
         <ChatRoomProvider
           id="foo"
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestUseRoom />
         </ChatRoomProvider>

--- a/test/react/helper/use-room-status.test.tsx
+++ b/test/react/helper/use-room-status.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Logger } from '../../../src/core/logger.ts';
 import { Room } from '../../../src/core/room.ts';
-import { DefaultRoomOptions } from '../../../src/core/room-options.ts';
+import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { InternalRoomLifecycle, RoomStatus, RoomStatusChange } from '../../../src/core/room-status.ts';
 import { useRoomStatus } from '../../../src/react/helper/use-room-status.ts';
 import { makeTestLogger } from '../../helper/logger.ts';
@@ -33,7 +33,7 @@ const updateMockRoom = (newRoom: Room) => {
 describe('useRoomStatus', () => {
   beforeEach(() => {
     mockLogger = makeTestLogger();
-    updateMockRoom(makeRandomRoom({ options: DefaultRoomOptions }));
+    updateMockRoom(makeRandomRoom({ options: AllFeaturesEnabled }));
   });
 
   afterEach(() => {

--- a/test/react/hooks/use-messages.integration.test.tsx
+++ b/test/react/hooks/use-messages.integration.test.tsx
@@ -6,7 +6,7 @@ import { ChatClient } from '../../../src/core/chat.ts';
 import { ChatMessageActions, MessageEvents } from '../../../src/core/events.ts';
 import { Message } from '../../../src/core/message.ts';
 import { MessageListener } from '../../../src/core/messages.ts';
-import { DefaultRoomOptions } from '../../../src/core/room-options.ts';
+import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { RoomStatus } from '../../../src/core/room-status.ts';
 import { useMessages } from '../../../src/react/hooks/use-messages.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
@@ -41,7 +41,7 @@ describe('useMessages', () => {
 
     // create a second room and attach it, so we can listen for messages
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, DefaultRoomOptions);
+    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
     await roomTwo.attach();
 
     // start listening for messages
@@ -64,7 +64,7 @@ describe('useMessages', () => {
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
           id={roomId}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent />
         </ChatRoomProvider>
@@ -85,7 +85,7 @@ describe('useMessages', () => {
 
     // create a second room and attach it, so we can listen for deletions
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, DefaultRoomOptions);
+    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
     await roomTwo.attach();
 
     // start listening for deletions
@@ -117,7 +117,7 @@ describe('useMessages', () => {
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
           id={roomId}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent />
         </ChatRoomProvider>
@@ -139,7 +139,7 @@ describe('useMessages', () => {
 
     // create a second room and attach it, so we can listen for updates
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, DefaultRoomOptions);
+    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
     await roomTwo.attach();
 
     // start listening for updates
@@ -179,7 +179,7 @@ describe('useMessages', () => {
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
           id={roomId}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent />
         </ChatRoomProvider>
@@ -208,7 +208,7 @@ describe('useMessages', () => {
 
     // create a second room so we can send messages from it
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, DefaultRoomOptions);
+    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
 
     // start listening for messages
     const messagesRoomOne: Message[] = [];
@@ -231,7 +231,7 @@ describe('useMessages', () => {
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
           id={roomId}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent />
         </ChatRoomProvider>
@@ -263,7 +263,7 @@ describe('useMessages', () => {
 
     // create a second room instance so we can send messages from it
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, DefaultRoomOptions);
+    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
     await roomTwo.attach();
 
     // send a few messages before the first room has subscribed
@@ -289,7 +289,7 @@ describe('useMessages', () => {
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
           id={roomId}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent />
         </ChatRoomProvider>
@@ -327,7 +327,7 @@ describe('useMessages', () => {
 
     // create a second room instance so we can send messages from it
     const roomId = randomRoomId();
-    const room = await chatClient.rooms.get(roomId, DefaultRoomOptions);
+    const room = await chatClient.rooms.get(roomId, AllFeaturesEnabled);
     await room.attach();
 
     let lastSeenMessageText: string | undefined;
@@ -364,7 +364,7 @@ describe('useMessages', () => {
       <ChatClientProvider client={chatClient}>
         <ChatRoomProvider
           id={roomId}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent defineListener={defineListener} />
         </ChatRoomProvider>
@@ -464,7 +464,7 @@ describe('useMessages', () => {
 
     // create a second room instance so we can send messages from it
     const roomId = randomRoomId();
-    const room = await chatClient.rooms.get(roomId, DefaultRoomOptions);
+    const room = await chatClient.rooms.get(roomId, AllFeaturesEnabled);
     await room.attach();
 
     let lastSeenMessageText: string | undefined;
@@ -501,7 +501,7 @@ describe('useMessages', () => {
       <ChatClientProvider client={chatClient}>
         <ChatRoomProvider
           id={roomId}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent listener={listener} />
         </ChatRoomProvider>

--- a/test/react/hooks/use-occupancy.integration.test.tsx
+++ b/test/react/hooks/use-occupancy.integration.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { OccupancyEvent, OccupancyListener } from '../../../src/core/occupancy.ts';
-import { DefaultRoomOptions } from '../../../src/core/room-options.ts';
+import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { useOccupancy } from '../../../src/react/hooks/use-occupancy.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
@@ -25,8 +25,8 @@ describe('useOccupancy', () => {
 
     // create two more rooms and attach to contribute towards occupancy metrics
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, DefaultRoomOptions);
-    const roomThree = await chatClientThree.rooms.get(roomId, DefaultRoomOptions);
+    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
+    const roomThree = await chatClientThree.rooms.get(roomId, AllFeaturesEnabled);
     await roomTwo.attach();
     await roomThree.attach();
 
@@ -52,7 +52,7 @@ describe('useOccupancy', () => {
       <ChatClientProvider client={chatClient}>
         <ChatRoomProvider
           id={roomId}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent listener={(occupancyEvent) => occupancyEvents.push(occupancyEvent)} />
         </ChatRoomProvider>

--- a/test/react/hooks/use-presence-listener.integration.test.tsx
+++ b/test/react/hooks/use-presence-listener.integration.test.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { PresenceEvent, PresenceListener, PresenceMember } from '../../../src/core/presence.ts';
-import { DefaultRoomOptions } from '../../../src/core/room-options.ts';
+import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { RoomStatus } from '../../../src/core/room-status.ts';
 import { usePresenceListener } from '../../../src/react/hooks/use-presence-listener.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
@@ -38,7 +38,7 @@ describe('usePresenceListener', () => {
 
     // create a second room and attach it, so we can send presence events with it
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, DefaultRoomOptions);
+    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
     await roomTwo.attach();
 
     // store the current presence member state
@@ -64,7 +64,7 @@ describe('usePresenceListener', () => {
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
           id={roomId}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent
             listener={(event: PresenceEvent) => {

--- a/test/react/hooks/use-presence.integration.test.tsx
+++ b/test/react/hooks/use-presence.integration.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { PresenceEvents } from '../../../src/core/events.ts';
 import { PresenceData, PresenceEvent } from '../../../src/core/presence.ts';
-import { DefaultRoomOptions } from '../../../src/core/room-options.ts';
+import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { usePresence } from '../../../src/react/hooks/use-presence.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
@@ -50,7 +50,7 @@ describe('usePresence', () => {
 
     // create a second room and attach it, so we can listen for presence events
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, DefaultRoomOptions);
+    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
     await roomTwo.attach();
 
     // start listening for presence events on room two
@@ -84,7 +84,7 @@ describe('usePresence', () => {
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
           id={roomId}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           {children}
         </ChatRoomProvider>

--- a/test/react/hooks/use-room-reactions.integration.test.tsx
+++ b/test/react/hooks/use-room-reactions.integration.test.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { Reaction } from '../../../src/core/reaction.ts';
-import { DefaultRoomOptions } from '../../../src/core/room-options.ts';
+import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { RoomReactionListener } from '../../../src/core/room-reactions.ts';
 import { RoomStatus } from '../../../src/core/room-status.ts';
 import { useRoomReactions } from '../../../src/react/hooks/use-room-reactions.ts';
@@ -39,7 +39,7 @@ describe('useRoomReactions', () => {
 
     // create a second room and attach it, so we can receive reactions
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, DefaultRoomOptions);
+    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
     await roomTwo.attach();
 
     // store the received reactions
@@ -68,7 +68,7 @@ describe('useRoomReactions', () => {
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
           id={roomId}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent />
         </ChatRoomProvider>
@@ -90,7 +90,7 @@ describe('useRoomReactions', () => {
 
     // create a second room and attach it, so we can send a reaction
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, DefaultRoomOptions);
+    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
     await roomTwo.attach();
 
     // store the received reactions
@@ -112,7 +112,7 @@ describe('useRoomReactions', () => {
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
           id={roomId}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent listener={(reaction) => reactions.push(reaction)} />
         </ChatRoomProvider>

--- a/test/react/hooks/use-room.test.tsx
+++ b/test/react/hooks/use-room.test.tsx
@@ -3,7 +3,7 @@ import * as Ably from 'ably';
 import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { DefaultRoomOptions } from '../../../src/core/room-options.ts';
+import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { RoomStatus, RoomStatusListener } from '../../../src/core/room-status.ts';
 import { ChatRoomProvider, useRoom, UseRoomResponse } from '../../../src/react/index.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
@@ -53,7 +53,7 @@ describe('useRoom', () => {
           id={roomId}
           attach={false}
           release={false}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent
             callback={(response) => {
@@ -82,7 +82,7 @@ describe('useRoom', () => {
           id={roomId}
           attach={false}
           release={false}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent
             callback={(response) => {
@@ -111,7 +111,7 @@ describe('useRoom', () => {
     let called1 = 0;
     let called2 = 0;
     const roomId = randomRoomId();
-    const room = await chatClient.rooms.get(roomId, DefaultRoomOptions);
+    const room = await chatClient.rooms.get(roomId, AllFeaturesEnabled);
 
     vi.spyOn(room, 'attach').mockImplementation(() => Promise.resolve());
     vi.spyOn(room, 'detach').mockImplementation(() => Promise.resolve());
@@ -123,7 +123,7 @@ describe('useRoom', () => {
           id={roomId}
           attach={false}
           release={false}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent
             callback={() => {
@@ -138,7 +138,7 @@ describe('useRoom', () => {
           id={roomId}
           attach={true}
           release={true}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent
             callback={() => {
@@ -234,7 +234,7 @@ describe('useRoom', () => {
   it('should correctly set room status callback', async () => {
     const chatClient = newChatClient();
     const roomId = randomRoomId();
-    const room = await chatClient.rooms.get(roomId, DefaultRoomOptions);
+    const room = await chatClient.rooms.get(roomId, AllFeaturesEnabled);
 
     let listeners: RoomStatusListener[] = [];
 
@@ -259,7 +259,7 @@ describe('useRoom', () => {
         <ChatClientProvider client={chatClient}>
           <ChatRoomProvider
             id={roomId}
-            options={DefaultRoomOptions}
+            options={AllFeaturesEnabled}
           >
             {children}
           </ChatRoomProvider>
@@ -291,7 +291,7 @@ describe('useRoom', () => {
   it('should correctly set room status and error state variables', async () => {
     const chatClient = newChatClient();
     const roomId = randomRoomId();
-    const room = await chatClient.rooms.get(roomId, DefaultRoomOptions);
+    const room = await chatClient.rooms.get(roomId, AllFeaturesEnabled);
 
     let listeners: RoomStatusListener[] = [];
 
@@ -309,7 +309,7 @@ describe('useRoom', () => {
         <ChatClientProvider client={chatClient}>
           <ChatRoomProvider
             id={roomId}
-            options={DefaultRoomOptions}
+            options={AllFeaturesEnabled}
           >
             {children}
           </ChatRoomProvider>

--- a/test/react/hooks/use-typing.integration.test.tsx
+++ b/test/react/hooks/use-typing.integration.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render } from '@testing-library/react';
 import React, { useEffect } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { DefaultRoomOptions } from '../../../src/core/room-options.ts';
+import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { RoomStatus } from '../../../src/core/room-status.ts';
 import { TypingEvent, TypingListener } from '../../../src/core/typing.ts';
 import { useTyping } from '../../../src/react/hooks/use-typing.ts';
@@ -38,7 +38,7 @@ describe('useTyping', () => {
 
     // create a second room and attach it, so we can listen for typing events
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, DefaultRoomOptions);
+    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
     await roomTwo.attach();
 
     // start listening for typing events on room two
@@ -64,7 +64,7 @@ describe('useTyping', () => {
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
           id={roomId}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent />
         </ChatRoomProvider>
@@ -85,7 +85,7 @@ describe('useTyping', () => {
 
     // create a second room and attach it, so we can send typing events
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, DefaultRoomOptions);
+    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
     await roomTwo.attach();
 
     // store the received typing events for room one
@@ -107,7 +107,7 @@ describe('useTyping', () => {
       <ChatClientProvider client={chatClientOne}>
         <ChatRoomProvider
           id={roomId}
-          options={DefaultRoomOptions}
+          options={AllFeaturesEnabled}
         >
           <TestComponent listener={(typingEvent) => typingEventsRoomOne.push(typingEvent)} />
         </ChatRoomProvider>

--- a/test/react/providers/chat-room-provider.integration.test.tsx
+++ b/test/react/providers/chat-room-provider.integration.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, configure, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { DefaultRoomOptions } from '../../../src/core/room-options.ts';
+import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { RoomStatus } from '../../../src/core/room-status.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
@@ -31,7 +31,7 @@ describe('ChatRoomProvider', () => {
         <ChatClientProvider client={chatClient}>
           <ChatRoomProvider
             id={roomId}
-            options={{ reactions: DefaultRoomOptions.reactions }}
+            options={{ reactions: AllFeaturesEnabled.reactions }}
             attach={true}
             release={false}
           >
@@ -42,7 +42,7 @@ describe('ChatRoomProvider', () => {
     };
     render(<TestProvider />);
 
-    const room = await chatClient.rooms.get(roomId, { reactions: DefaultRoomOptions.reactions });
+    const room = await chatClient.rooms.get(roomId, { reactions: AllFeaturesEnabled.reactions });
     await vi.waitFor(
       () => {
         expect(room.status).toBe(RoomStatus.Attached);

--- a/test/react/providers/room-provider.test.tsx
+++ b/test/react/providers/room-provider.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render } from '@testing-library/react';
 import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { DefaultRoomOptions } from '../../../src/core/room-options.ts';
+import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { useRoom } from '../../../src/react/index.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
@@ -32,7 +32,7 @@ describe('ChatRoomProvider', () => {
         <ChatClientProvider client={chatClient}>
           <ChatRoomProvider
             id={roomId}
-            options={{ reactions: DefaultRoomOptions.reactions }}
+            options={{ reactions: AllFeaturesEnabled.reactions }}
             attach={false}
             release={true}
           >
@@ -47,10 +47,10 @@ describe('ChatRoomProvider', () => {
     await vi.waitFor(() => {
       expect(roomResolved).toBeTruthy();
     });
-    await expect(() => chatClient.rooms.get(roomId, DefaultRoomOptions)).rejects.toBeErrorInfoWithCode(40000);
+    await expect(() => chatClient.rooms.get(roomId, AllFeaturesEnabled)).rejects.toBeErrorInfoWithCode(40000);
 
     // Now try it with the right options, should be fine
-    await chatClient.rooms.get(roomId, { reactions: DefaultRoomOptions.reactions });
+    await chatClient.rooms.get(roomId, { reactions: AllFeaturesEnabled.reactions });
   });
 
   it('should correctly release rooms', async () => {
@@ -64,7 +64,7 @@ describe('ChatRoomProvider', () => {
         <ChatClientProvider client={chatClient}>
           <ChatRoomProvider
             id={roomId}
-            options={{ reactions: DefaultRoomOptions.reactions }}
+            options={{ reactions: AllFeaturesEnabled.reactions }}
             attach={false}
             release={true}
           >
@@ -76,17 +76,17 @@ describe('ChatRoomProvider', () => {
     const r = render(<TestProvider />);
 
     // Try to get the client to get a room with different options, should fail
-    await expect(() => chatClient.rooms.get(roomId, DefaultRoomOptions)).rejects.toBeErrorInfoWithCode(40000);
+    await expect(() => chatClient.rooms.get(roomId, AllFeaturesEnabled)).rejects.toBeErrorInfoWithCode(40000);
 
     // Now try it with the right options, should be fine
-    expect(() => chatClient.rooms.get(roomId, { reactions: DefaultRoomOptions.reactions }));
+    expect(() => chatClient.rooms.get(roomId, { reactions: AllFeaturesEnabled.reactions }));
 
     // Unmount provider
     r.unmount();
 
     // Since the room is supposed to be released on unmount, we should be able
     // to get it again with different settings
-    expect(() => chatClient.rooms.get(roomId, DefaultRoomOptions)).toBeTruthy();
+    expect(() => chatClient.rooms.get(roomId, AllFeaturesEnabled)).toBeTruthy();
   });
 
   it('should attach and detach correctly', async () => {
@@ -96,7 +96,7 @@ describe('ChatRoomProvider', () => {
     };
     const roomId = randomRoomId();
 
-    const room = await chatClient.rooms.get(roomId, { reactions: DefaultRoomOptions.reactions });
+    const room = await chatClient.rooms.get(roomId, { reactions: AllFeaturesEnabled.reactions });
     expect(room).toBeTruthy();
 
     vi.spyOn(room, 'attach');
@@ -107,7 +107,7 @@ describe('ChatRoomProvider', () => {
         <ChatClientProvider client={chatClient}>
           <ChatRoomProvider
             id={roomId}
-            options={{ reactions: DefaultRoomOptions.reactions }}
+            options={{ reactions: AllFeaturesEnabled.reactions }}
             attach={true}
             release={false}
           >
@@ -130,7 +130,7 @@ describe('ChatRoomProvider', () => {
     });
 
     // Try to get the client to get a room with different options, should fail
-    await expect(() => chatClient.rooms.get(roomId, DefaultRoomOptions)).rejects.toBeErrorInfoWithCode(40000);
+    await expect(() => chatClient.rooms.get(roomId, AllFeaturesEnabled)).rejects.toBeErrorInfoWithCode(40000);
   });
 
   it('should not attach, detach, or release when not configured to do so', async () => {
@@ -140,7 +140,7 @@ describe('ChatRoomProvider', () => {
     };
     const roomId = randomRoomId();
 
-    const room = await chatClient.rooms.get(roomId, { reactions: DefaultRoomOptions.reactions });
+    const room = await chatClient.rooms.get(roomId, { reactions: AllFeaturesEnabled.reactions });
     expect(room).toBeTruthy();
 
     vi.spyOn(room, 'attach');
@@ -151,7 +151,7 @@ describe('ChatRoomProvider', () => {
         <ChatClientProvider client={chatClient}>
           <ChatRoomProvider
             id={roomId}
-            options={{ reactions: DefaultRoomOptions.reactions }}
+            options={{ reactions: AllFeaturesEnabled.reactions }}
             attach={false}
             release={false}
           >
@@ -170,7 +170,7 @@ describe('ChatRoomProvider', () => {
     expect(room.detach).toHaveBeenCalledTimes(0);
 
     // Try to get the client to get a room with different options, should fail (since it should not be released)
-    await expect(() => chatClient.rooms.get(roomId, DefaultRoomOptions)).rejects.toBeErrorInfoWithCode(40000);
+    await expect(() => chatClient.rooms.get(roomId, AllFeaturesEnabled)).rejects.toBeErrorInfoWithCode(40000);
 
     await chatClient.rooms.release(roomId);
   });


### PR DESCRIPTION
### Context

[CHA-851]

Docs PR: https://github.com/ably/docs/pull/2455

### Description

- Rename the `ClientOptions` to `ChatClientOptions` to avoid conflicts with ably-js.
- Rename `DefaultRoomOptions` to `AllFeaturesEnabled` so it doesn't imply that they're a recommendation.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A

[CHA-851]: https://ably.atlassian.net/browse/CHA-851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat rooms now offer an enhanced experience by automatically enabling the full range of chat features.
  
- **Refactor**
  - Updated the chat configuration settings for improved consistency and clarity in how chat options are managed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->