### PR TITLE
Refactor: Typing with heartbeats

### DIFF
--- a/demo/src/components/MessageInput/MessageInput.tsx
+++ b/demo/src/components/MessageInput/MessageInput.tsx
@@ -6,7 +6,7 @@ interface MessageInputProps {}
 
 export const MessageInput: FC<MessageInputProps> = ({}) => {
   const { send } = useMessages();
-  const { start, stop } = useTyping();
+  const { keystroke, stop } = useTyping();
   const { currentStatus } = useChatConnection();
   const [shouldDisable, setShouldDisable] = useState(true);
 
@@ -16,7 +16,7 @@ export const MessageInput: FC<MessageInputProps> = ({}) => {
   }, [currentStatus]);
 
   const handleStartTyping = () => {
-    start().catch((error: unknown) => {
+    keystroke().catch((error: unknown) => {
       console.error('Failed to start typing indicator', error);
     });
   };

--- a/src/core/channel.ts
+++ b/src/core/channel.ts
@@ -4,3 +4,11 @@
  * @returns The channel name.
  */
 export const messagesChannelName = (roomId: string): string => `${roomId}::$chat::$chatMessages`;
+
+/**
+ * Gets the single main channel for the chat room.
+ *
+ * @param roomId The room ID.
+ * @returns  The channel name.
+ */
+export const roomChannelName = (roomId: string): string => `${roomId}::$chat`;

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -5,6 +5,11 @@ import * as Ably from 'ably';
  */
 export enum ErrorCodes {
   /**
+   * The request was invalid.
+   */
+  BadRequest = 40000,
+
+  /**
    * The message was rejected before publishing by a rule on the chat room.
    */
   MessageRejectedByBeforePublishRule = 42211,

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -76,18 +76,18 @@ export enum TypingEvents {
   /**
    * Event triggered when a user is typing.
    */
-  Start = 'typing.start',
+  Start = 'typing.started',
 
   /**
    * Event triggered when a user stops typing.
    */
-  Stop = 'typing.stop',
+  Stop = 'typing.stopped',
 }
 
 /**
  * Represents a typing event payload.
  */
-export interface TypingEventPayload {
+export interface TypingEvent {
   /**
    * Get a set of clientIds that are currently typing.
    */

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -69,9 +69,39 @@ export enum PresenceEvents {
   Present = 'present',
 }
 
+/**
+ * All typing events.
+ */
 export enum TypingEvents {
-  /** The set of currently typing users has changed. */
-  Changed = 'typing.changed',
+  /**
+   * Event triggered when a user is typing.
+   */
+  Start = 'typing.start',
+
+  /**
+   * Event triggered when a user stops typing.
+   */
+  Stop = 'typing.stop',
+}
+
+/**
+ * Represents a typing event payload.
+ */
+export interface TypingEventPayload {
+  /**
+   * Get a set of clientIds that are currently typing.
+   */
+  get currentlyTyping(): Set<string>;
+
+  /**
+   * Get the client ID of the user who stopped/started typing.
+   */
+  clientId: string;
+
+  /**
+   * Type of the event.
+   */
+  type: TypingEvents;
 }
 
 /**

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -85,7 +85,7 @@ export enum TypingEvents {
 }
 
 /**
- * Represents a typing event payload.
+ * Represents a change in the state of current typers.
  */
 export interface TypingEvent {
   /**
@@ -94,7 +94,7 @@ export interface TypingEvent {
   currentlyTyping: Set<string>;
 
   /**
-   * Represents the change that resulted in the typing event.
+   * Represents the change that resulted in the new set of typers.
    */
   change: {
     /**
@@ -103,7 +103,7 @@ export interface TypingEvent {
     clientId: string;
 
     /**
-     * Type of the event.
+     * Type of the change. Either `typing.started` or `typing.stopped`.
      */
     type: TypingEvents;
   };

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -89,16 +89,16 @@ export enum TypingEvents {
  */
 export interface TypingEvent {
   /**
-   * Get a set of clientIds that are currently typing.
+   * The set of clientIds that are currently typing.
    */
-  get currentlyTyping(): Set<string>;
+  currentlyTyping: Set<string>;
 
   /**
    * Represents the change that resulted in the typing event.
    */
   change: {
     /**
-     * Get the client ID of the user who stopped/started typing.
+     * The client ID of the user who stopped/started typing.
      */
     clientId: string;
 

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -94,14 +94,19 @@ export interface TypingEvent {
   get currentlyTyping(): Set<string>;
 
   /**
-   * Get the client ID of the user who stopped/started typing.
+   * Represents the change that resulted in the typing event.
    */
-  clientId: string;
+  change: {
+    /**
+     * Get the client ID of the user who stopped/started typing.
+     */
+    clientId: string;
 
-  /**
-   * Type of the event.
-   */
-  type: TypingEvents;
+    /**
+     * Type of the event.
+     */
+    type: TypingEvents;
+  };
 }
 
 /**

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -8,7 +8,7 @@ export type { Connection, ConnectionStatusChange, ConnectionStatusListener } fro
 export { ConnectionStatus } from './connection.js';
 export type { DiscontinuityListener, OnDiscontinuitySubscriptionResponse } from './discontinuity.js';
 export { ErrorCodes, errorInfoIs } from './errors.js';
-export type { MessageEvent } from './events.js';
+export type { MessageEvent, TypingEventPayload } from './events.js';
 export { ChatMessageActions, MessageEvents, PresenceEvents } from './events.js';
 export type { Headers } from './headers.js';
 export type { LogContext, Logger, LogHandler } from './logger.js';
@@ -51,5 +51,5 @@ export type { RoomStatusChange, RoomStatusListener } from './room-status.js';
 export { RoomStatus } from './room-status.js';
 export type { Rooms } from './rooms.js';
 export type { StatusSubscription, Subscription } from './subscription.js';
-export type { Typing, TypingEvent, TypingListener } from './typing.js';
+export type { Typing, TypingListener } from './typing.js';
 export type { ChannelStateChange, ErrorInfo, RealtimePresenceParams } from 'ably';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -8,7 +8,7 @@ export type { Connection, ConnectionStatusChange, ConnectionStatusListener } fro
 export { ConnectionStatus } from './connection.js';
 export type { DiscontinuityListener, OnDiscontinuitySubscriptionResponse } from './discontinuity.js';
 export { ErrorCodes, errorInfoIs } from './errors.js';
-export type { MessageEvent, TypingEventPayload } from './events.js';
+export type { MessageEvent, TypingEvent, TypingEvents } from './events.js';
 export { ChatMessageActions, MessageEvents, PresenceEvents } from './events.js';
 export type { Headers } from './headers.js';
 export type { LogContext, Logger, LogHandler } from './logger.js';

--- a/src/core/realtime.ts
+++ b/src/core/realtime.ts
@@ -1,0 +1,19 @@
+import * as Ably from 'ably';
+
+/**
+ * Convenience function that takes an event name and optional data and turns it into a
+ * message that the server will recognize as ephemeral.
+ *
+ * @param name The name of the event.
+ * @param data Optional data to send with the event.
+ * @returns An Ably message.
+ */
+export const ephemeralMessage = (name: string, data?: unknown): Ably.Message => {
+  return {
+    name: name,
+    data: data,
+    extras: {
+      ephemeral: true,
+    },
+  };
+};

--- a/src/core/room-options.ts
+++ b/src/core/room-options.ts
@@ -29,7 +29,7 @@ export const AllFeaturesEnabled = {
      *
      * Spec: CHA-T10.
      */
-    heartbeatThrottleMs: 15000,
+    heartbeatThrottleMs: 10000,
   } as TypingOptions,
 
   /**

--- a/src/core/room-options.ts
+++ b/src/core/room-options.ts
@@ -69,12 +69,13 @@ export interface PresenceOptions {
  */
 export interface TypingOptions {
   /**
-   * The time, in milliseconds, that a client will wait before emitting a `typing.started` event.
+   * A throttle, in milliseconds, that enforces the minimum time interval between consecutive `typing.started`
+   * events sent by the client to the server.
    * If typing.start() is called, the first call will emit an event immediately.
-   * Later calls will no-op until the interval has elapsed.
-   * Calling typing.stop() will immediately send a `typing.stopped` event and reset the interval,
+   * Later calls will no-op until the time has elapsed.
+   * Calling typing.stop() will immediately send a `typing.stopped` event to the server and reset the interval,
    * allowing the client to send another `typing.started` event immediately.
-   * @defaultValue 15000
+   * @defaultValue 10000
    */
   heartbeatThrottleMs: number;
 }

--- a/src/core/room-options.ts
+++ b/src/core/room-options.ts
@@ -25,29 +25,11 @@ export const AllFeaturesEnabled = {
    */
   typing: {
     /**
-     * The default time that a client will wait after calling typing.start() before emitting a `typing.stopped`
-     * event.
-     * Restarts the interval with repeated calls to typing.start(), resets the interval with typing.stop().
-     *
-     * Spec: CHA-T3
-     * @defaultValue
-     */
-    timeoutMs: 2000,
-
-    /**
      * The default time that a client will wait between sending one typing heartbeat and the next.
      *
      * Spec: CHA-T10.
      */
-    heartbeatIntervalMs: 15000,
-
-    /**
-     * The default timeout for typing inactivity in milliseconds.
-     *
-     * TODO: Rename this?
-     * Spec: CHA-T11
-     */
-    inactivityTimeoutMs: 500,
+    heartbeatThrottleMs: 15000,
   } as TypingOptions,
 
   /**
@@ -92,23 +74,9 @@ export interface TypingOptions {
    * Later calls will no-op until the interval has elapsed.
    * Calling typing.stop() will immediately send a `typing.stopped` event and reset the interval,
    * allowing the client to send another `typing.started` event immediately.
-   * @defaultValue 17000
+   * @defaultValue 15000
    */
-  heartbeatIntervalMs: number;
-
-  /**
-   * The optional timeout, in milliseconds, after which a client that pauses typing and does not resume, will emit a `typing.stopped` event.
-   * If not set, the client will not emit a `typing.stopped` event until they call `typing.stop()`.
-   * @defaultValue 2000
-   */
-  timeoutMs?: number | undefined;
-
-  /**
-   * The time, in milliseconds, a client waits after failing to receive a typing heartbeat from another client before assuming the other client has stopped typing.
-   * In practice, this means the client waits the length of the heartbeat interval plus this value before emitting a `typing.stopped` event.
-   * @defaultValue 500
-   */
-  inactivityTimeoutMs: number;
+  heartbeatThrottleMs: number;
 }
 
 /**
@@ -177,14 +145,8 @@ export const validateRoomOptions = (options: RoomOptions): void => {
 };
 
 const validateTypingOptions = (options: TypingOptions): void => {
-  if (options.timeoutMs !== undefined && options.timeoutMs <= 0) {
-    throw invalidRoomConfiguration('typing timeout must be greater than 0');
-  }
-  if (options.heartbeatIntervalMs <= 0) {
+  if (options.heartbeatThrottleMs <= 0) {
     throw invalidRoomConfiguration('typing heartbeat interval must be greater than 0');
-  }
-  if (options.inactivityTimeoutMs <= 0) {
-    throw invalidRoomConfiguration('typing inactivity timeout must be greater than 0');
   }
 };
 

--- a/src/core/room-options.ts
+++ b/src/core/room-options.ts
@@ -28,18 +28,26 @@ export const AllFeaturesEnabled = {
      * The default time that a client will wait after calling typing.start() before emitting a `typing.stopped`
      * event.
      * Restarts the interval with repeated calls to typing.start(), resets the interval with typing.stop().
+     *
+     * Spec: CHA-T3
+     * @defaultValue
      */
     timeoutMs: 2000,
 
     /**
      * The default time that a client will wait between sending one typing heartbeat and the next.
+     *
+     * Spec: CHA-T10.
      */
-    heartbeatIntervalMs: 17000,
+    heartbeatIntervalMs: 15000,
 
     /**
      * The default timeout for typing inactivity in milliseconds.
+     *
+     * TODO: Rename this?
+     * Spec: CHA-T11
      */
-    inactivityTimeoutMs: 2000,
+    inactivityTimeoutMs: 500,
   } as TypingOptions,
 
   /**
@@ -93,12 +101,12 @@ export interface TypingOptions {
    * If not set, the client will not emit a `typing.stopped` event until they call `typing.stop()`.
    * @defaultValue 2000
    */
-  timeoutMs?: number;
+  timeoutMs?: number | undefined;
 
   /**
    * The time, in milliseconds, a client waits after failing to receive a typing heartbeat from another client before assuming the other client has stopped typing.
    * In practice, this means the client waits the length of the heartbeat interval plus this value before emitting a `typing.stopped` event.
-   * @defaultValue 2000
+   * @defaultValue 500
    */
   inactivityTimeoutMs: number;
 }

--- a/src/core/room-options.ts
+++ b/src/core/room-options.ts
@@ -25,9 +25,21 @@ export const AllFeaturesEnabled = {
    */
   typing: {
     /**
-     * The default timeout for typing events in milliseconds.
+     * The default time that a client will wait after calling typing.start() before emitting a `typing.stopped`
+     * event.
+     * Restarts the interval with repeated calls to typing.start(), resets the interval with typing.stop().
      */
-    timeoutMs: 5000,
+    timeoutMs: 2000,
+
+    /**
+     * The default time that a client will wait between sending one typing heartbeat and the next.
+     */
+    heartbeatIntervalMs: 17000,
+
+    /**
+     * The default timeout for typing inactivity in milliseconds.
+     */
+    inactivityTimeoutMs: 2000,
   } as TypingOptions,
 
   /**
@@ -67,11 +79,28 @@ export interface PresenceOptions {
  */
 export interface TypingOptions {
   /**
-   * The timeout for typing events in milliseconds. If typing.start() is not called for this amount of time, a stop
-   * typing event will be fired, resulting in the user being removed from the currently typing set.
-   * @defaultValue 5000
+   * The time, in milliseconds, that a client will wait before emitting a `typing.started` event.
+   * If typing.start() is called, the first call will emit an event immediately.
+   * Later calls will no-op until the interval has elapsed.
+   * Calling typing.stop() will immediately send a `typing.stopped` event and reset the interval,
+   * allowing the client to send another `typing.started` event immediately.
+   * @defaultValue 17000
    */
-  timeoutMs: number;
+  heartbeatIntervalMs: number;
+
+  /**
+   * The optional timeout, in milliseconds, after which a client that pauses typing and does not resume, will emit a `typing.stopped` event.
+   * If not set, the client will not emit a `typing.stopped` event until they call `typing.stop()`.
+   * @defaultValue 2000
+   */
+  timeoutMs?: number;
+
+  /**
+   * The time, in milliseconds, a client waits after failing to receive a typing heartbeat from another client before assuming the other client has stopped typing.
+   * In practice, this means the client waits the length of the heartbeat interval plus this value before emitting a `typing.stopped` event.
+   * @defaultValue 2000
+   */
+  inactivityTimeoutMs: number;
 }
 
 /**
@@ -134,8 +163,20 @@ const invalidRoomConfiguration = (reason: string): Error =>
   new Ably.ErrorInfo(`invalid room configuration: ${reason}`, 40001, 400);
 
 export const validateRoomOptions = (options: RoomOptions): void => {
-  if (options.typing && options.typing.timeoutMs <= 0) {
+  if (options.typing) {
+    validateTypingOptions(options.typing);
+  }
+};
+
+const validateTypingOptions = (options: TypingOptions): void => {
+  if (options.timeoutMs !== undefined && options.timeoutMs <= 0) {
     throw invalidRoomConfiguration('typing timeout must be greater than 0');
+  }
+  if (options.heartbeatIntervalMs <= 0) {
+    throw invalidRoomConfiguration('typing heartbeat interval must be greater than 0');
+  }
+  if (options.inactivityTimeoutMs <= 0) {
+    throw invalidRoomConfiguration('typing inactivity timeout must be greater than 0');
   }
 };
 

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -61,8 +61,10 @@ export interface Typing extends EmitsDiscontinuities {
    *   resolve to a consistent and correct state.
    *
    * @returns A promise which resolves upon success of the operation and rejects with an ErrorInfo object upon its failure.
+   * @throws {@link ErrorInfo} If the {@link RoomStatus} is not either {@link RoomStatus.Attached} or {@link RoomStatus.Attaching}.
+   * @throws {@link ErrorInfo} If the operation fails to send the event to the server.
+   * @throws {@link ErrorInfo} If there is a problem acquiring the mutex that controls serialization.
    */
-
   keystroke(): Promise<void>;
 
   /**
@@ -78,6 +80,9 @@ export interface Typing extends EmitsDiscontinuities {
    *   resolve to a consistent and correct state.
    *
    * @returns A promise which resolves upon success of the operation and rejects with an ErrorInfo object upon its failure.
+   * @throws {@link ErrorInfo} If the {@link RoomStatus} is not either {@link RoomStatus.Attached} or {@link RoomStatus.Attaching}.
+   * @throws {@link ErrorInfo} If the operation fails to send the event to the server.
+   * @throws {@link ErrorInfo} If there is a problem acquiring the mutex that controls serialization.
    */
 
   stop(): Promise<void>;
@@ -222,10 +227,12 @@ export class DefaultTyping
     });
     try {
       // CHA-T4d
-      // Ensure channel is attached
+      // Ensure room is attached
       if (this.channel.state !== 'attached' && this.channel.state !== 'attaching') {
-        this._logger.error(`DefaultTyping.keystroke(); channel is not attached`, { state: this.channel.state });
-        throw new Ably.ErrorInfo('cannot type, channel is not attached', 50000, 500);
+        this._logger.error(`DefaultTyping.keystroke(); room is not in the correct state `, {
+          State: this.channel.state,
+        });
+        throw new Ably.ErrorInfo('cannot type, room is not in the correct state', 50000, 500);
       }
 
       // Check whether user is already typing before publishing again
@@ -267,8 +274,8 @@ export class DefaultTyping
     try {
       // CHA-T5c
       if (this.channel.state !== 'attached' && this.channel.state !== 'attaching') {
-        this._logger.error(`DefaultTyping.stop(); channel is not attached`, { state: this.channel.state });
-        throw new Ably.ErrorInfo('cannot stop typing, channel is not attached', 50000, 500);
+        this._logger.error(`DefaultTyping.stop(); room is not in the correct state `, { State: this.channel.state });
+        throw new Ably.ErrorInfo('cannot stop typing, room is not in the correct state', 50000, 500);
       }
 
       // If the user is not typing, do nothing.

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -1,6 +1,7 @@
 import * as Ably from 'ably';
-import { dequal } from 'dequal';
+import { Mutex } from 'async-mutex';
 
+import { messagesChannelName } from './channel.js';
 import { ChannelManager } from './channel-manager.js';
 import {
   DiscontinuityEmitter,
@@ -11,16 +12,12 @@ import {
   OnDiscontinuitySubscriptionResponse,
 } from './discontinuity.js';
 import { ErrorCodes } from './errors.js';
-import { TypingEvents } from './events.js';
+import { TypingEventPayload, TypingEvents } from './events.js';
 import { Logger } from './logger.js';
 import { ContributesToRoomLifecycle } from './room-lifecycle-manager.js';
 import { TypingOptions } from './room-options.js';
 import { Subscription } from './subscription.js';
 import EventEmitter from './utils/event-emitter.js';
-
-const PRESENCE_GET_RETRY_INTERVAL_MS = 1500; // base retry interval, we double it each time
-const PRESENCE_GET_RETRY_MAX_INTERVAL_MS = 30000; // max retry interval
-const PRESENCE_GET_MAX_RETRIES = 5; // max num of retries
 
 /**
  * This interface is used to interact with typing in a chat room including subscribing to typing events and
@@ -49,9 +46,15 @@ export interface Typing extends EmitsDiscontinuities {
   get(): Promise<Set<string>>;
 
   /**
-   * Start indicates that the current user is typing. This will emit a typingStarted event to inform listening clients and begin a timer,
-   * once the timer expires, a typingStopped event will be emitted. The timeout is configurable through the typingTimeoutMs parameter.
-   * If the current user is already typing, it will reset the timer and begin counting down again without emitting a new event.
+   * Start indicates that the current user is typing.
+   * This will emit a `typing.start` event to inform listening clients and begin a heartbeat timer,
+   * which can be configured through the `heartbeatIntervalMs` parameter.
+   * If the current user is already typing, this will no-op until the heartbeat timer has elapsed,
+   * at which point calling `start()` will restart the timer and emit a new `typing.start` heartbeat.
+   * If the `timeoutMs` parameter is defined in the supplied {@link TypingOptions},
+   * then calls to `start()` will also begin a separate timer.
+   * Once this timer expires, a `typing.stop` event will be emitted.
+   * Further calls to `start()` will restart this timer.
    *
    * @returns A promise which resolves upon success of the operation and rejects with an ErrorInfo object upon its failure.
    */
@@ -59,8 +62,9 @@ export interface Typing extends EmitsDiscontinuities {
   start(): Promise<void>;
 
   /**
-   * Stop indicates that the current user has stopped typing. This will emit a typingStopped event to inform listening clients,
-   * and immediately clear the typing timeout timer.
+   * Stop indicates that the current user has stopped typing.
+   * This will emit a `typing.stop` event to inform listening clients,
+   * and immediately clear any active timers.
    *
    * @returns A promise which resolves upon success of the operation and rejects with an ErrorInfo object upon its failure.
    */
@@ -75,26 +79,17 @@ export interface Typing extends EmitsDiscontinuities {
 }
 
 /**
- * Represents a typing event.
- */
-export interface TypingEvent {
-  /**
-   * Get a set of clientIds that are currently typing.
-   */
-  get currentlyTyping(): Set<string>;
-}
-
-/**
  * A listener which listens for typing events.
  * @param event The typing event.
  */
-export type TypingListener = (event: TypingEvent) => void;
+export type TypingListener = (event: TypingEventPayload) => void;
 
 /**
  * Represents the typing events mapped to their respective event payloads.
  */
 interface TypingEventsMap {
-  [TypingEvents.Changed]: TypingEvent;
+  [TypingEvents.Start]: TypingEventPayload;
+  [TypingEvents.Stop]: TypingEventPayload;
 }
 
 /**
@@ -110,14 +105,15 @@ export class DefaultTyping
   private readonly _discontinuityEmitter: DiscontinuityEmitter = newDiscontinuityEmitter();
 
   // Timeout for typing
-  private readonly _typingTimeoutMs: number;
-  private _timerId: ReturnType<typeof setTimeout> | undefined;
+  private readonly _timeoutMs: number | undefined;
+  private _timeoutTimerId: ReturnType<typeof setTimeout> | undefined;
+  private readonly _heartbeatIntervalMs: number;
+  private _heartbeatTimerId: ReturnType<typeof setTimeout> | undefined;
+  private readonly _inactivityTimeoutMs: number;
 
-  private _receivedEventNumber = 0;
-  private _triggeredEventNumber = 0;
-  private _currentlyTyping: Set<string> = new Set<string>();
-  private _retryTimeout: ReturnType<typeof setTimeout> | undefined;
-  private _numRetries = 0;
+  private _opMtx: Mutex;
+
+  private _currentlyTyping: Map<string, ReturnType<typeof setTimeout> | undefined>;
 
   /**
    * Constructs a new `DefaultTyping` instance.
@@ -137,9 +133,17 @@ export class DefaultTyping
     super();
     this._clientId = clientId;
     this._channel = this._makeChannel(roomId, channelManager);
+    // Mutex to control access to the typing state
+    this._opMtx = new Mutex();
+    // Timeout for pause in typing
+    this._timeoutMs = options.timeoutMs;
+    // Timeout for inactivity, i.e. when we have not received a heartbeat for a configured time
+    this._inactivityTimeoutMs = options.inactivityTimeoutMs;
+    // Interval for the heartbeat, how often we should emit a typing event with repeated calls to start()
+    this._heartbeatIntervalMs = options.heartbeatIntervalMs;
 
-    // Timeout for typing
-    this._typingTimeoutMs = options.timeoutMs;
+    // Map of clientIds to their typing timers, used to track typing state
+    this._currentlyTyping = new Map<string, ReturnType<typeof setTimeout> | undefined>();
     this._logger = logger;
   }
 
@@ -147,20 +151,20 @@ export class DefaultTyping
    * Creates the realtime channel for typing indicators.
    */
   private _makeChannel(roomId: string, channelManager: ChannelManager): Ably.RealtimeChannel {
-    const channel = channelManager.get(`${roomId}::$chat::$typingIndicators`);
-
+    const channel = channelManager.get(messagesChannelName(roomId));
     // attachOnSubscribe is set to false in the default channel options, so this call cannot fail
-    void channel.presence.subscribe(this._internalSubscribeToEvents.bind(this));
-
+    void channel.subscribe([TypingEvents.Start, TypingEvents.Stop], this._internalSubscribeToEvents.bind(this));
     return channel;
   }
 
   /**
    * @inheritDoc
    */
-  get(): Promise<Set<string>> {
+  async get(): Promise<Set<string>> {
     this._logger.trace(`DefaultTyping.get();`);
-    return this._channel.presence.get().then((members) => new Set<string>(members.map((m) => m.clientId)));
+    return this._opMtx.runExclusive(() => {
+      return new Set<string>(this._currentlyTyping.keys());
+    });
   }
 
   /**
@@ -171,14 +175,29 @@ export class DefaultTyping
   }
 
   /**
-   * Start the typing timeout timer. This will emit a typingStopped event if the timer expires.
+   * Start the typing timeout timer. This will expire after the configured timeout.
    */
-  private _startTypingTimer(): void {
-    this._logger.trace(`DefaultTyping.startTypingTimer();`);
-    this._timerId = setTimeout(() => {
-      this._logger.debug(`DefaultTyping.startTypingTimer(); timeout expired`);
-      void this.stop();
-    }, this._typingTimeoutMs);
+  private _setTimeoutTimer(): void {
+    if (this._timeoutMs) {
+      clearTimeout(this._timeoutTimerId);
+      this._logger.trace(`DefaultTyping.startTypingTimer();`);
+      this._timeoutTimerId = setTimeout(() => {
+        this._logger.debug(`DefaultTyping.startTypingTimer(); timeout expired`);
+        void this.stop();
+      }, this._timeoutMs);
+    }
+  }
+
+  /**
+   * Start the heartbeat timer. This will expire after the configured interval.
+   */
+  private _startHeartbeatTimer(): void {
+    if (!this._heartbeatTimerId) {
+      this._logger.trace(`DefaultTyping.startHeartbeatTimer();`);
+      this._heartbeatTimerId = setTimeout(() => {
+        this._logger.debug(`DefaultTyping.startHeartbeatTimer(); heartbeat timer expired`);
+      }, this._heartbeatIntervalMs);
+    }
   }
 
   /**
@@ -186,17 +205,21 @@ export class DefaultTyping
    */
   async start(): Promise<void> {
     this._logger.trace(`DefaultTyping.start();`);
-    // If the user is already typing, reset the timer
-    if (this._timerId) {
-      this._logger.debug(`DefaultTyping.start(); already typing, resetting timer`);
-      clearTimeout(this._timerId);
-      this._startTypingTimer();
+
+    // If the user is already typing, and the timer has not expired, do not send another heartbeat
+    if (this._heartbeatTimerId) {
+      this._logger.debug(`DefaultTyping.start(); no-op, already typing and heartbeat timer has not expired`);
+      // Reset the timeout timer if the user is still typing
+      this._setTimeoutTimer()
       return;
     }
-
-    // Start typing and emit typingStarted event
-    this._startTypingTimer();
-    return this._channel.presence.enterClient(this._clientId);
+    return this._channel.publish(TypingEvents.Start, {}).then(() => {
+      this._logger.trace(`DefaultTyping.start(); starting timers`);
+      // Start the heartbeat timer
+      this._startHeartbeatTimer();
+      // Start the timeout timer
+      this._setTimeoutTimer();
+    });
   }
 
   /**
@@ -204,14 +227,24 @@ export class DefaultTyping
    */
   async stop(): Promise<void> {
     this._logger.trace(`DefaultTyping.stop();`);
-    // Clear the timer and emit typingStopped event
-    if (this._timerId) {
-      clearTimeout(this._timerId);
-      this._timerId = undefined;
+    // If the user is not typing, do nothing.
+    if (!this._heartbeatTimerId) {
+      this._logger.debug(`DefaultTyping.stop(); no-op, not currently typing`);
+      return;
     }
-
-    // Will throw an error if the user is not typing
-    return this._channel.presence.leaveClient(this._clientId);
+    return this._channel.publish(TypingEvents.Stop, {}).then(() => {
+      this._logger.trace(`DefaultTyping.stop(); clearing timers`);
+      // Clear the heartbeat timer
+      if (this._heartbeatTimerId) {
+        clearTimeout(this._heartbeatTimerId);
+        this._heartbeatTimerId = undefined;
+      }
+      // Clear the timeout timer, if it exists
+      if (this._timeoutTimerId) {
+        clearTimeout(this._timeoutTimerId);
+        this._timeoutTimerId = undefined;
+      }
+    });
   }
 
   /**
@@ -238,82 +271,158 @@ export class DefaultTyping
   }
 
   /**
-   * Subscribe to internal events. This will listen to presence events and convert them into associated typing events,
-   * while also updating the currentlyTypingClientIds set.
+   * Update the currently typing users. This method is called when a typing event is received.
+   * It will also acquire a mutex to ensure that the currentlyTyping state is updated safely.
+   * @param clientId The client ID of the user.
+   * @param event The typing event.
    */
-  private readonly _internalSubscribeToEvents = (member: Ably.PresenceMessage) => {
-    if (!member.clientId) {
-      this._logger.error(`unable to handle typing event; no clientId`, { member });
+  private async _updateCurrentlyTyping(clientId: string, event: TypingEvents): Promise<void> {
+    // Wrap the entire logic in the mutex so we can access currentlyTyping safely
+    await this._opMtx.runExclusive(() => {
+      this._logger.trace(`DefaultTyping._updateCurrentlyTyping();`, { clientId, event });
+
+      const existingTimeout = this._currentlyTyping.get(clientId);
+
+      if (event === TypingEvents.Start) {
+        this._handleTypingStart(clientId, existingTimeout);
+      } else {
+        this._handleTypingStop(clientId, existingTimeout);
+      }
+    });
+  }
+
+  /**
+   * Starts a new inactivity timer for the client.
+   * This timer will expire after the configured timeout,
+   * which is the sum of the heartbeat interval and the inactivity timeout.
+   * @param clientId
+   */
+  private _startNewClientInactivityTimer(clientId: string): ReturnType<typeof setTimeout> {
+    this._logger.trace(`DefaultTyping._startNewClientInactivityTimer(); starting new inactivity timer`, { clientId });
+    // Set or reset the typing timeout for this client
+    const timeoutId = setTimeout(() => {
+      this._logger.trace(`DefaultTyping._startNewClientInactivityTimer(); client typing timeout expired`, { clientId });
+      // Verify the timer is still valid (it might have been reset)
+      if (this._currentlyTyping.get(clientId) !== timeoutId) {
+        this._logger.debug(`DefaultTyping._startNewClientInactivityTimer(); timeout already cleared; ignoring`, {
+          clientId,
+        });
+        return;
+      }
+      // Remove client as their timeout has expired
+      this._opMtx
+        .runExclusive(() => {
+          this._currentlyTyping.delete(clientId);
+          this.emit(TypingEvents.Stop, {
+            clientId,
+            currentlyTyping: new Set<string>(this._currentlyTyping.keys()),
+            type: TypingEvents.Stop,
+          });
+        })
+        .catch((error: unknown) => {
+          this._logger.error(
+            `DefaultTyping._startNewClientInactivityTimer(); failed to update typing state in timeout`,
+            {
+              clientId,
+              error,
+            },
+          );
+        });
+    }, this._heartbeatIntervalMs + this._inactivityTimeoutMs);
+    return timeoutId;
+  }
+
+  /**
+   * Handles logic for TypingEvents.Start, including starting a new timeout or resetting an existing one.
+   * @param clientId
+   * @param existingTimeout
+   */
+  private _handleTypingStart(clientId: string, existingTimeout: NodeJS.Timeout | undefined): void {
+    this._logger.debug(`DefaultTyping._handleTypingStart();`, { clientId });
+    // Start a new timeout for the client
+    const timeoutId = this._startNewClientInactivityTimer(clientId);
+
+    // Set the new timeout for the client
+    this._currentlyTyping.set(clientId, timeoutId);
+
+    if (existingTimeout) {
+      // Heartbeat - User is already typing, we just need to clear the existing timeout
+      this._logger.debug(`DefaultTyping._handleTypingStart(); received heartbeat for currently typing client`, { clientId });
+      clearTimeout(existingTimeout);
+    } else {
+      // Otherwise, we need to emit a new typing event
+      this._logger.debug(`DefaultTyping._handleTypingStart(); new client started typing`, { clientId });
+      this.emit(TypingEvents.Start, {
+        clientId,
+        currentlyTyping: new Set<string>(this._currentlyTyping.keys()),
+        type: TypingEvents.Start,
+      });
+    }
+
+    // Track the new timeout
+    this._currentlyTyping.set(clientId, timeoutId);
+  }
+
+  // Handles logic for TypingEvents.Stop
+  private _handleTypingStop(clientId: string, existingTimeout: NodeJS.Timeout | undefined): void {
+    if (!existingTimeout) {
+      // Stop requested for a client that isn't currently typing
+      this._logger.warn(
+        `DefaultTyping._handleTypingStop(); received "Stop" event for client not in currentlyTyping list`,
+        { clientId },
+      );
       return;
     }
 
-    this._receivedEventNumber += 1;
+    // Stop typing: clear their timeout and remove from the currently typing set
+    this._logger.debug(`DefaultTyping._handleTypingStop(); client stopped typing`, { clientId });
+    clearTimeout(existingTimeout);
+    this._currentlyTyping.delete(clientId);
+    // Emit stop event only when the client is removed
+    this.emit(TypingEvents.Stop, {
+      clientId,
+      currentlyTyping: new Set<string>(this._currentlyTyping.keys()),
+      type: TypingEvents.Stop,
+    });
+  }
 
-    // received a real event, cancelling retry timeout
-    if (this._retryTimeout) {
-      clearTimeout(this._retryTimeout);
-      this._retryTimeout = undefined;
-      this._numRetries = 0;
+  /**
+   * Subscribe to internal events. This listens to events and converts them into typing updates, with validation.
+   */
+  private _internalSubscribeToEvents = (inbound: Ably.InboundMessage): void => {
+    const { name, clientId } = inbound;
+    this._logger.trace(`DefaultTyping._internalSubscribeToEvents(); received event`, { name, clientId });
+
+    if (clientId === undefined) {
+      this._logger.error(`DefaultTyping._internalSubscribeToEvents(); missing clientId in event payload`, { inbound });
+      return;
     }
 
-    this._getAndEmit(this._receivedEventNumber);
+    if (clientId === '') {
+      this._logger.error(`DefaultTyping._internalSubscribeToEvents(); empty clientId in event payload`, { inbound });
+      return;
+    }
+
+    // Safety check to ensure we are handling only typing events
+    if (name === TypingEvents.Start || name === TypingEvents.Stop) {
+      this._updateCurrentlyTyping(clientId, name)
+        .then(() => {
+          this._logger.debug(`DefaultTyping._internalSubscribeToEvents(); successfully updated typing state`, {
+            name,
+            clientId,
+          });
+        })
+        .catch((error: unknown) => {
+          this._logger.error(`DefaultTyping._internalSubscribeToEvents(); failed to update typing state`, {
+            name,
+            clientId,
+            error,
+          });
+        });
+    } else {
+      this._logger.warn(`DefaultTyping._internalSubscribeToEvents(); unrecognized event`, { name });
+    }
   };
-
-  private _getAndEmit(eventNum: number) {
-    this.get()
-      .then((currentlyTyping) => {
-        // successful fetch, remove retry timeout if one exists
-        if (this._retryTimeout) {
-          clearTimeout(this._retryTimeout);
-          this._retryTimeout = undefined;
-          this._numRetries = 0;
-        }
-
-        // if we've seen the result of a newer promise, do nothing
-        if (this._triggeredEventNumber >= eventNum) {
-          return;
-        }
-        this._triggeredEventNumber = eventNum;
-
-        // if current typers haven't changed since we last emitted, do nothing
-        if (dequal(this._currentlyTyping, currentlyTyping)) {
-          return;
-        }
-
-        this._currentlyTyping = currentlyTyping;
-        this.emit(TypingEvents.Changed, {
-          currentlyTyping: new Set(currentlyTyping),
-        });
-      })
-      .catch((error: unknown) => {
-        const willReattempt = this._numRetries < PRESENCE_GET_MAX_RETRIES;
-        this._logger.error(`Error fetching currently typing clientIds set.`, {
-          error,
-          willReattempt: willReattempt,
-        });
-        if (!willReattempt) {
-          return;
-        }
-
-        // already another timeout, do nothing
-        if (this._retryTimeout) {
-          return;
-        }
-
-        const waitBeforeRetry = Math.min(
-          PRESENCE_GET_RETRY_MAX_INTERVAL_MS,
-          PRESENCE_GET_RETRY_INTERVAL_MS * Math.pow(2, this._numRetries),
-        );
-
-        this._numRetries += 1;
-
-        this._retryTimeout = setTimeout(() => {
-          this._retryTimeout = undefined;
-          this._receivedEventNumber++;
-          this._getAndEmit(this._receivedEventNumber);
-        }, waitBeforeRetry);
-      });
-  }
 
   onDiscontinuity(listener: DiscontinuityListener): OnDiscontinuitySubscriptionResponse {
     this._logger.trace(`DefaultTyping.onDiscontinuity();`);
@@ -331,8 +440,16 @@ export class DefaultTyping
     this._discontinuityEmitter.emit('discontinuity', reason);
   }
 
-  get timeoutMs(): number {
-    return this._typingTimeoutMs;
+  get timeoutMs(): number | undefined {
+    return this._timeoutMs;
+  }
+
+  get inactivityTimeoutMs(): number {
+    return this._inactivityTimeoutMs;
+  }
+
+  get heartbeatIntervalMs(): number {
+    return this._heartbeatIntervalMs;
   }
 
   /**

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -120,7 +120,7 @@ export class DefaultTyping
   private readonly _logger: Logger;
   private readonly _discontinuityEmitter: DiscontinuityEmitter = newDiscontinuityEmitter();
 
-  // Throttle for the heartbeat, how often we should emit a typing event with repeated calls to start()
+  // Throttle for the heartbeat, how often we should emit a typing event with repeated calls to keystroke()
   // CHA-T10
   private readonly _heartbeatThrottleMs: number;
 
@@ -130,7 +130,7 @@ export class DefaultTyping
   private _heartbeatTimerId: TypingTimerHandle;
   private readonly _currentlyTyping: Map<string, TypingTimerHandle>;
 
-  // Mutex for controlling `start` and `stop` operations
+  // Mutex for controlling `start` and `keystroke` operations
   private readonly _mutex = new Mutex();
 
   /**
@@ -478,14 +478,5 @@ export class DefaultTyping
    */
   get detachmentErrorCode(): ErrorCodes {
     return ErrorCodes.TypingDetachmentFailed;
-  }
-
-  // Convenience getters for testing
-  get heartbeatTimerId(): TypingTimerHandle {
-    return this._heartbeatTimerId;
-  }
-
-  get currentlyTyping(): Map<string, TypingTimerHandle> {
-    return this._currentlyTyping;
   }
 }

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -60,10 +60,10 @@ export interface Typing extends EmitsDiscontinuities {
    * - The most recent operation (`keystroke()` or `stop()`) will always determine the final state, ensuring operations
    *   resolve to a consistent and correct state.
    *
-   * @returns A promise which resolves upon success of the operation and rejects with an ErrorInfo object upon its failure.
-   * @throws {@link ErrorInfo} If the {@link RoomStatus} is not either {@link RoomStatus.Attached} or {@link RoomStatus.Attaching}.
-   * @throws {@link ErrorInfo} If the operation fails to send the event to the server.
-   * @throws {@link ErrorInfo} If there is a problem acquiring the mutex that controls serialization.
+   * @returns A promise which resolves upon success of the operation and rejects with an {@link Ably.ErrorInfo} object upon its failure.
+   * @throws If the `RoomStatus` is not either `Attached` or `Attaching`.
+   * @throws If the operation fails to send the event to the server.
+   * @throws If there is a problem acquiring the mutex that controls serialization.
    */
   keystroke(): Promise<void>;
 
@@ -79,10 +79,10 @@ export interface Typing extends EmitsDiscontinuities {
    * - The most recent operation (`keystroke()` or `stop()`) will always determine the final state, ensuring operations
    *   resolve to a consistent and correct state.
    *
-   * @returns A promise which resolves upon success of the operation and rejects with an ErrorInfo object upon its failure.
-   * @throws {@link ErrorInfo} If the {@link RoomStatus} is not either {@link RoomStatus.Attached} or {@link RoomStatus.Attaching}.
-   * @throws {@link ErrorInfo} If the operation fails to send the event to the server.
-   * @throws {@link ErrorInfo} If there is a problem acquiring the mutex that controls serialization.
+   * @returns A promise which resolves upon success of the operation and rejects with an {@link Ably.ErrorInfo} object upon its failure.
+   * @throws If the `RoomStatus` is not either `Attached` or `Attaching`.
+   * @throws If the operation fails to send the event to the server.
+   * @throws If there is a problem acquiring the mutex that controls serialization.
    */
 
   stop(): Promise<void>;

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -1,5 +1,5 @@
 import * as Ably from 'ably';
-import { Mutex } from 'async-mutex';
+import { E_CANCELED, Mutex } from 'async-mutex';
 
 import { roomChannelName } from './channel.js';
 import { ChannelManager } from './channel-manager.js';
@@ -47,24 +47,35 @@ export interface Typing extends EmitsDiscontinuities {
   get(): Set<string>;
 
   /**
-   * "This will send a `typing.started` event to the server.
+   * This will send a `typing.started` event to the server.
    * Events are throttled according to the `heartbeatThrottleMs` room option.
-   * If an event has been sent within the interval, this operation is no-op."
+   * If an event has been sent within the interval, this operation is no-op.
    *
-   * Calls to `start()` and `stop()` will execute serially in the order they are called,
-   * resolving only when the previous call has completed.
+   *
+   * Calls to `keystroke()` and `stop()` are serialized and will always resolve in the correct order.
+   * - For example, if multiple `keystroke()` calls are made in quick succession before the first `keystroke()` call has
+   *   sent a `typing.started` event to the server, followed by one `stop()` call, the `stop()` call will execute
+   *   as soon as the first `keystroke()` call completes.
+   *   All intermediate `keystroke()` calls will be treated as no-ops.
+   * - The most recent operation (`keystroke()` or `stop()`) will always determine the final state, ensuring operations
+   *   resolve to a consistent and correct state.
    *
    * @returns A promise which resolves upon success of the operation and rejects with an ErrorInfo object upon its failure.
    */
 
-  start(): Promise<void>;
+  keystroke(): Promise<void>;
 
   /**
    * This will send a `typing.stopped` event to the server.
    * If the user was not currently typing, this operation is no-op.
    *
-   * Calls to `start()` and `stop()` will execute serially in the order they are called,
-   * resolving only when the previous call has completed.
+   * Calls to `keystroke()` and `stop()` are serialized and will always resolve in the correct order.
+   * - For example, if multiple `keystroke()` calls are made in quick succession before the first `keystroke()` call has
+   *   sent a `typing.started` event to the server, followed by one `stop()` call, the `stop()` call will execute
+   *   as soon as the first `keystroke()` call completes.
+   *   All intermediate `keystroke()` calls will be treated as no-ops.
+   * - The most recent operation (`keystroke()` or `stop()`) will always determine the final state, ensuring operations
+   *   resolve to a consistent and correct state.
    *
    * @returns A promise which resolves upon success of the operation and rejects with an ErrorInfo object upon its failure.
    */
@@ -197,23 +208,30 @@ export class DefaultTyping
   /**
    * @inheritDoc
    */
-  async start(): Promise<void> {
-    this._logger.trace(`DefaultTyping.start();`);
+  async keystroke(): Promise<void> {
+    this._logger.trace(`DefaultTyping.keystroke();`);
+    this._mutex.cancel();
 
     // Acquire a mutex
-    await this._mutex.acquire();
+    await this._mutex.acquire().catch((error: unknown) => {
+      if (error === E_CANCELED) {
+        this._logger.debug(`DefaultTyping.keystroke(); mutex was canceled by a later operation`);
+        return;
+      }
+      throw new Ably.ErrorInfo('mutex acquisition failed', 50000, 500);
+    });
     try {
       // CHA-T4d
       // Ensure channel is attached
       if (this.channel.state !== 'attached' && this.channel.state !== 'attaching') {
-        this._logger.error(`DefaultTyping.start(); channel is not attached`, { state: this.channel.state });
-        throw new Ably.ErrorInfo('cannot start typing, channel is not attached', 50000, 500);
+        this._logger.error(`DefaultTyping.keystroke(); channel is not attached`, { state: this.channel.state });
+        throw new Ably.ErrorInfo('cannot type, channel is not attached', 50000, 500);
       }
 
       // Check whether user is already typing before publishing again
       // CHA-T4c1, CHA-T4c2
       if (this._heartbeatTimerId) {
-        this._logger.debug(`DefaultTyping.start(); no-op, already typing and heartbeat timer has not expired`);
+        this._logger.debug(`DefaultTyping.keystroke(); no-op, already typing and heartbeat timer has not expired`);
         return;
       }
 
@@ -224,9 +242,9 @@ export class DefaultTyping
       // Start the timer after publishing
       // CHA-T4a5
       this._startHeartbeatTimer();
-      this._logger.trace(`DefaultTyping.start(); starting timers`);
+      this._logger.trace(`DefaultTyping.keystroke(); starting timers`);
     } finally {
-      this._logger.trace(`DefaultTyping.start(); releasing mutex`);
+      this._logger.trace(`DefaultTyping.keystroke(); releasing mutex`);
       this._mutex.release();
     }
   }
@@ -237,8 +255,15 @@ export class DefaultTyping
   async stop(): Promise<void> {
     this._logger.trace(`DefaultTyping.stop();`);
 
+    this._mutex.cancel();
     // Acquire a mutex
-    await this._mutex.acquire();
+    await this._mutex.acquire().catch((error: unknown) => {
+      if (error === E_CANCELED) {
+        this._logger.debug(`DefaultTyping.stop(); mutex was canceled by a later operation`);
+        return;
+      }
+      throw new Ably.ErrorInfo('mutex acquisition failed', 50000, 500);
+    });
     try {
       // CHA-T5c
       if (this.channel.state !== 'attached' && this.channel.state !== 'attaching') {
@@ -300,7 +325,7 @@ export class DefaultTyping
     this._logger.trace(`DefaultTyping._updateCurrentlyTyping();`, { clientId, event });
 
     if (event === TypingEvents.Start) {
-      this._handleTypingStart(clientId,);
+      this._handleTypingStart(clientId);
     } else {
       this._handleTypingStop(clientId);
     }

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -135,7 +135,7 @@ export class DefaultTyping
   private _heartbeatTimerId: TypingTimerHandle;
   private readonly _currentlyTyping: Map<string, TypingTimerHandle>;
 
-  // Mutex for controlling `start` and `keystroke` operations
+  // Mutex for controlling `keystroke` and `stop` operations
   private readonly _mutex = new Mutex();
 
   /**

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -42,7 +42,7 @@ export interface Typing extends EmitsDiscontinuities {
 
   /**
    * Get the current typers, a set of clientIds.
-   * @returns A Promise of a set of clientIds that are currently typing.
+   * @returns The set of clientIds that are currently typing.
    */
   get(): Set<string>;
 
@@ -93,6 +93,11 @@ interface TypingEventsMap {
 }
 
 /**
+ * Represents a timer handle that can be undefined.
+ */
+type TypingTimerHandle = ReturnType<typeof setTimeout> | undefined;
+
+/**
  * @inheritDoc
  */
 export class DefaultTyping
@@ -111,8 +116,8 @@ export class DefaultTyping
   // Grace period for inactivity before another user is considered to have stopped typing
   // CHA-T10a
   private readonly _timeoutMs = 2000;
-  private _heartbeatTimerId: ReturnType<typeof setTimeout> | undefined;
-  private readonly _currentlyTyping: Map<string, ReturnType<typeof setTimeout> | undefined>;
+  private _heartbeatTimerId: TypingTimerHandle;
+  private readonly _currentlyTyping: Map<string, TypingTimerHandle>;
 
   // Mutex for controlling `start` and `stop` operations
   private readonly _mutex = new Mutex();
@@ -140,7 +145,7 @@ export class DefaultTyping
     this._heartbeatThrottleMs = options.heartbeatThrottleMs;
 
     // Map of clientIds to their typing timers, used to track typing state
-    this._currentlyTyping = new Map<string, ReturnType<typeof setTimeout> | undefined>();
+    this._currentlyTyping = new Map<string, TypingTimerHandle>();
     this._logger = logger;
   }
 
@@ -194,35 +199,36 @@ export class DefaultTyping
    */
   async start(): Promise<void> {
     this._logger.trace(`DefaultTyping.start();`);
+
     // Acquire a mutex
     await this._mutex.acquire();
-    // CHA-T4d
-    if (this.channel.state !== 'attached' && this.channel.state !== 'attaching') {
-      this._logger.error(`DefaultTyping.start(); channel is not attached`, { state: this.channel.state });
-      throw new Ably.ErrorInfo('cannot start typing, channel is not attached', ErrorCodes.BadRequest, 400);
-    }
+    try {
+      // CHA-T4d
+      // Ensure channel is attached
+      if (this.channel.state !== 'attached' && this.channel.state !== 'attaching') {
+        this._logger.error(`DefaultTyping.start(); channel is not attached`, { state: this.channel.state });
+        throw new Ably.ErrorInfo('cannot start typing, channel is not attached', 50000, 500);
+      }
 
-    // If the user is already typing, and the timer has not expired, do not send another heartbeat
-    // CHA-T4c1, CHA-T4c2
-    if (this._heartbeatTimerId) {
-      this._logger.debug(`DefaultTyping.start(); no-op, already typing and heartbeat timer has not expired`);
+      // Check whether user is already typing before publishing again
+      // CHA-T4c1, CHA-T4c2
+      if (this._heartbeatTimerId) {
+        this._logger.debug(`DefaultTyping.start(); no-op, already typing and heartbeat timer has not expired`);
+        return;
+      }
+
+      // Perform the publish
+      // CHA-T4a3
+      await this._channel.publish(ephemeralMessage(TypingEvents.Start));
+
+      // Start the timer after publishing
+      // CHA-T4a5
+      this._startHeartbeatTimer();
+      this._logger.trace(`DefaultTyping.start(); starting timers`);
+    } finally {
+      this._logger.trace(`DefaultTyping.start(); releasing mutex`);
       this._mutex.release();
-      return;
     }
-
-    // CHA-T4a3
-    return this._channel
-      .publish(ephemeralMessage(TypingEvents.Start))
-      .then(() => {
-        // start the timer and publish the typing event
-        // CHA-T4a5
-        this._startHeartbeatTimer();
-        this._logger.trace(`DefaultTyping.start(); starting timers`);
-      })
-      .finally(() => {
-        this._logger.trace(`DefaultTyping.start(); releasing mutex`);
-        this._mutex.release();
-      });
   }
 
   /**
@@ -230,38 +236,35 @@ export class DefaultTyping
    */
   async stop(): Promise<void> {
     this._logger.trace(`DefaultTyping.stop();`);
+
     // Acquire a mutex
     await this._mutex.acquire();
-    // CHA-T5c
-    if (this.channel.state !== 'attached' && this.channel.state !== 'attaching') {
-      this._logger.error(`DefaultTyping.stop(); channel is not attached`, { state: this.channel.state });
-      throw new Ably.ErrorInfo('cannot stop typing, channel is not attached', ErrorCodes.BadRequest, 400);
-    }
+    try {
+      // CHA-T5c
+      if (this.channel.state !== 'attached' && this.channel.state !== 'attaching') {
+        this._logger.error(`DefaultTyping.stop(); channel is not attached`, { state: this.channel.state });
+        throw new Ably.ErrorInfo('cannot stop typing, channel is not attached', 50000, 500);
+      }
 
-    // If the user is not typing, do nothing.
-    // CHA-T5a
-    if (!this._heartbeatTimerId) {
-      this._logger.debug(`DefaultTyping.stop(); no-op, not currently typing`);
+      // If the user is not typing, do nothing.
+      // CHA-T5a
+      if (!this._heartbeatTimerId) {
+        this._logger.debug(`DefaultTyping.stop(); no-op, not currently typing`);
+        return;
+      }
+
+      // CHA-T5d
+      await this._channel.publish(ephemeralMessage(TypingEvents.Stop));
+      this._logger.trace(`DefaultTyping.stop(); clearing timers`);
+
+      // CHA-T5e
+      // Clear the heartbeat timer
+      clearTimeout(this._heartbeatTimerId);
+      this._heartbeatTimerId = undefined;
+    } finally {
+      this._logger.trace(`DefaultTyping.stop(); releasing mutex`);
       this._mutex.release();
-      return;
     }
-
-    // CHA-T5d
-    return this._channel
-      .publish(ephemeralMessage(TypingEvents.Stop))
-      .then(() => {
-        this._logger.trace(`DefaultTyping.stop(); clearing timers`);
-        // CHA-T5e
-        // Clear the heartbeat timer
-        if (this._heartbeatTimerId) {
-          clearTimeout(this._heartbeatTimerId);
-          this._heartbeatTimerId = undefined;
-        }
-      })
-      .finally(() => {
-        this._logger.trace(`DefaultTyping.stop(); releasing mutex`);
-        this._mutex.release();
-      });
   }
 
   /**
@@ -457,11 +460,11 @@ export class DefaultTyping
   }
 
   // Convenience getters for testing
-  get heartbeatTimerId(): ReturnType<typeof setTimeout> | undefined {
+  get heartbeatTimerId(): TypingTimerHandle {
     return this._heartbeatTimerId;
   }
 
-  get currentlyTyping(): Map<string, ReturnType<typeof setTimeout> | undefined> {
+  get currentlyTyping(): Map<string, TypingTimerHandle> {
     return this._currentlyTyping;
   }
 }

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -1,4 +1,5 @@
 import * as Ably from 'ably';
+import { Mutex } from 'async-mutex';
 
 import { roomChannelName } from './channel.js';
 import { ChannelManager } from './channel-manager.js';
@@ -46,11 +47,12 @@ export interface Typing extends EmitsDiscontinuities {
   get(): Set<string>;
 
   /**
-   * Start indicates that the current user is typing.
-   * This will emit a `typing.start` event to inform listening clients and begin a heartbeat timer,
-   * which can be configured through the `heartbeatThrottleMs` parameter.
-   * If the current user is already typing, this will no-op until the heartbeat timer has elapsed,
-   * at which point calling `start()` will restart the timer and emit a new `typing.start` heartbeat.
+   * "This will send a `typing.started` event to the server.
+   * Events are throttled according to the `heartbeatThrottleMs` room option.
+   * If an event has been sent within the interval, this operation is no-op."
+   *
+   * Calls to `start()` and `stop()` will execute serially in the order they are called,
+   * resolving only when the previous call has completed.
    *
    * @returns A promise which resolves upon success of the operation and rejects with an ErrorInfo object upon its failure.
    */
@@ -58,9 +60,11 @@ export interface Typing extends EmitsDiscontinuities {
   start(): Promise<void>;
 
   /**
-   * Stop indicates that the current user has stopped typing.
-   * This will emit a `typing.stop` event to inform listening clients,
-   * and immediately clear any active timers.
+   * This will send a `typing.stopped` event to the server.
+   * If the user was not currently typing, this operation is no-op.
+   *
+   * Calls to `start()` and `stop()` will execute serially in the order they are called,
+   * resolving only when the previous call has completed.
    *
    * @returns A promise which resolves upon success of the operation and rejects with an ErrorInfo object upon its failure.
    */
@@ -109,6 +113,9 @@ export class DefaultTyping
   private readonly _timeoutMs = 2000;
   private _heartbeatTimerId: ReturnType<typeof setTimeout> | undefined;
   private readonly _currentlyTyping: Map<string, ReturnType<typeof setTimeout> | undefined>;
+
+  // Mutex for controlling `start` and `stop` operations
+  private readonly _mutex = new Mutex();
 
   /**
    * Constructs a new `DefaultTyping` instance.
@@ -187,7 +194,8 @@ export class DefaultTyping
    */
   async start(): Promise<void> {
     this._logger.trace(`DefaultTyping.start();`);
-
+    // Acquire a mutex
+    await this._mutex.acquire();
     // CHA-T4d
     if (this.channel.state !== 'attached' && this.channel.state !== 'attaching') {
       this._logger.error(`DefaultTyping.start(); channel is not attached`, { state: this.channel.state });
@@ -198,15 +206,23 @@ export class DefaultTyping
     // CHA-T4c1, CHA-T4c2
     if (this._heartbeatTimerId) {
       this._logger.debug(`DefaultTyping.start(); no-op, already typing and heartbeat timer has not expired`);
+      this._mutex.release();
       return;
     }
 
     // CHA-T4a3
-    return this._channel.publish(ephemeralMessage(TypingEvents.Start)).then(() => {
-      this._logger.trace(`DefaultTyping.start(); starting timers`);
-      // CHA-T4a5
-      this._startHeartbeatTimer();
-    });
+    return this._channel
+      .publish(ephemeralMessage(TypingEvents.Start))
+      .then(() => {
+        // start the timer and publish the typing event
+        // CHA-T4a5
+        this._startHeartbeatTimer();
+        this._logger.trace(`DefaultTyping.start(); starting timers`);
+      })
+      .finally(() => {
+        this._logger.trace(`DefaultTyping.start(); releasing mutex`);
+        this._mutex.release();
+      });
   }
 
   /**
@@ -214,30 +230,38 @@ export class DefaultTyping
    */
   async stop(): Promise<void> {
     this._logger.trace(`DefaultTyping.stop();`);
-    // If the user is not typing, do nothing.
-    // CHA-T5a
-    if (!this._heartbeatTimerId) {
-      this._logger.debug(`DefaultTyping.stop(); no-op, not currently typing`);
-      return;
-    }
-
+    // Acquire a mutex
+    await this._mutex.acquire();
     // CHA-T5c
     if (this.channel.state !== 'attached' && this.channel.state !== 'attaching') {
       this._logger.error(`DefaultTyping.stop(); channel is not attached`, { state: this.channel.state });
       throw new Ably.ErrorInfo('cannot stop typing, channel is not attached', ErrorCodes.BadRequest, 400);
     }
 
-    // CHA-T5d
-    return this._channel.publish(ephemeralMessage(TypingEvents.Stop)).then(() => {
-      this._logger.trace(`DefaultTyping.stop(); clearing timers`);
+    // If the user is not typing, do nothing.
+    // CHA-T5a
+    if (!this._heartbeatTimerId) {
+      this._logger.debug(`DefaultTyping.stop(); no-op, not currently typing`);
+      this._mutex.release();
+      return;
+    }
 
-      // CHA-T5e
-      // Clear the heartbeat timer
-      if (this._heartbeatTimerId) {
-        clearTimeout(this._heartbeatTimerId);
-        this._heartbeatTimerId = undefined;
-      }
-    });
+    // CHA-T5d
+    return this._channel
+      .publish(ephemeralMessage(TypingEvents.Stop))
+      .then(() => {
+        this._logger.trace(`DefaultTyping.stop(); clearing timers`);
+        // CHA-T5e
+        // Clear the heartbeat timer
+        if (this._heartbeatTimerId) {
+          clearTimeout(this._heartbeatTimerId);
+          this._heartbeatTimerId = undefined;
+        }
+      })
+      .finally(() => {
+        this._logger.trace(`DefaultTyping.stop(); releasing mutex`);
+        this._mutex.release();
+      });
   }
 
   /**
@@ -352,7 +376,7 @@ export class DefaultTyping
   private _handleTypingStop(clientId: string, existingTimeout: NodeJS.Timeout | undefined): void {
     if (!existingTimeout) {
       // Stop requested for a client that isn't currently typing
-      this._logger.warn(
+      this._logger.trace(
         `DefaultTyping._handleTypingStop(); received "Stop" event for client not in currentlyTyping list`,
         { clientId },
       );

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -1,7 +1,6 @@
 import * as Ably from 'ably';
-import { Mutex } from 'async-mutex';
 
-import { messagesChannelName } from './channel.js';
+import { roomChannelName } from './channel.js';
 import { ChannelManager } from './channel-manager.js';
 import {
   DiscontinuityEmitter,
@@ -12,8 +11,9 @@ import {
   OnDiscontinuitySubscriptionResponse,
 } from './discontinuity.js';
 import { ErrorCodes } from './errors.js';
-import { TypingEventPayload, TypingEvents } from './events.js';
+import { TypingEvent, TypingEvents } from './events.js';
 import { Logger } from './logger.js';
+import { ephemeralMessage } from './realtime.js';
 import { ContributesToRoomLifecycle } from './room-lifecycle-manager.js';
 import { TypingOptions } from './room-options.js';
 import { Subscription } from './subscription.js';
@@ -43,7 +43,7 @@ export interface Typing extends EmitsDiscontinuities {
    * Get the current typers, a set of clientIds.
    * @returns A Promise of a set of clientIds that are currently typing.
    */
-  get(): Promise<Set<string>>;
+  get(): Set<string>;
 
   /**
    * Start indicates that the current user is typing.
@@ -82,14 +82,14 @@ export interface Typing extends EmitsDiscontinuities {
  * A listener which listens for typing events.
  * @param event The typing event.
  */
-export type TypingListener = (event: TypingEventPayload) => void;
+export type TypingListener = (event: TypingEvent) => void;
 
 /**
  * Represents the typing events mapped to their respective event payloads.
  */
 interface TypingEventsMap {
-  [TypingEvents.Start]: TypingEventPayload;
-  [TypingEvents.Stop]: TypingEventPayload;
+  [TypingEvents.Start]: TypingEvent;
+  [TypingEvents.Stop]: TypingEvent;
 }
 
 /**
@@ -110,9 +110,6 @@ export class DefaultTyping
   private readonly _heartbeatIntervalMs: number;
   private _heartbeatTimerId: ReturnType<typeof setTimeout> | undefined;
   private readonly _inactivityTimeoutMs: number;
-
-  private _opMtx: Mutex;
-
   private _currentlyTyping: Map<string, ReturnType<typeof setTimeout> | undefined>;
 
   /**
@@ -133,8 +130,6 @@ export class DefaultTyping
     super();
     this._clientId = clientId;
     this._channel = this._makeChannel(roomId, channelManager);
-    // Mutex to control access to the typing state
-    this._opMtx = new Mutex();
     // Timeout for pause in typing
     this._timeoutMs = options.timeoutMs;
     // Timeout for inactivity, i.e. when we have not received a heartbeat for a configured time
@@ -151,20 +146,22 @@ export class DefaultTyping
    * Creates the realtime channel for typing indicators.
    */
   private _makeChannel(roomId: string, channelManager: ChannelManager): Ably.RealtimeChannel {
-    const channel = channelManager.get(messagesChannelName(roomId));
+    // CHA-T8
+    const channel = channelManager.get(roomChannelName(roomId));
+
     // attachOnSubscribe is set to false in the default channel options, so this call cannot fail
     void channel.subscribe([TypingEvents.Start, TypingEvents.Stop], this._internalSubscribeToEvents.bind(this));
     return channel;
   }
 
   /**
+   * CHA-T9
+   *
    * @inheritDoc
    */
-  async get(): Promise<Set<string>> {
+  get(): Set<string> {
     this._logger.trace(`DefaultTyping.get();`);
-    return this._opMtx.runExclusive(() => {
-      return new Set<string>(this._currentlyTyping.keys());
-    });
+    return new Set<string>(this._currentlyTyping.keys());
   }
 
   /**
@@ -178,13 +175,31 @@ export class DefaultTyping
    * Start the typing timeout timer. This will expire after the configured timeout.
    */
   private _setTimeoutTimer(): void {
+    // Don't set the timeout timer if the timeout is not configured
+    if (this._timeoutMs === undefined) {
+      return;
+    }
+
+    this._logger.trace(`DefaultTyping._setTimeoutTimer();`);
+    const timer = (this._timeoutTimerId = setTimeout(() => {
+      // CHA-T12b
+      this._logger.debug(`DefaultTyping._setTimeoutTimer(); timeout expired`);
+      void this.stop()
+        .catch((error: unknown) => {
+          this._logger.error(`DefaultTyping._setTimeoutTimer(); failed to stop typing`, { error });
+        })
+        .finally(() => {
+          if (timer === this._timeoutTimerId) {
+            this._timeoutTimerId = undefined;
+          }
+        });
+    }, this._timeoutMs));
+  }
+
+  private _resetTimeoutTimer(): void {
     if (this._timeoutMs) {
       clearTimeout(this._timeoutTimerId);
-      this._logger.trace(`DefaultTyping.startTypingTimer();`);
-      this._timeoutTimerId = setTimeout(() => {
-        this._logger.debug(`DefaultTyping.startTypingTimer(); timeout expired`);
-        void this.stop();
-      }, this._timeoutMs);
+      this._setTimeoutTimer();
     }
   }
 
@@ -194,9 +209,13 @@ export class DefaultTyping
   private _startHeartbeatTimer(): void {
     if (!this._heartbeatTimerId) {
       this._logger.trace(`DefaultTyping.startHeartbeatTimer();`);
-      this._heartbeatTimerId = setTimeout(() => {
+      const timer = (this._heartbeatTimerId = setTimeout(() => {
         this._logger.debug(`DefaultTyping.startHeartbeatTimer(); heartbeat timer expired`);
-      }, this._heartbeatIntervalMs);
+        // CHA-T2a
+        if (timer === this._heartbeatTimerId) {
+          this._heartbeatTimerId = undefined;
+        }
+      }, this._heartbeatIntervalMs));
     }
   }
 
@@ -206,18 +225,28 @@ export class DefaultTyping
   async start(): Promise<void> {
     this._logger.trace(`DefaultTyping.start();`);
 
+    // CHA-T4d
+    if (this.channel.state !== 'attached' && this.channel.state !== 'attaching') {
+      this._logger.error(`DefaultTyping.start(); channel is not attached`, { state: this.channel.state });
+      throw new Ably.ErrorInfo('cannot start typing, channel is not attached', ErrorCodes.BadRequest, 400);
+    }
+
     // If the user is already typing, and the timer has not expired, do not send another heartbeat
+    // CHA-T4c1, CHA-T4c2
     if (this._heartbeatTimerId) {
       this._logger.debug(`DefaultTyping.start(); no-op, already typing and heartbeat timer has not expired`);
-      // Reset the timeout timer if the user is still typing
-      this._setTimeoutTimer()
+      this._resetTimeoutTimer();
       return;
     }
-    return this._channel.publish(TypingEvents.Start, {}).then(() => {
+
+    // CHA-T4a3
+    return this._channel.publish(ephemeralMessage(TypingEvents.Start)).then(() => {
       this._logger.trace(`DefaultTyping.start(); starting timers`);
-      // Start the heartbeat timer
+
+      // CHA-T4a5
       this._startHeartbeatTimer();
-      // Start the timeout timer
+
+      // CHA-T4a4
       this._setTimeoutTimer();
     });
   }
@@ -228,12 +257,23 @@ export class DefaultTyping
   async stop(): Promise<void> {
     this._logger.trace(`DefaultTyping.stop();`);
     // If the user is not typing, do nothing.
+    // CHA-T5a
     if (!this._heartbeatTimerId) {
       this._logger.debug(`DefaultTyping.stop(); no-op, not currently typing`);
       return;
     }
-    return this._channel.publish(TypingEvents.Stop, {}).then(() => {
+
+    // CHA-T5c
+    if (this.channel.state !== 'attached' && this.channel.state !== 'attaching') {
+      this._logger.error(`DefaultTyping.stop(); channel is not attached`, { state: this.channel.state });
+      throw new Ably.ErrorInfo('cannot stop typing, channel is not attached', ErrorCodes.BadRequest, 400);
+    }
+
+    // CHA-T5d
+    return this._channel.publish(ephemeralMessage(TypingEvents.Stop)).then(() => {
       this._logger.trace(`DefaultTyping.stop(); clearing timers`);
+
+      // CHA-T5e
       // Clear the heartbeat timer
       if (this._heartbeatTimerId) {
         clearTimeout(this._heartbeatTimerId);
@@ -276,19 +316,16 @@ export class DefaultTyping
    * @param clientId The client ID of the user.
    * @param event The typing event.
    */
-  private async _updateCurrentlyTyping(clientId: string, event: TypingEvents): Promise<void> {
-    // Wrap the entire logic in the mutex so we can access currentlyTyping safely
-    await this._opMtx.runExclusive(() => {
-      this._logger.trace(`DefaultTyping._updateCurrentlyTyping();`, { clientId, event });
+  private _updateCurrentlyTyping(clientId: string, event: TypingEvents): void {
+    this._logger.trace(`DefaultTyping._updateCurrentlyTyping();`, { clientId, event });
 
-      const existingTimeout = this._currentlyTyping.get(clientId);
+    const existingTimeout = this._currentlyTyping.get(clientId);
 
-      if (event === TypingEvents.Start) {
-        this._handleTypingStart(clientId, existingTimeout);
-      } else {
-        this._handleTypingStop(clientId, existingTimeout);
-      }
-    });
+    if (event === TypingEvents.Start) {
+      this._handleTypingStart(clientId, existingTimeout);
+    } else {
+      this._handleTypingStop(clientId, existingTimeout);
+    }
   }
 
   /**
@@ -309,25 +346,14 @@ export class DefaultTyping
         });
         return;
       }
-      // Remove client as their timeout has expired
-      this._opMtx
-        .runExclusive(() => {
-          this._currentlyTyping.delete(clientId);
-          this.emit(TypingEvents.Stop, {
-            clientId,
-            currentlyTyping: new Set<string>(this._currentlyTyping.keys()),
-            type: TypingEvents.Stop,
-          });
-        })
-        .catch((error: unknown) => {
-          this._logger.error(
-            `DefaultTyping._startNewClientInactivityTimer(); failed to update typing state in timeout`,
-            {
-              clientId,
-              error,
-            },
-          );
-        });
+
+      // Remove client whose timeout has expired
+      this._currentlyTyping.delete(clientId);
+      this.emit(TypingEvents.Stop, {
+        clientId,
+        currentlyTyping: new Set<string>(this._currentlyTyping.keys()),
+        type: TypingEvents.Stop,
+      });
     }, this._heartbeatIntervalMs + this._inactivityTimeoutMs);
     return timeoutId;
   }
@@ -347,7 +373,9 @@ export class DefaultTyping
 
     if (existingTimeout) {
       // Heartbeat - User is already typing, we just need to clear the existing timeout
-      this._logger.debug(`DefaultTyping._handleTypingStart(); received heartbeat for currently typing client`, { clientId });
+      this._logger.debug(`DefaultTyping._handleTypingStart(); received heartbeat for currently typing client`, {
+        clientId,
+      });
       clearTimeout(existingTimeout);
     } else {
       // Otherwise, we need to emit a new typing event
@@ -405,20 +433,7 @@ export class DefaultTyping
 
     // Safety check to ensure we are handling only typing events
     if (name === TypingEvents.Start || name === TypingEvents.Stop) {
-      this._updateCurrentlyTyping(clientId, name)
-        .then(() => {
-          this._logger.debug(`DefaultTyping._internalSubscribeToEvents(); successfully updated typing state`, {
-            name,
-            clientId,
-          });
-        })
-        .catch((error: unknown) => {
-          this._logger.error(`DefaultTyping._internalSubscribeToEvents(); failed to update typing state`, {
-            name,
-            clientId,
-            error,
-          });
-        });
+      this._updateCurrentlyTyping(clientId, name);
     } else {
       this._logger.warn(`DefaultTyping._internalSubscribeToEvents(); unrecognized event`, { name });
     }
@@ -464,5 +479,18 @@ export class DefaultTyping
    */
   get detachmentErrorCode(): ErrorCodes {
     return ErrorCodes.TypingDetachmentFailed;
+  }
+
+  // Convenience getters for testing
+  get timeoutTimerId(): ReturnType<typeof setTimeout> | undefined {
+    return this._timeoutTimerId;
+  }
+
+  get heartbeatTimerId(): ReturnType<typeof setTimeout> | undefined {
+    return this._heartbeatTimerId;
+  }
+
+  get currentlyTyping(): Map<string, ReturnType<typeof setTimeout> | undefined> {
+    return this._currentlyTyping;
   }
 }

--- a/src/react/hooks/use-typing.ts
+++ b/src/react/hooks/use-typing.ts
@@ -2,8 +2,9 @@ import * as Ably from 'ably';
 import { useCallback, useEffect, useState } from 'react';
 
 import { ErrorCodes, errorInfoIs } from '../../core/errors.js';
+import { TypingEventPayload } from '../../core/events.js';
 import { RoomStatus } from '../../core/room-status.js';
-import { Typing, TypingEvent, TypingListener } from '../../core/typing.js';
+import { Typing, TypingListener } from '../../core/typing.js';
 import { wrapRoomPromise } from '../helper/room-promise.js';
 import { useEventListenerRef } from '../helper/use-event-listener-ref.js';
 import { useEventualRoomProperty } from '../helper/use-eventual-room.js';
@@ -42,7 +43,7 @@ export interface UseTypingResponse extends ChatStatusResponse {
    * A state value representing the set of client IDs that are currently typing in the room.
    * It automatically updates based on typing events received from the room.
    */
-  readonly currentlyTyping: TypingEvent['currentlyTyping'];
+  readonly currentlyTyping: TypingEventPayload['currentlyTyping'];
 
   /**
    * Provides access to the underlying {@link Typing} instance of the room.
@@ -114,7 +115,6 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
             .catch((error: unknown) => {
               const errorInfo = error as Ably.ErrorInfo;
               if (!mounted || errorInfoIs(errorInfo, ErrorCodes.RoomIsReleased)) return;
-
               setErrorState(errorInfo);
             });
         } else {

--- a/src/react/hooks/use-typing.ts
+++ b/src/react/hooks/use-typing.ts
@@ -29,9 +29,9 @@ export interface TypingParams extends StatusParams, Listenable<TypingListener> {
 
 export interface UseTypingResponse extends ChatStatusResponse {
   /**
-   * A shortcut to the {@link Typing.start} method.
+   * A shortcut to the {@link Typing.keystroke} method.
    */
-  readonly start: Typing['start'];
+  readonly keystroke: Typing['keystroke'];
 
   /**
    * A shortcut to the {@link Typing.stop} method.
@@ -162,7 +162,7 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
   }, [context, listenerRef, logger]);
 
   // memoize the methods to avoid re-renders, and ensure the same instance is used
-  const start = useCallback(() => context.room.then((room) => room.typing.start()), [context]);
+  const keystroke = useCallback(() => context.room.then((room) => room.typing.keystroke()), [context]);
   const stop = useCallback(() => context.room.then((room) => room.typing.stop()), [context]);
 
   return {
@@ -171,7 +171,7 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
     connectionError,
     roomStatus,
     roomError,
-    start,
+    keystroke,
     stop,
     currentlyTyping,
   };

--- a/test/core/room.test.ts
+++ b/test/core/room.test.ts
@@ -148,7 +148,11 @@ describe('Room', () => {
         );
 
         // Check that the reactions and typing channels were called with the default options
-        expect(context.realtime.channels.get).toHaveBeenNthCalledWith(3, room.typing.channel.name, defaultOptions);
+        expect(context.realtime.channels.get).toHaveBeenNthCalledWith(
+          3,
+          room.typing.channel.name,
+          expectedMessagesChannelOptions,
+        );
         expect(context.realtime.channels.get).toHaveBeenNthCalledWith(4, room.reactions.channel.name, defaultOptions);
       });
     },

--- a/test/core/room.test.ts
+++ b/test/core/room.test.ts
@@ -68,8 +68,28 @@ describe('Room', () => {
   });
 
   describe.each([
-    ['typing timeout <0', 'typing timeout must be greater than 0', { typing: { timeoutMs: -1 } }],
-    ['typing timeout =0', 'typing timeout must be greater than 0', { typing: { timeoutMs: 0 } }],
+    ['typing timeout <0', 'typing timeout must be greater than 0', { typing: { timeoutMs: -1 } } as RoomOptions],
+    ['typing timeout =0', 'typing timeout must be greater than 0', { typing: { timeoutMs: 0 } } as RoomOptions],
+    [
+      'typing timeout <0',
+      'typing heartbeat interval must be greater than 0',
+      { typing: { heartbeatIntervalMs: -1 } } as RoomOptions,
+    ],
+    [
+      'typing timeout =0',
+      'typing heartbeat interval must be greater than 0',
+      { typing: { heartbeatIntervalMs: 0 } } as RoomOptions,
+    ],
+    [
+      'typing timeout <0',
+      'typing inactivity timeout must be greater than 0',
+      { typing: { inactivityTimeoutMs: -1 } } as RoomOptions,
+    ],
+    [
+      'typing timeout =0',
+      'typing inactivity timeout must be greater than 0',
+      { typing: { inactivityTimeoutMs: 0 } } as RoomOptions,
+    ],
   ])('feature configured', (description: string, reason: string, options: RoomOptions) => {
     it<TestContext>(`should throw an error when passed invalid options: ${description}`, (context) => {
       expect(() => {
@@ -82,7 +102,11 @@ describe('Room', () => {
   });
 
   describe.each([
-    ['typing timeout', { typing: { timeoutMs: 5 } }, (room: Room) => (room.typing as DefaultTyping).timeoutMs === 5],
+    [
+      'typing timeout',
+      { typing: { timeoutMs: 5, heartbeatIntervalMs: 10, inactivityTimeoutMs: 5 } },
+      (room: Room) => (room.typing as DefaultTyping).timeoutMs === 5,
+    ],
   ])('feature configured', (description: string, options: RoomOptions, checkFunc: (room: Room) => boolean) => {
     it<TestContext>(`should apply room options: ${description}`, (context) => {
       expect(checkFunc(context.getRoom(options))).toBe(true);

--- a/test/core/room.test.ts
+++ b/test/core/room.test.ts
@@ -68,27 +68,15 @@ describe('Room', () => {
   });
 
   describe.each([
-    ['typing timeout <0', 'typing timeout must be greater than 0', { typing: { timeoutMs: -1 } } as RoomOptions],
-    ['typing timeout =0', 'typing timeout must be greater than 0', { typing: { timeoutMs: 0 } } as RoomOptions],
     [
-      'typing timeout <0',
+      'heartbeat interval < 0',
       'typing heartbeat interval must be greater than 0',
-      { typing: { heartbeatIntervalMs: -1 } } as RoomOptions,
+      { typing: { heartbeatThrottleMs: -1 } } as RoomOptions,
     ],
     [
-      'typing timeout =0',
+      'heartbeat interval = 0',
       'typing heartbeat interval must be greater than 0',
-      { typing: { heartbeatIntervalMs: 0 } } as RoomOptions,
-    ],
-    [
-      'typing timeout <0',
-      'typing inactivity timeout must be greater than 0',
-      { typing: { inactivityTimeoutMs: -1 } } as RoomOptions,
-    ],
-    [
-      'typing timeout =0',
-      'typing inactivity timeout must be greater than 0',
-      { typing: { inactivityTimeoutMs: 0 } } as RoomOptions,
+      { typing: { heartbeatThrottleMs: 0 } } as RoomOptions,
     ],
   ])('feature configured', (description: string, reason: string, options: RoomOptions) => {
     it<TestContext>(`should throw an error when passed invalid options: ${description}`, (context) => {
@@ -103,9 +91,9 @@ describe('Room', () => {
 
   describe.each([
     [
-      'typing timeout',
-      { typing: { timeoutMs: 5, heartbeatIntervalMs: 10, inactivityTimeoutMs: 5 } },
-      (room: Room) => (room.typing as DefaultTyping).timeoutMs === 5,
+      'heartbeat interval timeout',
+      { typing: { heartbeatThrottleMs: 10 } },
+      (room: Room) => (room.typing as DefaultTyping).heartbeatThrottleMs === 10,
     ],
   ])('feature configured', (description: string, options: RoomOptions, checkFunc: (room: Room) => boolean) => {
     it<TestContext>(`should apply room options: ${description}`, (context) => {
@@ -148,11 +136,7 @@ describe('Room', () => {
         );
 
         // Check that the reactions and typing channels were called with the default options
-        expect(context.realtime.channels.get).toHaveBeenNthCalledWith(
-          3,
-          room.typing.channel.name,
-          expectedMessagesChannelOptions,
-        );
+        expect(context.realtime.channels.get).toHaveBeenNthCalledWith(3, room.typing.channel.name, defaultOptions);
         expect(context.realtime.channels.get).toHaveBeenNthCalledWith(4, room.reactions.channel.name, defaultOptions);
       });
     },

--- a/test/core/rooms.integration.test.ts
+++ b/test/core/rooms.integration.test.ts
@@ -10,23 +10,33 @@ import { waitForRoomStatus } from '../helper/room.ts';
 describe('Rooms', () => {
   it('throws an error if you create the same room with different options', async () => {
     const chat = newChatClient({ logLevel: LogLevel.Silent });
-    await chat.rooms.get('test', { typing: { timeoutMs: 1000 } });
-    await expect(chat.rooms.get('test', { typing: { timeoutMs: 2000 } })).rejects.toBeErrorInfoWithCode(40000);
+    await chat.rooms.get('test', { typing: { timeoutMs: 1000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 } });
+    await expect(
+      chat.rooms.get('test', { typing: { timeoutMs: 2000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 } }),
+    ).rejects.toBeErrorInfoWithCode(40000);
   });
 
   it('gets the same room if you create it with the same options', async () => {
     const chat = newChatClient();
-    const room1 = await chat.rooms.get('test', { typing: { timeoutMs: 1000 } });
-    const room2 = await chat.rooms.get('test', { typing: { timeoutMs: 1000 } });
+    const room1 = await chat.rooms.get('test', {
+      typing: { timeoutMs: 1000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+    });
+    const room2 = await chat.rooms.get('test', {
+      typing: { timeoutMs: 1000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+    });
     expect(room1).toBe(room2);
   });
 
   it('releases a room', async () => {
     // Create a room, then release, then create another room with different options
     const chat = newChatClient();
-    const room1 = await chat.rooms.get('test', { typing: { timeoutMs: 1000 } });
+    const room1 = await chat.rooms.get('test', {
+      typing: { timeoutMs: 1000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+    });
     await chat.rooms.release('test');
-    const room = await chat.rooms.get('test', { typing: { timeoutMs: 2000 } });
+    const room = await chat.rooms.get('test', {
+      typing: { timeoutMs: 2000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+    });
     expect(room.options().typing?.timeoutMs).toBe(2000);
     expect(room).not.toBe(room1);
   });
@@ -36,22 +46,33 @@ describe('Rooms', () => {
     // We include presence options here because that invokes a change to channel modes - which would flag up
     // an error if we were doing releases in the wrong order etc
     const chat = newChatClient();
-    const room1 = await chat.rooms.get('test', { typing: { timeoutMs: 1000 }, presence: AllFeaturesEnabled.presence });
+    const room1 = await chat.rooms.get('test', {
+      typing: { timeoutMs: 1000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+      presence: AllFeaturesEnabled.presence,
+    });
     await room1.attach();
     await chat.rooms.release('test');
 
-    const room2 = await chat.rooms.get('test', { typing: { timeoutMs: 2000 }, presence: AllFeaturesEnabled.presence });
+    const room2 = await chat.rooms.get('test', {
+      typing: { timeoutMs: 2000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+      presence: AllFeaturesEnabled.presence,
+    });
     await room2.attach();
     await chat.rooms.release('test');
 
-    await chat.rooms.get('test', { typing: { timeoutMs: 3000 }, presence: AllFeaturesEnabled.presence });
+    await chat.rooms.get('test', {
+      typing: { timeoutMs: 3000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+      presence: AllFeaturesEnabled.presence,
+    });
     await chat.rooms.release('test');
   });
 
   it('releases a failed room', async () => {
     // Create a room, fail it, then release.
     const chat = newChatClient();
-    const room = await chat.rooms.get('test', { typing: { timeoutMs: 1000 } });
+    const room = await chat.rooms.get('test', {
+      typing: { timeoutMs: 1000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+    });
 
     // Make sure our room is attached
     await room.attach();

--- a/test/core/rooms.integration.test.ts
+++ b/test/core/rooms.integration.test.ts
@@ -10,19 +10,19 @@ import { waitForRoomStatus } from '../helper/room.ts';
 describe('Rooms', () => {
   it('throws an error if you create the same room with different options', async () => {
     const chat = newChatClient({ logLevel: LogLevel.Silent });
-    await chat.rooms.get('test', { typing: { timeoutMs: 1000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 } });
-    await expect(
-      chat.rooms.get('test', { typing: { timeoutMs: 2000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 } }),
-    ).rejects.toBeErrorInfoWithCode(40000);
+    await chat.rooms.get('test', { typing: { heartbeatThrottleMs: 5000 } });
+    await expect(chat.rooms.get('test', { typing: { heartbeatThrottleMs: 6000 } })).rejects.toBeErrorInfoWithCode(
+      40000,
+    );
   });
 
   it('gets the same room if you create it with the same options', async () => {
     const chat = newChatClient();
     const room1 = await chat.rooms.get('test', {
-      typing: { timeoutMs: 1000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+      typing: { heartbeatThrottleMs: 5000 },
     });
     const room2 = await chat.rooms.get('test', {
-      typing: { timeoutMs: 1000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+      typing: { heartbeatThrottleMs: 5000 },
     });
     expect(room1).toBe(room2);
   });
@@ -31,13 +31,13 @@ describe('Rooms', () => {
     // Create a room, then release, then create another room with different options
     const chat = newChatClient();
     const room1 = await chat.rooms.get('test', {
-      typing: { timeoutMs: 1000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+      typing: { heartbeatThrottleMs: 5000 },
     });
     await chat.rooms.release('test');
     const room = await chat.rooms.get('test', {
-      typing: { timeoutMs: 2000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+      typing: { heartbeatThrottleMs: 5000 },
     });
-    expect(room.options().typing?.timeoutMs).toBe(2000);
+    expect(room.options().typing?.heartbeatThrottleMs).toBe(5000);
     expect(room).not.toBe(room1);
   });
 
@@ -47,21 +47,21 @@ describe('Rooms', () => {
     // an error if we were doing releases in the wrong order etc
     const chat = newChatClient();
     const room1 = await chat.rooms.get('test', {
-      typing: { timeoutMs: 1000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+      typing: { heartbeatThrottleMs: 5000 },
       presence: AllFeaturesEnabled.presence,
     });
     await room1.attach();
     await chat.rooms.release('test');
 
     const room2 = await chat.rooms.get('test', {
-      typing: { timeoutMs: 2000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+      typing: { heartbeatThrottleMs: 5000 },
       presence: AllFeaturesEnabled.presence,
     });
     await room2.attach();
     await chat.rooms.release('test');
 
     await chat.rooms.get('test', {
-      typing: { timeoutMs: 3000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+      typing: { heartbeatThrottleMs: 5000 },
       presence: AllFeaturesEnabled.presence,
     });
     await chat.rooms.release('test');
@@ -71,7 +71,7 @@ describe('Rooms', () => {
     // Create a room, fail it, then release.
     const chat = newChatClient();
     const room = await chat.rooms.get('test', {
-      typing: { timeoutMs: 1000, inactivityTimeoutMs: 2000, heartbeatIntervalMs: 5000 },
+      typing: { heartbeatThrottleMs: 5000 },
     });
 
     // Make sure our room is attached

--- a/test/core/typing.integration.test.ts
+++ b/test/core/typing.integration.test.ts
@@ -4,7 +4,7 @@ import { dequal } from 'dequal';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { normalizeClientOptions } from '../../src/core/config.ts';
-import { TypingEventPayload, TypingEvents } from '../../src/core/events.ts';
+import { TypingEvent, TypingEvents } from '../../src/core/events.ts';
 import { Room } from '../../src/core/room.ts';
 import { AllFeaturesEnabled } from '../../src/core/room-options.ts';
 import { RoomStatus } from '../../src/core/room-status.ts';
@@ -26,7 +26,7 @@ interface TestContext {
 }
 
 // Wait for a typing event matching the expected event to be received
-const waitForTypingEvent = async (events: TypingEventPayload[], expected: TypingEventPayload) => {
+const waitForTypingEvent = async (events: TypingEvent[], expected: TypingEvent) => {
   await vi.waitFor(
     () => {
       expect(events.some((event) => dequal(event, expected))).toBe(true);
@@ -42,7 +42,7 @@ describe('Typing', () => {
     context.chat = new DefaultRooms(context.realtime, normalizeClientOptions({}), makeTestLogger());
     context.clientId = context.realtime.auth.clientId;
     context.chatRoom = await context.chat.get(randomRoomId(), {
-      typing: { timeoutMs: 500, inactivityTimeoutMs: 15000, heartbeatIntervalMs: 400 },
+      typing: { timeoutMs: 500, inactivityTimeoutMs: 15000, heartbeatIntervalMs: 600 },
     });
   });
 
@@ -50,7 +50,7 @@ describe('Typing', () => {
   it<TestContext>(
     'successfully starts typing and then stops after the default timeout',
     async (context) => {
-      const events: TypingEventPayload[] = [];
+      const events: TypingEvent[] = [];
       // Subscribe to typing events
       context.chatRoom.typing.subscribe((event) => {
         events.push(event);
@@ -72,7 +72,7 @@ describe('Typing', () => {
   it<TestContext>(
     'subscribes to all typing events, sent by start and stop',
     async (context) => {
-      const events: TypingEventPayload[] = [];
+      const events: TypingEvent[] = [];
       context.chatRoom.typing.subscribe((event) => {
         events.push(event);
       });
@@ -95,7 +95,7 @@ describe('Typing', () => {
   it<TestContext>(
     'gets the set of currently typing client ids',
     async (context) => {
-      let events: TypingEventPayload[] = [];
+      let events: TypingEvent[] = [];
       // Subscribe to typing events
       context.chatRoom.typing.subscribe((event) => {
         events.push(event);
@@ -139,7 +139,7 @@ describe('Typing', () => {
         type: TypingEvents.Start,
       });
       // Get the currently typing client ids
-      const currentlyTypingClientIds = await context.chatRoom.typing.get();
+      const currentlyTypingClientIds = context.chatRoom.typing.get();
       // Ensure that the client ids are correct
       expect(currentlyTypingClientIds.has(clientId2), 'client2 should be typing').toEqual(true);
       expect(currentlyTypingClientIds.has(clientId1), 'client1 should be typing').toEqual(true);
@@ -154,7 +154,7 @@ describe('Typing', () => {
         type: TypingEvents.Stop,
       });
       // Get the currently typing client ids
-      const currentlyTypingClientIdsAfterStop = await context.chatRoom.typing.get();
+      const currentlyTypingClientIdsAfterStop = context.chatRoom.typing.get();
       // Ensure that the client ids are correct and client1 is no longer typing
       expect(currentlyTypingClientIdsAfterStop.has(clientId2), 'client2 should be typing').toEqual(true);
       expect(currentlyTypingClientIdsAfterStop.has(clientId1), 'client1 should not be typing').toEqual(false);

--- a/test/core/typing.integration.test.ts
+++ b/test/core/typing.integration.test.ts
@@ -42,7 +42,7 @@ describe('Typing', () => {
     context.chat = new DefaultRooms(context.realtime, normalizeClientOptions({}), makeTestLogger());
     context.clientId = context.realtime.auth.clientId;
     context.chatRoom = await context.chat.get(randomRoomId(), {
-      typing: { timeoutMs: 500, inactivityTimeoutMs: 15000, heartbeatIntervalMs: 600 },
+      typing: { heartbeatThrottleMs: 600 },
     });
   });
 
@@ -114,7 +114,7 @@ describe('Typing', () => {
         makeTestLogger(),
       );
 
-      const roomOptions = { typing: { timeoutMs: 15000, heartbeatIntervalMs: 10000, inactivityTimeoutMs: 2000 } };
+      const roomOptions = { typing: { heartbeatThrottleMs: 10000 } };
 
       const client1Room = await client1.get(context.chatRoom.roomId, roomOptions);
       const client2Room = await client2.get(context.chatRoom.roomId, roomOptions);
@@ -129,14 +129,12 @@ describe('Typing', () => {
       await client2Room.typing.start();
       // Wait for the typing events to be received
       await waitForTypingEvent(events, {
-        clientId: clientId1,
         currentlyTyping: new Set([clientId1]),
-        type: TypingEvents.Start,
+        change: { clientId: clientId1, type: TypingEvents.Start },
       });
       await waitForTypingEvent(events, {
-        clientId: clientId2,
         currentlyTyping: new Set([clientId1, clientId2]),
-        type: TypingEvents.Start,
+        change: { clientId: clientId2, type: TypingEvents.Start },
       });
       // Get the currently typing client ids
       const currentlyTypingClientIds = context.chatRoom.typing.get();
@@ -149,9 +147,8 @@ describe('Typing', () => {
       await client1Room.typing.stop();
       // Wait for the typing events to be received
       await waitForTypingEvent(events, {
-        clientId: clientId1,
         currentlyTyping: new Set([clientId2]),
-        type: TypingEvents.Stop,
+        change: { clientId: clientId1, type: TypingEvents.Stop },
       });
       // Get the currently typing client ids
       const currentlyTypingClientIdsAfterStop = context.chatRoom.typing.get();

--- a/test/core/typing.integration.test.ts
+++ b/test/core/typing.integration.test.ts
@@ -58,7 +58,7 @@ describe('Typing', () => {
       // Attach the room
       await context.chatRoom.attach();
       // Start typing and emit typingStarted event
-      await context.chatRoom.typing.start();
+      await context.chatRoom.typing.keystroke();
       // Once the timeout timer expires, the typingStopped event should be emitted
       await waitForArrayLength(events, 2);
       // Should have received a typingStarted and then typingStopped event
@@ -70,7 +70,7 @@ describe('Typing', () => {
   );
 
   it<TestContext>(
-    'subscribes to all typing events, sent by start and stop',
+    'subscribes to all typing events, sent by keystroke and stop',
     async (context) => {
       const events: TypingEvent[] = [];
       context.chatRoom.typing.subscribe((event) => {
@@ -80,7 +80,7 @@ describe('Typing', () => {
       await context.chatRoom.attach();
 
       // Send typing events
-      await context.chatRoom.typing.start();
+      await context.chatRoom.typing.keystroke();
       await waitForArrayLength(events, 1);
       expect(events.length).toEqual(1);
       expect(events[0]?.currentlyTyping).toEqual(new Set([context.clientId]));
@@ -125,8 +125,8 @@ describe('Typing', () => {
       await client2Room.attach();
 
       // send typing event for client1 and client2
-      await client1Room.typing.start();
-      await client2Room.typing.start();
+      await client1Room.typing.keystroke();
+      await client2Room.typing.keystroke();
       // Wait for the typing events to be received
       await waitForTypingEvent(events, {
         currentlyTyping: new Set([clientId1]),

--- a/test/core/typing.test.ts
+++ b/test/core/typing.test.ts
@@ -140,7 +140,7 @@ describe('Typing', () => {
       const { room } = context;
       vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('detached');
 
-      await expect(room.typing.start()).rejects.toBeErrorInfoWithCode(40000);
+      await expect(room.typing.start()).rejects.toBeErrorInfoWithCode(50000);
     });
 
     // CHA-T4a
@@ -226,7 +226,7 @@ describe('Typing', () => {
         await room.typing.start();
         vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('detached');
 
-        await expect(room.typing.stop()).rejects.toBeErrorInfoWithCode(40000);
+        await expect(room.typing.stop()).rejects.toBeErrorInfoWithCode(50000);
 
         // Check that no messages were sent
         expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);

--- a/test/core/typing.test.ts
+++ b/test/core/typing.test.ts
@@ -1,9 +1,10 @@
 import * as Ably from 'ably';
-import { beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
 
 import { ChatClient } from '../../src/core/chat.ts';
 import { ChatApi } from '../../src/core/chat-api.ts';
-import { TypingEventPayload, TypingEvents } from '../../src/core/events.ts';
+import { TypingEvent, TypingEvents } from '../../src/core/events.ts';
+import { Logger } from '../../src/core/logger.ts';
 import { Room } from '../../src/core/room.ts';
 import { RoomOptions } from '../../src/core/room-options.ts';
 import { DefaultTyping } from '../../src/core/typing.ts';
@@ -19,16 +20,32 @@ interface TestContext {
   room: Room;
   emulateBackendPublish: ChannelEventEmitterReturnType<Partial<Ably.InboundMessage>>;
   options: RoomOptions;
+  logger: Logger;
 }
 
-const TEST_TYPING_TIMEOUT_MS = 200;
+const TEST_TYPING_TIMEOUT_MS = 100;
 const TEST_INACTIVITY_TIMEOUT_MS = 400;
-const TEST_HEARTBEAT_INTERVAL_MS = 100;
+const TEST_HEARTBEAT_INTERVAL_MS = 200;
+
+const startMessage: Ably.Message = {
+  name: TypingEvents.Start,
+  extras: {
+    ephemeral: true,
+  },
+};
+
+const stopMessage: Ably.Message = {
+  name: TypingEvents.Stop,
+  extras: {
+    ephemeral: true,
+  },
+};
 
 vi.mock('ably');
 
 describe('Typing', () => {
   beforeEach<TestContext>((context) => {
+    context.logger = makeTestLogger();
     context.options = {
       typing: {
         timeoutMs: TEST_TYPING_TIMEOUT_MS,
@@ -37,231 +54,857 @@ describe('Typing', () => {
       },
     };
     context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
-    context.chatApi = new ChatApi(context.realtime, makeTestLogger());
+    context.chatApi = new ChatApi(context.realtime, context.logger);
     context.room = makeRandomRoom(context);
     const channel = context.room.typing.channel;
     context.emulateBackendPublish = channelEventEmitter(channel);
   });
 
-  it<TestContext>('delays stop timeout while still typing', async (context) => {
-    const { room } = context;
-    // If stop is called, the test should fail as the timer should not have expired
-    vi.spyOn(room.typing, 'stop').mockImplementation(async (): Promise<void> => {});
-    vi.spyOn(room.typing.channel, 'publish').mockImplementation(async (): Promise<void> => {});
-    // Start typing - we will wait/type a few times to ensure the timer is resetting
-    await room.typing.start();
-    // wait for half the timers timeout
-    await new Promise((resolve) => setTimeout(resolve, TEST_TYPING_TIMEOUT_MS / 2));
-    // Start typing again to reset the timer
-    await room.typing.start();
-    // wait for half the timers timeout
-    await new Promise((resolve) => setTimeout(resolve, TEST_TYPING_TIMEOUT_MS / 2));
-    // Start typing again to reset the timer
-    await room.typing.start();
-    // wait for half the timers timeout
-    await new Promise((resolve) => setTimeout(resolve, TEST_TYPING_TIMEOUT_MS / 2));
-    // Should have waited 1.5x the timeout at this point
-
-    // Ensure that stop was not called
-    expect(room.typing.stop).not.toHaveBeenCalled();
+  // CHA-T8
+  it<TestContext>('uses the correct realtime channel', (context) => {
+    expect(context.room.typing.channel.name).toBe(`${context.room.roomId}::$chat`);
   });
 
-  it<TestContext>('when stop is called, immediately stops typing', async (context) => {
-    const { realtime, room } = context;
-    const channel = room.typing.channel;
-    const realtimeChannel = realtime.channels.get(channel.name);
-
-    // If stop is called, it should publish a leave message
-    vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
-
-    // Start typing and then immediately stop typing
-    await room.typing.start();
-    await room.typing.stop();
-
-    // The timer should be stopped and so waiting beyond timeout should not trigger stop again
-    await new Promise((resolve) => setTimeout(resolve, TEST_TYPING_TIMEOUT_MS * 2));
-
-    expect(realtimeChannel.publish).toHaveBeenCalledTimes(2);
-    // Ensure that publish was called with typing.started only once
-    expect(realtimeChannel.publish).toHaveBeenCalledWith(TypingEvents.Start, {});
-    // Ensure that publish was called with typing.stopped only once
-    expect(realtimeChannel.publish).toHaveBeenCalledWith(TypingEvents.Stop, {});
-  });
-
-  it<TestContext>('allows listeners to be unsubscribed', async (context) => {
+  // CHA-T9
+  it<TestContext>('gets current typers', (context) => {
     const { room } = context;
-
-    // Add a listener
-    const receivedEvents: TypingEventPayload[] = [];
-    const { unsubscribe } = room.typing.subscribe((event: TypingEventPayload) => {
-      receivedEvents.push(event);
-    });
-
-    // Another listener used to receive all events, to make sure events were emitted
-    const allEvents: TypingEventPayload[] = [];
-    const allSubscription = room.typing.subscribe((event: TypingEventPayload) => {
-      allEvents.push(event);
-    });
 
     // Emulate a typing event
     context.emulateBackendPublish({
       name: TypingEvents.Start,
-      clientId: 'otherClient',
+      clientId: 'some',
     });
 
-    await waitForArrayLength(receivedEvents, 1);
-
-    // Ensure that the listener received the event
-    expect(receivedEvents).toHaveLength(1);
-    expect(receivedEvents[0]).toEqual({
-      type: TypingEvents.Start,
-      clientId: 'otherClient',
-      currentlyTyping: new Set(['otherClient']),
-    });
-
-    // Unsubscribe the listener
-    unsubscribe();
-
-    // Emulate another typing event for anotherClient
-    context.emulateBackendPublish({
-      name: TypingEvents.Start,
-      clientId: 'anotherClient',
-    });
-
-    // wait for check events to be length 2 to make sure second event was triggered
-    await waitForArrayLength(allEvents, 2);
-    expect(allEvents.length).toEqual(2);
-    expect(allEvents[1]?.currentlyTyping).toEqual(new Set(['otherClient', 'anotherClient']));
-
-    // Ensure that the listener did not receive the event
-    expect(receivedEvents).toHaveLength(1);
-
-    // Calling unsubscribe again should not throw
-    unsubscribe();
-
-    allSubscription.unsubscribe();
+    // Ensure that the typing status is correct
+    expect(room.typing.get()).toEqual(new Set(['some']));
   });
 
-  it<TestContext>('allows all listeners to be unsubscribed at once', async (context) => {
-    const { room } = context;
+  // CHA-T4
+  describe('start typing', () => {
+    // CHA-T4d
+    it<TestContext>('does not allow typing start if channel is not attached or attaching', async (context) => {
+      const { room } = context;
+      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('detached');
 
-    // Add a listener
-    const receivedEvents: TypingEventPayload[] = [];
-    const { unsubscribe } = room.typing.subscribe((event: TypingEventPayload) => {
-      receivedEvents.push(event);
+      await expect(room.typing.start()).rejects.toBeErrorInfoWithCode(40000);
     });
 
-    // Add another
-    const receivedEvents2: TypingEventPayload[] = [];
-    const { unsubscribe: unsubscribe2 } = room.typing.subscribe((event: TypingEventPayload) => {
-      receivedEvents2.push(event);
+    // CHA-T4a
+    it<TestContext>('starts typing', async (context) => {
+      const { room, realtime } = context;
+      const channel = room.typing.channel;
+      const realtimeChannel = realtime.channels.get(channel.name);
+
+      // If start is called, it should publish a start message
+      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
+      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
+
+      // Start typing
+      await room.typing.start();
+
+      // Ensure that publish was called with typing.started
+      expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
+      expect(realtimeChannel.publish).toHaveBeenCalledWith(startMessage);
+
+      // Check that our timers have been set
+      const defaultTyping = room.typing as DefaultTyping;
+
+      // CHA-T4a4
+      expect(defaultTyping.timeoutTimerId).toBeDefined();
+
+      // CHA-T4a5
+      expect(defaultTyping.heartbeatTimerId).toBeDefined();
     });
 
-    // Emulate a typing event
-    context.emulateBackendPublish({
-      name: TypingEvents.Start,
-      clientId: 'otherClient',
+    // CHA-T4a4
+    it<TestContext>('does not set stop timeout if not in options', async (context) => {
+      context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
+      context.chatApi = new ChatApi(context.realtime, makeTestLogger());
+      context.options.typing = {
+        heartbeatIntervalMs: TEST_HEARTBEAT_INTERVAL_MS,
+        inactivityTimeoutMs: TEST_INACTIVITY_TIMEOUT_MS,
+      };
+      context.room = makeRandomRoom(context);
+
+      const { room, realtime } = context;
+      const channel = room.typing.channel;
+      const realtimeChannel = realtime.channels.get(channel.name);
+
+      // If start is called, it should publish a start message
+      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
+      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
+
+      // Start typing
+      await room.typing.start();
+
+      // Ensure that publish was called with typing.started
+      expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
+      expect(realtimeChannel.publish).toHaveBeenCalledWith(startMessage);
+
+      // Check that our timers have been set
+      const defaultTyping = room.typing as DefaultTyping;
+
+      // CHA-T4a4
+      expect(defaultTyping.timeoutTimerId).toBeUndefined();
+
+      // CHA-T4a5
+      expect(defaultTyping.heartbeatTimerId).toBeDefined();
     });
 
-    await waitForArrayLength(receivedEvents, 1);
+    // CHA-T4c1
+    it<TestContext>('does not start typing if already typing', async (context) => {
+      const { room, realtime } = context;
+      const channel = room.typing.channel;
+      const realtimeChannel = realtime.channels.get(channel.name);
 
-    // Ensure that the listener received the event
-    expect(receivedEvents).toHaveLength(1);
-    expect(receivedEvents[0]).toEqual({
-      type: TypingEvents.Start,
-      clientId: 'otherClient',
-      currentlyTyping: new Set(['otherClient']),
+      // If start is called, it should publish a start message
+      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
+      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
+
+      // Start typing
+      await room.typing.start();
+
+      // Ensure that publish was called with typing.started
+      expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
+      expect(realtimeChannel.publish).toHaveBeenCalledWith(startMessage);
+
+      // Check that our timers have been set
+      const defaultTyping = room.typing as DefaultTyping;
+
+      // CHA-T4a4
+      expect(defaultTyping.timeoutTimerId).toBeDefined();
+
+      // CHA-T4a5
+      expect(defaultTyping.heartbeatTimerId).toBeDefined();
+
+      // Start typing again
+      await room.typing.start();
+
+      // Ensure that publish was not called again
+      expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
     });
 
-    await waitForArrayLength(receivedEvents2, 1);
-    // Ensure that the second listener received the event
-    expect(receivedEvents2).toHaveLength(1);
-    expect(receivedEvents2[0]).toEqual({
-      type: TypingEvents.Start,
-      clientId: 'otherClient',
-      currentlyTyping: new Set(['otherClient']),
+    // CHA-T4c2
+    it<TestContext>('resets CHA-T3 timeout on second start typing call', async (context) => {
+      const { room, realtime } = context;
+      const channel = room.typing.channel;
+      const realtimeChannel = realtime.channels.get(channel.name);
+
+      // If start is called, it should publish a start message
+      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
+      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
+
+      // Start typing
+      await room.typing.start();
+
+      const timer = (room.typing as DefaultTyping).timeoutTimerId;
+      expect(timer).toBeDefined();
+
+      // Start typing again
+      await room.typing.start();
+
+      // Check we have a new timer
+      const newTimer = (room.typing as DefaultTyping).timeoutTimerId;
+      expect(newTimer).toBeDefined();
+      expect(newTimer).not.toBe(timer);
     });
-
-    // Unsubscribe all listeners
-    room.typing.unsubscribeAll();
-
-    // subscribe a check subscriber
-    const checkEvents: TypingEventPayload[] = [];
-    room.typing.subscribe((event) => {
-      checkEvents.push(event);
-    });
-
-    // Emulate another typing event
-    context.emulateBackendPublish({
-      name: TypingEvents.Start,
-      clientId: 'anotherClient2',
-    });
-
-    await waitForArrayLength(checkEvents, 1);
-    expect(checkEvents[0]?.currentlyTyping).toEqual(new Set(['otherClient', 'anotherClient2']));
-
-    // Ensure that the listeners did not receive the event
-    expect(receivedEvents).toHaveLength(1);
-    expect(receivedEvents2).toHaveLength(1);
-
-    // Calling unsubscribe should not throw
-    unsubscribe();
-    unsubscribe2();
   });
 
-  describe.each([
-    [
-      'no client id',
-      {
+  describe<TestContext>('implicit typing stop', () => {
+    beforeEach<TestContext>(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach<TestContext>(() => {
+      vi.useRealTimers();
+    });
+
+    // CHA-T12a
+    it<TestContext>('unset the heartbeat timer after CHA-T10 timeout', async (context) => {
+      context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
+      context.chatApi = new ChatApi(context.realtime, makeTestLogger());
+      context.options.typing = {
+        heartbeatIntervalMs: TEST_HEARTBEAT_INTERVAL_MS,
+        inactivityTimeoutMs: TEST_INACTIVITY_TIMEOUT_MS,
+      };
+      context.room = makeRandomRoom(context);
+      const { room, realtime } = context;
+      const channel = room.typing.channel;
+      const realtimeChannel = realtime.channels.get(channel.name);
+
+      // If start is called, it should publish a start message
+      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
+      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
+
+      // Mock the timers
+
+      // Start typing
+      await room.typing.start();
+
+      // Ensure that publish was called with typing.started
+      expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
+      expect(realtimeChannel.publish).toHaveBeenCalledWith(startMessage);
+
+      // Check that our timers have been set
+      const defaultTyping = room.typing as DefaultTyping;
+
+      // CHA-T4a4
+      expect(defaultTyping.timeoutTimerId).toBeUndefined();
+
+      // CHA-T4a5
+      expect(defaultTyping.heartbeatTimerId).toBeDefined();
+
+      // Advance our timers
+      vi.runAllTimers();
+
+      // Check that the timers have been cleared
+      expect(defaultTyping.timeoutTimerId).toBeUndefined();
+      expect(defaultTyping.heartbeatTimerId).toBeUndefined();
+    });
+
+    // CHA-T12b1
+    it<TestContext>('performs an explicit stop after CHA-T3 expiry', async (context) => {
+      const { room, realtime } = context;
+      const channel = room.typing.channel;
+      const realtimeChannel = realtime.channels.get(channel.name);
+
+      // If start is called, it should publish a start message
+      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
+      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
+
+      // Mock the timers
+
+      // Start typing
+      await room.typing.start();
+
+      // Ensure that publish was called with typing.started
+      expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
+      expect(realtimeChannel.publish).toHaveBeenCalledWith(startMessage);
+
+      // Check that our timers have been set
+      const defaultTyping = room.typing as DefaultTyping;
+
+      // CHA-T4a4
+      expect(defaultTyping.timeoutTimerId).toBeDefined();
+
+      // CHA-T4a5
+      expect(defaultTyping.heartbeatTimerId).toBeDefined();
+
+      // Advance to the timeout
+      vi.advanceTimersToNextTimer();
+
+      // We should wait until the stop has been called
+      await vi.waitFor(
+        () => {
+          expect(realtimeChannel.publish).toHaveBeenCalledTimes(2);
+          expect(realtimeChannel.publish).toHaveBeenCalledWith(stopMessage);
+        },
+        { timeout: 1000 },
+      );
+
+      // Check that the timers have been cleared
+      expect(defaultTyping.timeoutTimerId).toBeUndefined();
+      expect(defaultTyping.heartbeatTimerId).toBeUndefined();
+    });
+
+    // CHA-T12b2
+    it<TestContext>('handles failure of publish after CHA-T3 expiry', async (context) => {
+      context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
+      context.chatApi = new ChatApi(context.realtime, makeTestLogger());
+      // Set some large numbers
+      context.options.typing = {
+        heartbeatIntervalMs: 20000,
+        inactivityTimeoutMs: 15000,
+        timeoutMs: 100,
+      };
+      context.room = makeRandomRoom(context);
+      const { room, realtime } = context;
+      const channel = room.typing.channel;
+      const realtimeChannel = realtime.channels.get(channel.name);
+
+      // If start is called, it should publish a start message
+      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
+      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
+
+      // Mock the timers
+
+      // Start typing
+      await room.typing.start();
+
+      // Ensure that publish was called with typing.started
+      expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
+      expect(realtimeChannel.publish).toHaveBeenCalledWith(startMessage);
+
+      // Check that our timers have been set
+      const defaultTyping = room.typing as DefaultTyping;
+
+      // CHA-T4a4
+      expect(defaultTyping.timeoutTimerId).toBeDefined();
+
+      // CHA-T4a5
+      expect(defaultTyping.heartbeatTimerId).toBeDefined();
+
+      // The channel publish should fail
+      vi.spyOn(realtimeChannel, 'publish').mockRejectedValue(new Ably.ErrorInfo('Failed to publish', 50000, 500));
+
+      // Advance to the timeout
+      await vi.advanceTimersToNextTimerAsync();
+
+      // We should wait until the stop has been called
+      await vi.waitFor(
+        () => {
+          expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
+          expect(realtimeChannel.publish).toHaveBeenCalledWith(stopMessage);
+        },
+        { timeout: 1000 },
+      );
+
+      // Wait for a small amount of time to ensure the timer gets to clear via finally
+      await vi.waitFor(
+        () => {
+          expect(defaultTyping.timeoutTimerId).toBeUndefined();
+          expect(defaultTyping.heartbeatTimerId).toBeDefined();
+        },
+        { timeout: 1000 },
+      );
+
+      // Advance to the next timeout
+      vi.advanceTimersToNextTimer();
+
+      // Now the heartbeat should have been cleared
+      expect(defaultTyping.heartbeatTimerId).toBeUndefined();
+    });
+
+    // CHA-T12b3
+    it<TestContext>('handles failure of publish after CHA-T3 expiry due to detachment', async (context) => {
+      context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
+      context.chatApi = new ChatApi(context.realtime, makeTestLogger());
+      // Set some large numbers
+      context.options.typing = {
+        heartbeatIntervalMs: 20000,
+        inactivityTimeoutMs: 15000,
+        timeoutMs: 100,
+      };
+      context.room = makeRandomRoom(context);
+      const { room, realtime } = context;
+      const channel = room.typing.channel;
+      const realtimeChannel = realtime.channels.get(channel.name);
+
+      // If start is called, it should publish a start message
+      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
+      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
+
+      // Mock the timers
+
+      // Start typing
+      await room.typing.start();
+
+      // Ensure that publish was called with typing.started
+      expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
+      expect(realtimeChannel.publish).toHaveBeenCalledWith(startMessage);
+
+      // Check that our timers have been set
+      const defaultTyping = room.typing as DefaultTyping;
+
+      // CHA-T4a4
+      expect(defaultTyping.timeoutTimerId).toBeDefined();
+
+      // CHA-T4a5
+      expect(defaultTyping.heartbeatTimerId).toBeDefined();
+
+      // The channel should be detached
+      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('detached');
+
+      // Advance to the timeout
+      await vi.advanceTimersToNextTimerAsync();
+
+      // Wait for a small amount of time to ensure the timer gets to clear via finally
+      await vi.waitFor(
+        () => {
+          expect(defaultTyping.timeoutTimerId).toBeUndefined();
+          expect(defaultTyping.heartbeatTimerId).toBeDefined();
+        },
+        { timeout: 1000 },
+      );
+
+      // Advance to the next timeout
+      vi.advanceTimersToNextTimer();
+
+      // Now the heartbeat should have been cleared
+      expect(defaultTyping.heartbeatTimerId).toBeUndefined();
+    });
+  });
+
+  describe<TestContext>('explicit typing stop', () => {
+    // CHA-T5a
+    it<TestContext>('is no-op if stop called whilst not typing', async (context) => {
+      const { room, realtime } = context;
+      const channel = room.typing.channel;
+      const realtimeChannel = realtime.channels.get(channel.name);
+
+      // If stop is called, the test should fail as the timer should not have expired
+      vi.spyOn(room.typing, 'stop').mockImplementation(async (): Promise<void> => {});
+      vi.spyOn(room.typing.channel, 'publish').mockImplementation(async (): Promise<void> => {});
+      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
+
+      // Stop typing
+      await room.typing.stop();
+
+      // Ensure that no messages were sent
+      expect(realtimeChannel.publish).not.toHaveBeenCalled();
+    });
+
+    // CHA-T5c
+    it<TestContext>('throws an error if typing.stop is called when the channel is not attached', async (context) => {
+      const { room, realtime } = context;
+      const channel = room.typing.channel;
+      const realtimeChannel = realtime.channels.get(channel.name);
+      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
+      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
+      await room.typing.start();
+      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('detached');
+
+      await expect(room.typing.stop()).rejects.toBeErrorInfoWithCode(40000);
+
+      // Check that no messages were sent
+      expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
+    });
+
+    it<TestContext>('delays stop timeout while still typing', async (context) => {
+      const { room } = context;
+      // If stop is called, the test should fail as the timer should not have expired
+      vi.spyOn(room.typing, 'stop').mockImplementation(async (): Promise<void> => {});
+      vi.spyOn(room.typing.channel, 'publish').mockImplementation(async (): Promise<void> => {});
+      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
+
+      // Start typing - we will wait/type a few times to ensure the timer is resetting
+      await room.typing.start();
+      // wait for half the timers timeout
+      await new Promise((resolve) => setTimeout(resolve, TEST_TYPING_TIMEOUT_MS / 2));
+      // Start typing again to reset the timer
+      await room.typing.start();
+      // wait for half the timers timeout
+      await new Promise((resolve) => setTimeout(resolve, TEST_TYPING_TIMEOUT_MS / 2));
+      // Start typing again to reset the timer
+      await room.typing.start();
+      // wait for half the timers timeout
+      await new Promise((resolve) => setTimeout(resolve, TEST_TYPING_TIMEOUT_MS / 2));
+      // Should have waited 1.5x the timeout at this point
+
+      // Ensure that stop was not called
+      expect(room.typing.stop).not.toHaveBeenCalled();
+    });
+
+    it<TestContext>('when stop is called, immediately stops typing', async (context) => {
+      const { realtime, room } = context;
+      const channel = room.typing.channel;
+      const realtimeChannel = realtime.channels.get(channel.name);
+
+      // If stop is called, it should publish a leave message
+      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
+      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
+
+      // Start typing and then immediately stop typing
+      await room.typing.start();
+      await room.typing.stop();
+
+      // The timer should be stopped and so waiting beyond timeout should not trigger stop again
+      await new Promise((resolve) => setTimeout(resolve, TEST_TYPING_TIMEOUT_MS * 2));
+
+      expect(realtimeChannel.publish).toHaveBeenCalledTimes(2);
+      // Ensure that publish was called with typing.started only once
+      expect(realtimeChannel.publish).toHaveBeenCalledWith(startMessage);
+      // Ensure that publish was called with typing.stopped only once
+      expect(realtimeChannel.publish).toHaveBeenCalledWith(stopMessage);
+
+      // Check that the timers have been cleared
+      const defaultTyping = room.typing as DefaultTyping;
+      expect(defaultTyping.timeoutTimerId).toBeUndefined();
+      expect(defaultTyping.heartbeatTimerId).toBeUndefined();
+    });
+  });
+
+  describe<TestContext>('typing subscriptions', () => {
+    beforeEach<TestContext>(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach<TestContext>(() => {
+      vi.useRealTimers();
+    });
+
+    // CHA-T6a, CHA-T6b
+    it<TestContext>('allows listeners to be subscribed and unsubscribed', async (context) => {
+      const { room } = context;
+
+      // Add a listener
+      const receivedEvents: TypingEvent[] = [];
+      const { unsubscribe } = room.typing.subscribe((event: TypingEvent) => {
+        console.log('HERE WITH EVENT!');
+        receivedEvents.push(event);
+      });
+
+      // Another listener used to receive all events, to make sure events were emitted
+      const allEvents: TypingEvent[] = [];
+      const allSubscription = room.typing.subscribe((event: TypingEvent) => {
+        allEvents.push(event);
+      });
+
+      // Emulate a typing event
+      context.emulateBackendPublish({
         name: TypingEvents.Start,
-        connectionId: '',
-        id: '',
-        encoding: '',
-        timestamp: 0,
-        extras: {},
-        data: {},
-      } as Ably.InboundMessage,
-    ],
-    [
-      'empty client id',
-      {
+        clientId: 'otherClient',
+      });
+
+      await waitForArrayLength(receivedEvents, 1);
+
+      // Ensure that the listener received the event
+      expect(receivedEvents).toHaveLength(1);
+      expect(receivedEvents[0]).toEqual({
+        type: TypingEvents.Start,
+        clientId: 'otherClient',
+        currentlyTyping: new Set(['otherClient']),
+      });
+
+      // Unsubscribe the listener
+      unsubscribe();
+
+      // Emulate another typing event for anotherClient
+      context.emulateBackendPublish({
         name: TypingEvents.Start,
-        clientId: '',
-        connectionId: '',
-        id: '',
-        encoding: '',
-        timestamp: 0,
-        extras: {},
-        data: {},
-      } as Ably.InboundMessage,
-    ],
-    [
-      'unhandled event name',
-      {
-        name: 'notATypingEvent',
-        clientId: 'someClient',
-        connectionId: '',
-        id: '',
-        encoding: '',
-        timestamp: 0,
-        extras: {},
-        data: {},
-      } as Ably.InboundMessage,
-    ],
-  ])('invalid incoming typing messages: %s', (description: string, inbound: Ably.InboundMessage) => {
-    test<TestContext>(`does not process invalid incoming typing messages: ${description}`, (context) => {
+        clientId: 'anotherClient',
+      });
+
+      // wait for check events to be length 2 to make sure second event was triggered
+      await waitForArrayLength(allEvents, 2);
+      expect(allEvents.length).toEqual(2);
+      expect(allEvents[1]?.currentlyTyping).toEqual(new Set(['otherClient', 'anotherClient']));
+
+      // Ensure that the listener did not receive the event
+      expect(receivedEvents).toHaveLength(1);
+
+      // Calling unsubscribe again should not throw
+      unsubscribe();
+
+      allSubscription.unsubscribe();
+    });
+
+    // CHA-T6b
+    it<TestContext>('allows all listeners to be unsubscribed at once', async (context) => {
+      const { room } = context;
+
+      // Add a listener
+      const receivedEvents: TypingEvent[] = [];
+      const { unsubscribe } = room.typing.subscribe((event: TypingEvent) => {
+        receivedEvents.push(event);
+      });
+
+      // Add another
+      const receivedEvents2: TypingEvent[] = [];
+      const { unsubscribe: unsubscribe2 } = room.typing.subscribe((event: TypingEvent) => {
+        receivedEvents2.push(event);
+      });
+
+      // Emulate a typing event
+      context.emulateBackendPublish({
+        name: TypingEvents.Start,
+        clientId: 'otherClient',
+      });
+
+      await waitForArrayLength(receivedEvents, 1);
+
+      // Ensure that the listener received the event
+      expect(receivedEvents).toHaveLength(1);
+      expect(receivedEvents[0]).toEqual({
+        type: TypingEvents.Start,
+        clientId: 'otherClient',
+        currentlyTyping: new Set(['otherClient']),
+      });
+
+      await waitForArrayLength(receivedEvents2, 1);
+      // Ensure that the second listener received the event
+      expect(receivedEvents2).toHaveLength(1);
+      expect(receivedEvents2[0]).toEqual({
+        type: TypingEvents.Start,
+        clientId: 'otherClient',
+        currentlyTyping: new Set(['otherClient']),
+      });
+
+      // Unsubscribe all listeners
+      room.typing.unsubscribeAll();
+
+      // subscribe a check subscriber
+      const checkEvents: TypingEvent[] = [];
+      room.typing.subscribe((event) => {
+        checkEvents.push(event);
+      });
+
+      // Emulate another typing event
+      context.emulateBackendPublish({
+        name: TypingEvents.Start,
+        clientId: 'anotherClient2',
+      });
+
+      await waitForArrayLength(checkEvents, 1);
+      expect(checkEvents[0]?.currentlyTyping).toEqual(new Set(['otherClient', 'anotherClient2']));
+
+      // Ensure that the listeners did not receive the event
+      expect(receivedEvents).toHaveLength(1);
+      expect(receivedEvents2).toHaveLength(1);
+
+      // Calling unsubscribe should not throw
+      unsubscribe();
+      unsubscribe2();
+    });
+
+    // CHA-T13a
+    describe.each([
+      [
+        'no client id',
+        {
+          name: TypingEvents.Start,
+          connectionId: '',
+          id: '',
+          encoding: '',
+          timestamp: 0,
+          extras: {},
+          data: {},
+        } as Ably.InboundMessage,
+      ],
+      [
+        'empty client id',
+        {
+          name: TypingEvents.Start,
+          clientId: '',
+          connectionId: '',
+          id: '',
+          encoding: '',
+          timestamp: 0,
+          extras: {},
+          data: {},
+        } as Ably.InboundMessage,
+      ],
+      [
+        'unhandled event name',
+        {
+          name: 'notATypingEvent',
+          clientId: 'someClient',
+          connectionId: '',
+          id: '',
+          encoding: '',
+          timestamp: 0,
+          extras: {},
+          data: {},
+        } as Ably.InboundMessage,
+      ],
+    ])('invalid incoming typing messages: %s', (description: string, inbound: Ably.InboundMessage) => {
+      test<TestContext>(`does not process invalid incoming typing messages: ${description}`, (context) => {
+        const { room } = context;
+
+        // Subscribe to typing events
+        const receivedEvents: TypingEvent[] = [];
+        room.typing.subscribe((event: TypingEvent) => {
+          receivedEvents.push(event);
+        });
+
+        // Emulate a typing event
+        context.emulateBackendPublish({
+          ...inbound,
+        } as Ably.InboundMessage);
+
+        // Ensure that no typing events were received
+        expect(receivedEvents).toHaveLength(0);
+      });
+    });
+
+    // CHA-T13b1
+    it<TestContext>('starts typing for inbound typing start event', async (context) => {
       const { room } = context;
 
       // Subscribe to typing events
-      const receivedEvents: TypingEventPayload[] = [];
-      room.typing.subscribe((event: TypingEventPayload) => {
+      const receivedEvents: TypingEvent[] = [];
+      room.typing.subscribe((event: TypingEvent) => {
         receivedEvents.push(event);
       });
 
       // Emulate a typing event
       context.emulateBackendPublish({
-        ...inbound,
-      } as Ably.InboundMessage);
+        name: TypingEvents.Start,
+        clientId: 'otherClient',
+      });
+
+      // Ensure that the listener received the event
+      await waitForMessages(receivedEvents, 1);
+      expect(receivedEvents).toHaveLength(1);
+      expect(receivedEvents[0]).toEqual({
+        type: TypingEvents.Start,
+        clientId: 'otherClient',
+        currentlyTyping: new Set(['otherClient']),
+      });
+
+      // Check our current typers
+      expect(room.typing.get()).toEqual(new Set(['otherClient']));
+
+      // Check we have an active timer
+      const defaultTyping = room.typing as DefaultTyping;
+      const inactivity = defaultTyping.currentlyTyping.get('otherClient');
+      expect(inactivity).toBeDefined();
+    });
+
+    // CHA-T13b2
+    it<TestContext>('resets the inactivity timer on inbound typing start event', async (context) => {
+      const { room } = context;
+
+      // Subscribe to typing events
+      const receivedEvents: TypingEvent[] = [];
+      room.typing.subscribe((event: TypingEvent) => {
+        receivedEvents.push(event);
+      });
+
+      // Emulate a typing event
+      context.emulateBackendPublish({
+        name: TypingEvents.Start,
+        clientId: 'otherClient',
+      });
+
+      // Ensure that the listener received the event
+      await waitForMessages(receivedEvents, 1);
+      expect(receivedEvents).toHaveLength(1);
+      expect(receivedEvents[0]).toEqual({
+        type: TypingEvents.Start,
+        clientId: 'otherClient',
+        currentlyTyping: new Set(['otherClient']),
+      });
+
+      // Get current inactivity timer
+      const defaultTyping = room.typing as DefaultTyping;
+      const inactivity = defaultTyping.currentlyTyping.get('otherClient');
+      expect(inactivity).toBeDefined();
+
+      // Now send another typing event
+      context.emulateBackendPublish({
+        name: TypingEvents.Start,
+        clientId: 'otherClient',
+      });
+
+      // Check that eventually (yay promises), the inactivity timer has been reset
+      await vi.waitFor(
+        () => {
+          const newInactivity = defaultTyping.currentlyTyping.get('otherClient');
+          expect(newInactivity).toBeDefined();
+          expect(newInactivity).not.toBe(inactivity);
+        },
+        { timeout: 1000 },
+      );
+    });
+
+    // CHA-T13b3
+    it<TestContext>('emits a typing stop event when the inactivity timer expires', async (context) => {
+      const { room } = context;
+
+      // Subscribe to typing events
+      const receivedEvents: TypingEvent[] = [];
+      room.typing.subscribe((event: TypingEvent) => {
+        receivedEvents.push(event);
+      });
+
+      // Emulate a typing event
+      context.emulateBackendPublish({
+        name: TypingEvents.Start,
+        clientId: 'otherClient',
+      });
+
+      // Ensure that the listener received the event
+      await waitForMessages(receivedEvents, 1);
+      expect(receivedEvents).toHaveLength(1);
+      expect(receivedEvents[0]).toEqual({
+        type: TypingEvents.Start,
+        clientId: 'otherClient',
+        currentlyTyping: new Set(['otherClient']),
+      });
+
+      // Get current inactivity timer
+      const defaultTyping = room.typing as DefaultTyping;
+      const inactivity = defaultTyping.currentlyTyping.get('otherClient');
+      expect(inactivity).toBeDefined();
+
+      // Expire the inactivity timer
+      vi.advanceTimersToNextTimer();
+
+      // Ensure that the listener received the event
+      await waitForMessages(receivedEvents, 2);
+      expect(receivedEvents).toHaveLength(2);
+      expect(receivedEvents[1]).toEqual({
+        type: TypingEvents.Stop,
+        clientId: 'otherClient',
+        currentlyTyping: new Set(),
+      });
+    });
+
+    // CHA-T13b4
+    it<TestContext>('stops typing for inbound typing stop event', async (context) => {
+      const { room } = context;
+
+      // Subscribe to typing events
+      const receivedEvents: TypingEvent[] = [];
+      room.typing.subscribe((event: TypingEvent) => {
+        receivedEvents.push(event);
+      });
+
+      // Emulate a typing event
+      context.emulateBackendPublish({
+        name: TypingEvents.Start,
+        clientId: 'otherClient',
+      });
+
+      // Ensure that the listener received the event
+      await waitForMessages(receivedEvents, 1);
+      expect(receivedEvents).toHaveLength(1);
+      expect(receivedEvents[0]).toEqual({
+        type: TypingEvents.Start,
+        clientId: 'otherClient',
+        currentlyTyping: new Set(['otherClient']),
+      });
+
+      // Get current inactivity timer
+      const defaultTyping = room.typing as DefaultTyping;
+      const inactivity = defaultTyping.currentlyTyping.get('otherClient');
+      expect(inactivity).toBeDefined();
+
+      // Emulate a typing stop event
+      context.emulateBackendPublish({
+        name: TypingEvents.Stop,
+        clientId: 'otherClient',
+      });
+
+      // Ensure that the listener received the event
+      await waitForMessages(receivedEvents, 2);
+      expect(receivedEvents).toHaveLength(2);
+      expect(receivedEvents[1]).toEqual({
+        type: TypingEvents.Stop,
+        clientId: 'otherClient',
+        currentlyTyping: new Set(),
+      });
+
+      // Check that the inactivity timer has been cleared
+      expect(defaultTyping.currentlyTyping.get('otherClient')).toBeUndefined();
+    });
+
+    // CHA-T13b5
+    it<TestContext>('ignores stopped typing events for clients not currently typing', (context) => {
+      const { room } = context;
+
+      // Subscribe to typing events
+      const receivedEvents: TypingEvent[] = [];
+      room.typing.subscribe((event: TypingEvent) => {
+        receivedEvents.push(event);
+      });
+
+      // Emulate a typing stop event
+      context.emulateBackendPublish({
+        name: TypingEvents.Stop,
+        clientId: 'otherClient',
+      });
 
       // Ensure that no typing events were received
       expect(receivedEvents).toHaveLength(0);

--- a/test/core/typing.test.ts
+++ b/test/core/typing.test.ts
@@ -23,9 +23,7 @@ interface TestContext {
   logger: Logger;
 }
 
-const TEST_TYPING_TIMEOUT_MS = 100;
-const TEST_INACTIVITY_TIMEOUT_MS = 400;
-const TEST_HEARTBEAT_INTERVAL_MS = 200;
+const TEST_HEARTBEAT_THROTTLE_MS = 200;
 
 const startMessage: Ably.Message = {
   name: TypingEvents.Start,
@@ -48,9 +46,7 @@ describe('Typing', () => {
     context.logger = makeTestLogger();
     context.options = {
       typing: {
-        timeoutMs: TEST_TYPING_TIMEOUT_MS,
-        inactivityTimeoutMs: TEST_INACTIVITY_TIMEOUT_MS,
-        heartbeatIntervalMs: TEST_HEARTBEAT_INTERVAL_MS,
+        heartbeatThrottleMs: TEST_HEARTBEAT_THROTTLE_MS,
       },
     };
     context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
@@ -110,44 +106,6 @@ describe('Typing', () => {
       const defaultTyping = room.typing as DefaultTyping;
 
       // CHA-T4a4
-      expect(defaultTyping.timeoutTimerId).toBeDefined();
-
-      // CHA-T4a5
-      expect(defaultTyping.heartbeatTimerId).toBeDefined();
-    });
-
-    // CHA-T4a4
-    it<TestContext>('does not set stop timeout if not in options', async (context) => {
-      context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
-      context.chatApi = new ChatApi(context.realtime, makeTestLogger());
-      context.options.typing = {
-        heartbeatIntervalMs: TEST_HEARTBEAT_INTERVAL_MS,
-        inactivityTimeoutMs: TEST_INACTIVITY_TIMEOUT_MS,
-      };
-      context.room = makeRandomRoom(context);
-
-      const { room, realtime } = context;
-      const channel = room.typing.channel;
-      const realtimeChannel = realtime.channels.get(channel.name);
-
-      // If start is called, it should publish a start message
-      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
-      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
-
-      // Start typing
-      await room.typing.start();
-
-      // Ensure that publish was called with typing.started
-      expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
-      expect(realtimeChannel.publish).toHaveBeenCalledWith(startMessage);
-
-      // Check that our timers have been set
-      const defaultTyping = room.typing as DefaultTyping;
-
-      // CHA-T4a4
-      expect(defaultTyping.timeoutTimerId).toBeUndefined();
-
-      // CHA-T4a5
       expect(defaultTyping.heartbeatTimerId).toBeDefined();
     });
 
@@ -172,9 +130,6 @@ describe('Typing', () => {
       const defaultTyping = room.typing as DefaultTyping;
 
       // CHA-T4a4
-      expect(defaultTyping.timeoutTimerId).toBeDefined();
-
-      // CHA-T4a5
       expect(defaultTyping.heartbeatTimerId).toBeDefined();
 
       // Start typing again
@@ -184,521 +139,266 @@ describe('Typing', () => {
       expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
     });
 
-    // CHA-T4c2
-    it<TestContext>('resets CHA-T3 timeout on second start typing call', async (context) => {
-      const { room, realtime } = context;
-      const channel = room.typing.channel;
-      const realtimeChannel = realtime.channels.get(channel.name);
-
-      // If start is called, it should publish a start message
-      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
-      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
-
-      // Start typing
-      await room.typing.start();
-
-      const timer = (room.typing as DefaultTyping).timeoutTimerId;
-      expect(timer).toBeDefined();
-
-      // Start typing again
-      await room.typing.start();
-
-      // Check we have a new timer
-      const newTimer = (room.typing as DefaultTyping).timeoutTimerId;
-      expect(newTimer).toBeDefined();
-      expect(newTimer).not.toBe(timer);
-    });
-  });
-
-  describe<TestContext>('implicit typing stop', () => {
-    beforeEach<TestContext>(() => {
-      vi.useFakeTimers();
-    });
-
-    afterEach<TestContext>(() => {
-      vi.useRealTimers();
-    });
-
-    // CHA-T12a
-    it<TestContext>('unset the heartbeat timer after CHA-T10 timeout', async (context) => {
-      context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
-      context.chatApi = new ChatApi(context.realtime, makeTestLogger());
-      context.options.typing = {
-        heartbeatIntervalMs: TEST_HEARTBEAT_INTERVAL_MS,
-        inactivityTimeoutMs: TEST_INACTIVITY_TIMEOUT_MS,
-      };
-      context.room = makeRandomRoom(context);
-      const { room, realtime } = context;
-      const channel = room.typing.channel;
-      const realtimeChannel = realtime.channels.get(channel.name);
-
-      // If start is called, it should publish a start message
-      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
-      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
-
-      // Mock the timers
-
-      // Start typing
-      await room.typing.start();
-
-      // Ensure that publish was called with typing.started
-      expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
-      expect(realtimeChannel.publish).toHaveBeenCalledWith(startMessage);
-
-      // Check that our timers have been set
-      const defaultTyping = room.typing as DefaultTyping;
-
-      // CHA-T4a4
-      expect(defaultTyping.timeoutTimerId).toBeUndefined();
-
-      // CHA-T4a5
-      expect(defaultTyping.heartbeatTimerId).toBeDefined();
-
-      // Advance our timers
-      vi.runAllTimers();
-
-      // Check that the timers have been cleared
-      expect(defaultTyping.timeoutTimerId).toBeUndefined();
-      expect(defaultTyping.heartbeatTimerId).toBeUndefined();
-    });
-
-    // CHA-T12b1
-    it<TestContext>('performs an explicit stop after CHA-T3 expiry', async (context) => {
-      const { room, realtime } = context;
-      const channel = room.typing.channel;
-      const realtimeChannel = realtime.channels.get(channel.name);
-
-      // If start is called, it should publish a start message
-      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
-      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
-
-      // Mock the timers
-
-      // Start typing
-      await room.typing.start();
-
-      // Ensure that publish was called with typing.started
-      expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
-      expect(realtimeChannel.publish).toHaveBeenCalledWith(startMessage);
-
-      // Check that our timers have been set
-      const defaultTyping = room.typing as DefaultTyping;
-
-      // CHA-T4a4
-      expect(defaultTyping.timeoutTimerId).toBeDefined();
-
-      // CHA-T4a5
-      expect(defaultTyping.heartbeatTimerId).toBeDefined();
-
-      // Advance to the timeout
-      vi.advanceTimersToNextTimer();
-
-      // We should wait until the stop has been called
-      await vi.waitFor(
-        () => {
-          expect(realtimeChannel.publish).toHaveBeenCalledTimes(2);
-          expect(realtimeChannel.publish).toHaveBeenCalledWith(stopMessage);
-        },
-        { timeout: 1000 },
-      );
-
-      // Check that the timers have been cleared
-      expect(defaultTyping.timeoutTimerId).toBeUndefined();
-      expect(defaultTyping.heartbeatTimerId).toBeUndefined();
-    });
-
-    // CHA-T12b2
-    it<TestContext>('handles failure of publish after CHA-T3 expiry', async (context) => {
-      context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
-      context.chatApi = new ChatApi(context.realtime, makeTestLogger());
-      // Set some large numbers
-      context.options.typing = {
-        heartbeatIntervalMs: 20000,
-        inactivityTimeoutMs: 15000,
-        timeoutMs: 100,
-      };
-      context.room = makeRandomRoom(context);
-      const { room, realtime } = context;
-      const channel = room.typing.channel;
-      const realtimeChannel = realtime.channels.get(channel.name);
-
-      // If start is called, it should publish a start message
-      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
-      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
-
-      // Mock the timers
-
-      // Start typing
-      await room.typing.start();
-
-      // Ensure that publish was called with typing.started
-      expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
-      expect(realtimeChannel.publish).toHaveBeenCalledWith(startMessage);
-
-      // Check that our timers have been set
-      const defaultTyping = room.typing as DefaultTyping;
-
-      // CHA-T4a4
-      expect(defaultTyping.timeoutTimerId).toBeDefined();
-
-      // CHA-T4a5
-      expect(defaultTyping.heartbeatTimerId).toBeDefined();
-
-      // The channel publish should fail
-      vi.spyOn(realtimeChannel, 'publish').mockRejectedValue(new Ably.ErrorInfo('Failed to publish', 50000, 500));
-
-      // Advance to the timeout
-      await vi.advanceTimersToNextTimerAsync();
-
-      // We should wait until the stop has been called
-      await vi.waitFor(
-        () => {
-          expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
-          expect(realtimeChannel.publish).toHaveBeenCalledWith(stopMessage);
-        },
-        { timeout: 1000 },
-      );
-
-      // Wait for a small amount of time to ensure the timer gets to clear via finally
-      await vi.waitFor(
-        () => {
-          expect(defaultTyping.timeoutTimerId).toBeUndefined();
-          expect(defaultTyping.heartbeatTimerId).toBeDefined();
-        },
-        { timeout: 1000 },
-      );
-
-      // Advance to the next timeout
-      vi.advanceTimersToNextTimer();
-
-      // Now the heartbeat should have been cleared
-      expect(defaultTyping.heartbeatTimerId).toBeUndefined();
-    });
-
-    // CHA-T12b3
-    it<TestContext>('handles failure of publish after CHA-T3 expiry due to detachment', async (context) => {
-      context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
-      context.chatApi = new ChatApi(context.realtime, makeTestLogger());
-      // Set some large numbers
-      context.options.typing = {
-        heartbeatIntervalMs: 20000,
-        inactivityTimeoutMs: 15000,
-        timeoutMs: 100,
-      };
-      context.room = makeRandomRoom(context);
-      const { room, realtime } = context;
-      const channel = room.typing.channel;
-      const realtimeChannel = realtime.channels.get(channel.name);
-
-      // If start is called, it should publish a start message
-      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
-      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
-
-      // Mock the timers
-
-      // Start typing
-      await room.typing.start();
-
-      // Ensure that publish was called with typing.started
-      expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
-      expect(realtimeChannel.publish).toHaveBeenCalledWith(startMessage);
-
-      // Check that our timers have been set
-      const defaultTyping = room.typing as DefaultTyping;
-
-      // CHA-T4a4
-      expect(defaultTyping.timeoutTimerId).toBeDefined();
-
-      // CHA-T4a5
-      expect(defaultTyping.heartbeatTimerId).toBeDefined();
-
-      // The channel should be detached
-      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('detached');
-
-      // Advance to the timeout
-      await vi.advanceTimersToNextTimerAsync();
-
-      // Wait for a small amount of time to ensure the timer gets to clear via finally
-      await vi.waitFor(
-        () => {
-          expect(defaultTyping.timeoutTimerId).toBeUndefined();
-          expect(defaultTyping.heartbeatTimerId).toBeDefined();
-        },
-        { timeout: 1000 },
-      );
-
-      // Advance to the next timeout
-      vi.advanceTimersToNextTimer();
-
-      // Now the heartbeat should have been cleared
-      expect(defaultTyping.heartbeatTimerId).toBeUndefined();
-    });
-  });
-
-  describe<TestContext>('explicit typing stop', () => {
-    // CHA-T5a
-    it<TestContext>('is no-op if stop called whilst not typing', async (context) => {
-      const { room, realtime } = context;
-      const channel = room.typing.channel;
-      const realtimeChannel = realtime.channels.get(channel.name);
-
-      // If stop is called, the test should fail as the timer should not have expired
-      vi.spyOn(room.typing, 'stop').mockImplementation(async (): Promise<void> => {});
-      vi.spyOn(room.typing.channel, 'publish').mockImplementation(async (): Promise<void> => {});
-      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
-
-      // Stop typing
-      await room.typing.stop();
-
-      // Ensure that no messages were sent
-      expect(realtimeChannel.publish).not.toHaveBeenCalled();
-    });
-
-    // CHA-T5c
-    it<TestContext>('throws an error if typing.stop is called when the channel is not attached', async (context) => {
-      const { room, realtime } = context;
-      const channel = room.typing.channel;
-      const realtimeChannel = realtime.channels.get(channel.name);
-      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
-      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
-      await room.typing.start();
-      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('detached');
-
-      await expect(room.typing.stop()).rejects.toBeErrorInfoWithCode(40000);
-
-      // Check that no messages were sent
-      expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
-    });
-
-    it<TestContext>('delays stop timeout while still typing', async (context) => {
-      const { room } = context;
-      // If stop is called, the test should fail as the timer should not have expired
-      vi.spyOn(room.typing, 'stop').mockImplementation(async (): Promise<void> => {});
-      vi.spyOn(room.typing.channel, 'publish').mockImplementation(async (): Promise<void> => {});
-      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
-
-      // Start typing - we will wait/type a few times to ensure the timer is resetting
-      await room.typing.start();
-      // wait for half the timers timeout
-      await new Promise((resolve) => setTimeout(resolve, TEST_TYPING_TIMEOUT_MS / 2));
-      // Start typing again to reset the timer
-      await room.typing.start();
-      // wait for half the timers timeout
-      await new Promise((resolve) => setTimeout(resolve, TEST_TYPING_TIMEOUT_MS / 2));
-      // Start typing again to reset the timer
-      await room.typing.start();
-      // wait for half the timers timeout
-      await new Promise((resolve) => setTimeout(resolve, TEST_TYPING_TIMEOUT_MS / 2));
-      // Should have waited 1.5x the timeout at this point
-
-      // Ensure that stop was not called
-      expect(room.typing.stop).not.toHaveBeenCalled();
-    });
-
-    it<TestContext>('when stop is called, immediately stops typing', async (context) => {
-      const { realtime, room } = context;
-      const channel = room.typing.channel;
-      const realtimeChannel = realtime.channels.get(channel.name);
-
-      // If stop is called, it should publish a leave message
-      vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
-      vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
-
-      // Start typing and then immediately stop typing
-      await room.typing.start();
-      await room.typing.stop();
-
-      // The timer should be stopped and so waiting beyond timeout should not trigger stop again
-      await new Promise((resolve) => setTimeout(resolve, TEST_TYPING_TIMEOUT_MS * 2));
-
-      expect(realtimeChannel.publish).toHaveBeenCalledTimes(2);
-      // Ensure that publish was called with typing.started only once
-      expect(realtimeChannel.publish).toHaveBeenCalledWith(startMessage);
-      // Ensure that publish was called with typing.stopped only once
-      expect(realtimeChannel.publish).toHaveBeenCalledWith(stopMessage);
-
-      // Check that the timers have been cleared
-      const defaultTyping = room.typing as DefaultTyping;
-      expect(defaultTyping.timeoutTimerId).toBeUndefined();
-      expect(defaultTyping.heartbeatTimerId).toBeUndefined();
-    });
-  });
-
-  describe<TestContext>('typing subscriptions', () => {
-    beforeEach<TestContext>(() => {
-      vi.useFakeTimers();
-    });
-
-    afterEach<TestContext>(() => {
-      vi.useRealTimers();
-    });
-
-    // CHA-T6a, CHA-T6b
-    it<TestContext>('allows listeners to be subscribed and unsubscribed', async (context) => {
-      const { room } = context;
-
-      // Add a listener
-      const receivedEvents: TypingEvent[] = [];
-      const { unsubscribe } = room.typing.subscribe((event: TypingEvent) => {
-        console.log('HERE WITH EVENT!');
-        receivedEvents.push(event);
+    describe<TestContext>('explicit typing stop', () => {
+      // CHA-T5a
+      it<TestContext>('is no-op if stop called whilst not typing', async (context) => {
+        const { room, realtime } = context;
+        const channel = room.typing.channel;
+        const realtimeChannel = realtime.channels.get(channel.name);
+
+        // If stop is called, the test should fail as the timer should not have expired
+        vi.spyOn(room.typing, 'stop').mockImplementation(async (): Promise<void> => {});
+        vi.spyOn(room.typing.channel, 'publish').mockImplementation(async (): Promise<void> => {});
+        vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
+
+        // Stop typing
+        await room.typing.stop();
+
+        // Ensure that no messages were sent
+        expect(realtimeChannel.publish).not.toHaveBeenCalled();
       });
 
-      // Another listener used to receive all events, to make sure events were emitted
-      const allEvents: TypingEvent[] = [];
-      const allSubscription = room.typing.subscribe((event: TypingEvent) => {
-        allEvents.push(event);
+      // CHA-T5c
+      it<TestContext>('throws an error if typing.stop is called when the channel is not attached', async (context) => {
+        const { room, realtime } = context;
+        const channel = room.typing.channel;
+        const realtimeChannel = realtime.channels.get(channel.name);
+        vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
+        vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
+        await room.typing.start();
+        vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('detached');
+
+        await expect(room.typing.stop()).rejects.toBeErrorInfoWithCode(40000);
+
+        // Check that no messages were sent
+        expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
       });
 
-      // Emulate a typing event
-      context.emulateBackendPublish({
-        name: TypingEvents.Start,
-        clientId: 'otherClient',
+      it<TestContext>('when stop is called, immediately stops typing', async (context) => {
+        const { realtime, room } = context;
+        const channel = room.typing.channel;
+        const realtimeChannel = realtime.channels.get(channel.name);
+
+        // If stop is called, it should publish a leave message
+        vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
+        vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
+
+        // Start typing and then immediately stop typing
+        await room.typing.start();
+        await room.typing.stop();
+
+        expect(realtimeChannel.publish).toHaveBeenCalledTimes(2);
+        // Ensure that publish was called with typing.started only once
+        expect(realtimeChannel.publish).toHaveBeenCalledWith(startMessage);
+        // Ensure that publish was called with typing.stopped only once
+        expect(realtimeChannel.publish).toHaveBeenCalledWith(stopMessage);
+
+        // Check that the timers have been cleared
+        const defaultTyping = room.typing as DefaultTyping;
+        expect(defaultTyping.heartbeatTimerId).toBeUndefined();
       });
-
-      await waitForArrayLength(receivedEvents, 1);
-
-      // Ensure that the listener received the event
-      expect(receivedEvents).toHaveLength(1);
-      expect(receivedEvents[0]).toEqual({
-        type: TypingEvents.Start,
-        clientId: 'otherClient',
-        currentlyTyping: new Set(['otherClient']),
-      });
-
-      // Unsubscribe the listener
-      unsubscribe();
-
-      // Emulate another typing event for anotherClient
-      context.emulateBackendPublish({
-        name: TypingEvents.Start,
-        clientId: 'anotherClient',
-      });
-
-      // wait for check events to be length 2 to make sure second event was triggered
-      await waitForArrayLength(allEvents, 2);
-      expect(allEvents.length).toEqual(2);
-      expect(allEvents[1]?.currentlyTyping).toEqual(new Set(['otherClient', 'anotherClient']));
-
-      // Ensure that the listener did not receive the event
-      expect(receivedEvents).toHaveLength(1);
-
-      // Calling unsubscribe again should not throw
-      unsubscribe();
-
-      allSubscription.unsubscribe();
     });
 
-    // CHA-T6b
-    it<TestContext>('allows all listeners to be unsubscribed at once', async (context) => {
-      const { room } = context;
-
-      // Add a listener
-      const receivedEvents: TypingEvent[] = [];
-      const { unsubscribe } = room.typing.subscribe((event: TypingEvent) => {
-        receivedEvents.push(event);
+    describe<TestContext>('typing subscriptions', () => {
+      beforeEach<TestContext>(() => {
+        vi.useFakeTimers();
       });
 
-      // Add another
-      const receivedEvents2: TypingEvent[] = [];
-      const { unsubscribe: unsubscribe2 } = room.typing.subscribe((event: TypingEvent) => {
-        receivedEvents2.push(event);
+      afterEach<TestContext>(() => {
+        vi.useRealTimers();
       });
 
-      // Emulate a typing event
-      context.emulateBackendPublish({
-        name: TypingEvents.Start,
-        clientId: 'otherClient',
-      });
+      // CHA-T6a, CHA-T6b
+      it<TestContext>('allows listeners to be subscribed and unsubscribed', async (context) => {
+        const { room } = context;
 
-      await waitForArrayLength(receivedEvents, 1);
+        // Add a listener
+        const receivedEvents: TypingEvent[] = [];
+        const { unsubscribe } = room.typing.subscribe((event: TypingEvent) => {
+          receivedEvents.push(event);
+        });
 
-      // Ensure that the listener received the event
-      expect(receivedEvents).toHaveLength(1);
-      expect(receivedEvents[0]).toEqual({
-        type: TypingEvents.Start,
-        clientId: 'otherClient',
-        currentlyTyping: new Set(['otherClient']),
-      });
+        // Another listener used to receive all events, to make sure events were emitted
+        const allEvents: TypingEvent[] = [];
+        const allSubscription = room.typing.subscribe((event: TypingEvent) => {
+          allEvents.push(event);
+        });
 
-      await waitForArrayLength(receivedEvents2, 1);
-      // Ensure that the second listener received the event
-      expect(receivedEvents2).toHaveLength(1);
-      expect(receivedEvents2[0]).toEqual({
-        type: TypingEvents.Start,
-        clientId: 'otherClient',
-        currentlyTyping: new Set(['otherClient']),
-      });
-
-      // Unsubscribe all listeners
-      room.typing.unsubscribeAll();
-
-      // subscribe a check subscriber
-      const checkEvents: TypingEvent[] = [];
-      room.typing.subscribe((event) => {
-        checkEvents.push(event);
-      });
-
-      // Emulate another typing event
-      context.emulateBackendPublish({
-        name: TypingEvents.Start,
-        clientId: 'anotherClient2',
-      });
-
-      await waitForArrayLength(checkEvents, 1);
-      expect(checkEvents[0]?.currentlyTyping).toEqual(new Set(['otherClient', 'anotherClient2']));
-
-      // Ensure that the listeners did not receive the event
-      expect(receivedEvents).toHaveLength(1);
-      expect(receivedEvents2).toHaveLength(1);
-
-      // Calling unsubscribe should not throw
-      unsubscribe();
-      unsubscribe2();
-    });
-
-    // CHA-T13a
-    describe.each([
-      [
-        'no client id',
-        {
+        // Emulate a typing event
+        context.emulateBackendPublish({
           name: TypingEvents.Start,
-          connectionId: '',
-          id: '',
-          encoding: '',
-          timestamp: 0,
-          extras: {},
-          data: {},
-        } as Ably.InboundMessage,
-      ],
-      [
-        'empty client id',
-        {
+          clientId: 'otherClient',
+        });
+
+        await waitForArrayLength(receivedEvents, 1);
+
+        // Ensure that the listener received the event
+        expect(receivedEvents).toHaveLength(1);
+        expect(receivedEvents[0]).toEqual({
+          change: {
+            clientId: 'otherClient',
+            type: TypingEvents.Start,
+          },
+          currentlyTyping: new Set(['otherClient']),
+        });
+
+        // Unsubscribe the listener
+        unsubscribe();
+
+        // Emulate another typing event for anotherClient
+        context.emulateBackendPublish({
           name: TypingEvents.Start,
-          clientId: '',
-          connectionId: '',
-          id: '',
-          encoding: '',
-          timestamp: 0,
-          extras: {},
-          data: {},
-        } as Ably.InboundMessage,
-      ],
-      [
-        'unhandled event name',
-        {
-          name: 'notATypingEvent',
-          clientId: 'someClient',
-          connectionId: '',
-          id: '',
-          encoding: '',
-          timestamp: 0,
-          extras: {},
-          data: {},
-        } as Ably.InboundMessage,
-      ],
-    ])('invalid incoming typing messages: %s', (description: string, inbound: Ably.InboundMessage) => {
-      test<TestContext>(`does not process invalid incoming typing messages: ${description}`, (context) => {
+          clientId: 'anotherClient',
+        });
+
+        // wait for check events to be length 2 to make sure second event was triggered
+        await waitForArrayLength(allEvents, 2);
+        expect(allEvents.length).toEqual(2);
+        expect(allEvents[1]?.currentlyTyping).toEqual(new Set(['otherClient', 'anotherClient']));
+
+        // Ensure that the listener did not receive the event
+        expect(receivedEvents).toHaveLength(1);
+
+        // Calling unsubscribe again should not throw
+        unsubscribe();
+
+        allSubscription.unsubscribe();
+      });
+
+      // CHA-T6b
+      it<TestContext>('allows all listeners to be unsubscribed at once', async (context) => {
+        const { room } = context;
+
+        // Add a listener
+        const receivedEvents: TypingEvent[] = [];
+        const { unsubscribe } = room.typing.subscribe((event: TypingEvent) => {
+          receivedEvents.push(event);
+        });
+
+        // Add another
+        const receivedEvents2: TypingEvent[] = [];
+        const { unsubscribe: unsubscribe2 } = room.typing.subscribe((event: TypingEvent) => {
+          receivedEvents2.push(event);
+        });
+
+        // Emulate a typing event
+        context.emulateBackendPublish({
+          name: TypingEvents.Start,
+          clientId: 'otherClient',
+        });
+
+        await waitForArrayLength(receivedEvents, 1);
+
+        // Ensure that the listener received the event
+        expect(receivedEvents).toHaveLength(1);
+        expect(receivedEvents[0]).toEqual({
+          change: {
+            clientId: 'otherClient',
+            type: TypingEvents.Start,
+          },
+          currentlyTyping: new Set(['otherClient']),
+        });
+
+        await waitForArrayLength(receivedEvents2, 1);
+        // Ensure that the second listener received the event
+        expect(receivedEvents2).toHaveLength(1);
+        expect(receivedEvents2[0]).toEqual({
+          change: {
+            clientId: 'otherClient',
+            type: TypingEvents.Start,
+          },
+          currentlyTyping: new Set(['otherClient']),
+        });
+
+        // Unsubscribe all listeners
+        room.typing.unsubscribeAll();
+
+        // subscribe a check subscriber
+        const checkEvents: TypingEvent[] = [];
+        room.typing.subscribe((event) => {
+          checkEvents.push(event);
+        });
+
+        // Emulate another typing event
+        context.emulateBackendPublish({
+          name: TypingEvents.Start,
+          clientId: 'anotherClient2',
+        });
+
+        await waitForArrayLength(checkEvents, 1);
+        expect(checkEvents[0]?.currentlyTyping).toEqual(new Set(['otherClient', 'anotherClient2']));
+
+        // Ensure that the listeners did not receive the event
+        expect(receivedEvents).toHaveLength(1);
+        expect(receivedEvents2).toHaveLength(1);
+
+        // Calling unsubscribe should not throw
+        unsubscribe();
+        unsubscribe2();
+      });
+
+      // CHA-T13a
+      describe.each([
+        [
+          'no client id',
+          {
+            name: TypingEvents.Start,
+            connectionId: '',
+            id: '',
+            encoding: '',
+            timestamp: 0,
+            extras: {},
+            data: {},
+          } as Ably.InboundMessage,
+        ],
+        [
+          'empty client id',
+          {
+            name: TypingEvents.Start,
+            clientId: '',
+            connectionId: '',
+            id: '',
+            encoding: '',
+            timestamp: 0,
+            extras: {},
+            data: {},
+          } as Ably.InboundMessage,
+        ],
+        [
+          'unhandled event name',
+          {
+            name: 'notATypingEvent',
+            clientId: 'someClient',
+            connectionId: '',
+            id: '',
+            encoding: '',
+            timestamp: 0,
+            extras: {},
+            data: {},
+          } as Ably.InboundMessage,
+        ],
+      ])('invalid incoming typing messages: %s', (description: string, inbound: Ably.InboundMessage) => {
+        test<TestContext>(`does not process invalid incoming typing messages: ${description}`, (context) => {
+          const { room } = context;
+
+          // Subscribe to typing events
+          const receivedEvents: TypingEvent[] = [];
+          room.typing.subscribe((event: TypingEvent) => {
+            receivedEvents.push(event);
+          });
+
+          // Emulate a typing event
+          context.emulateBackendPublish({
+            ...inbound,
+          } as Ably.InboundMessage);
+
+          // Ensure that no typing events were received
+          expect(receivedEvents).toHaveLength(0);
+        });
+      });
+
+      // CHA-T13b1
+      it<TestContext>('starts typing for inbound typing start event', async (context) => {
         const { room } = context;
 
         // Subscribe to typing events
@@ -709,213 +409,206 @@ describe('Typing', () => {
 
         // Emulate a typing event
         context.emulateBackendPublish({
-          ...inbound,
-        } as Ably.InboundMessage);
+          name: TypingEvents.Start,
+          clientId: 'otherClient',
+        });
+
+        // Ensure that the listener received the event
+        await waitForArrayLength(receivedEvents, 1);
+        expect(receivedEvents).toHaveLength(1);
+        expect(receivedEvents[0]).toEqual({
+          change: {
+            clientId: 'otherClient',
+            type: TypingEvents.Start,
+          },
+          currentlyTyping: new Set(['otherClient']),
+        });
+
+        // Check our current typers
+        expect(room.typing.get()).toEqual(new Set(['otherClient']));
+
+        // Check we have an active timer
+        const defaultTyping = room.typing as DefaultTyping;
+        const inactivity = defaultTyping.currentlyTyping.get('otherClient');
+        expect(inactivity).toBeDefined();
+      });
+
+      // CHA-T13b2
+      it<TestContext>('resets the inactivity timer on inbound typing start event', async (context) => {
+        const { room } = context;
+
+        // Subscribe to typing events
+        const receivedEvents: TypingEvent[] = [];
+        room.typing.subscribe((event: TypingEvent) => {
+          receivedEvents.push(event);
+        });
+
+        // Emulate a typing event
+        context.emulateBackendPublish({
+          name: TypingEvents.Start,
+          clientId: 'otherClient',
+        });
+
+        // Ensure that the listener received the event
+        await waitForArrayLength(receivedEvents, 1);
+        expect(receivedEvents).toHaveLength(1);
+        expect(receivedEvents[0]).toEqual({
+          change: {
+            clientId: 'otherClient',
+            type: TypingEvents.Start,
+          },
+          currentlyTyping: new Set(['otherClient']),
+        });
+
+        // Get current inactivity timer
+        const defaultTyping = room.typing as DefaultTyping;
+        const inactivity = defaultTyping.currentlyTyping.get('otherClient');
+        expect(inactivity).toBeDefined();
+
+        // Now send another typing event
+        context.emulateBackendPublish({
+          name: TypingEvents.Start,
+          clientId: 'otherClient',
+        });
+
+        // Check that eventually (yay promises), the inactivity timer has been reset
+        await vi.waitFor(
+          () => {
+            const newInactivity = defaultTyping.currentlyTyping.get('otherClient');
+            expect(newInactivity).toBeDefined();
+            expect(newInactivity).not.toBe(inactivity);
+          },
+          { timeout: 1000 },
+        );
+      });
+
+      // CHA-T13b3
+      it<TestContext>('emits a typing stop event when the inactivity timer expires', async (context) => {
+        const { room } = context;
+
+        // Subscribe to typing events
+        const receivedEvents: TypingEvent[] = [];
+        room.typing.subscribe((event: TypingEvent) => {
+          receivedEvents.push(event);
+        });
+
+        // Emulate a typing event
+        context.emulateBackendPublish({
+          name: TypingEvents.Start,
+          clientId: 'otherClient',
+        });
+
+        // Ensure that the listener received the event
+        await waitForArrayLength(receivedEvents, 1);
+        expect(receivedEvents).toHaveLength(1);
+        expect(receivedEvents[0]).toEqual({
+          change: {
+            clientId: 'otherClient',
+            type: TypingEvents.Start,
+          },
+          currentlyTyping: new Set(['otherClient']),
+        });
+
+        // Get current inactivity timer
+        const defaultTyping = room.typing as DefaultTyping;
+        const inactivity = defaultTyping.currentlyTyping.get('otherClient');
+        expect(inactivity).toBeDefined();
+
+        // Expire the inactivity timer
+        vi.advanceTimersToNextTimer();
+
+        // Ensure that the listener received the event
+        await waitForArrayLength(receivedEvents, 2);
+        expect(receivedEvents).toHaveLength(2);
+        expect(receivedEvents[1]).toEqual({
+          change: {
+            clientId: 'otherClient',
+            type: TypingEvents.Stop,
+          },
+          currentlyTyping: new Set(),
+        });
+      });
+
+      // CHA-T13b4
+      it<TestContext>('stops typing for inbound typing stop event', async (context) => {
+        const { room } = context;
+
+        // Subscribe to typing events
+        const receivedEvents: TypingEvent[] = [];
+        room.typing.subscribe((event: TypingEvent) => {
+          receivedEvents.push(event);
+        });
+
+        // Emulate a typing event
+        context.emulateBackendPublish({
+          name: TypingEvents.Start,
+          clientId: 'otherClient',
+        });
+
+        // Ensure that the listener received the event
+        await waitForArrayLength(receivedEvents, 1);
+        expect(receivedEvents).toHaveLength(1);
+        expect(receivedEvents[0]).toEqual({
+          change: {
+            clientId: 'otherClient',
+            type: TypingEvents.Start,
+          },
+          currentlyTyping: new Set(['otherClient']),
+        });
+
+        // Get current inactivity timer
+        const defaultTyping = room.typing as DefaultTyping;
+        const inactivity = defaultTyping.currentlyTyping.get('otherClient');
+        expect(inactivity).toBeDefined();
+
+        // Emulate a typing stop event
+        context.emulateBackendPublish({
+          name: TypingEvents.Stop,
+          clientId: 'otherClient',
+        });
+
+        // Ensure that the listener received the event
+        await waitForArrayLength(receivedEvents, 2);
+        expect(receivedEvents).toHaveLength(2);
+        expect(receivedEvents[1]).toEqual({
+          change: {
+            clientId: 'otherClient',
+            type: TypingEvents.Stop,
+          },
+          currentlyTyping: new Set(),
+        });
+
+        // Check that the inactivity timer has been cleared
+        expect(defaultTyping.currentlyTyping.get('otherClient')).toBeUndefined();
+      });
+
+      // CHA-T13b5
+      it<TestContext>('ignores stopped typing events for clients not currently typing', (context) => {
+        const { room } = context;
+
+        // Subscribe to typing events
+        const receivedEvents: TypingEvent[] = [];
+        room.typing.subscribe((event: TypingEvent) => {
+          receivedEvents.push(event);
+        });
+
+        // Emulate a typing stop event
+        context.emulateBackendPublish({
+          name: TypingEvents.Stop,
+          clientId: 'otherClient',
+        });
 
         // Ensure that no typing events were received
         expect(receivedEvents).toHaveLength(0);
       });
     });
 
-    // CHA-T13b1
-    it<TestContext>('starts typing for inbound typing start event', async (context) => {
-      const { room } = context;
-
-      // Subscribe to typing events
-      const receivedEvents: TypingEvent[] = [];
-      room.typing.subscribe((event: TypingEvent) => {
-        receivedEvents.push(event);
-      });
-
-      // Emulate a typing event
-      context.emulateBackendPublish({
-        name: TypingEvents.Start,
-        clientId: 'otherClient',
-      });
-
-      // Ensure that the listener received the event
-      await waitForMessages(receivedEvents, 1);
-      expect(receivedEvents).toHaveLength(1);
-      expect(receivedEvents[0]).toEqual({
-        type: TypingEvents.Start,
-        clientId: 'otherClient',
-        currentlyTyping: new Set(['otherClient']),
-      });
-
-      // Check our current typers
-      expect(room.typing.get()).toEqual(new Set(['otherClient']));
-
-      // Check we have an active timer
-      const defaultTyping = room.typing as DefaultTyping;
-      const inactivity = defaultTyping.currentlyTyping.get('otherClient');
-      expect(inactivity).toBeDefined();
+    it<TestContext>('has an attachment error code', (context) => {
+      expect((context.room.typing as DefaultTyping).attachmentErrorCode).toBe(102005);
     });
 
-    // CHA-T13b2
-    it<TestContext>('resets the inactivity timer on inbound typing start event', async (context) => {
-      const { room } = context;
-
-      // Subscribe to typing events
-      const receivedEvents: TypingEvent[] = [];
-      room.typing.subscribe((event: TypingEvent) => {
-        receivedEvents.push(event);
-      });
-
-      // Emulate a typing event
-      context.emulateBackendPublish({
-        name: TypingEvents.Start,
-        clientId: 'otherClient',
-      });
-
-      // Ensure that the listener received the event
-      await waitForMessages(receivedEvents, 1);
-      expect(receivedEvents).toHaveLength(1);
-      expect(receivedEvents[0]).toEqual({
-        type: TypingEvents.Start,
-        clientId: 'otherClient',
-        currentlyTyping: new Set(['otherClient']),
-      });
-
-      // Get current inactivity timer
-      const defaultTyping = room.typing as DefaultTyping;
-      const inactivity = defaultTyping.currentlyTyping.get('otherClient');
-      expect(inactivity).toBeDefined();
-
-      // Now send another typing event
-      context.emulateBackendPublish({
-        name: TypingEvents.Start,
-        clientId: 'otherClient',
-      });
-
-      // Check that eventually (yay promises), the inactivity timer has been reset
-      await vi.waitFor(
-        () => {
-          const newInactivity = defaultTyping.currentlyTyping.get('otherClient');
-          expect(newInactivity).toBeDefined();
-          expect(newInactivity).not.toBe(inactivity);
-        },
-        { timeout: 1000 },
-      );
+    it<TestContext>('has a detachment error code', (context) => {
+      expect((context.room.typing as DefaultTyping).detachmentErrorCode).toBe(102054);
     });
-
-    // CHA-T13b3
-    it<TestContext>('emits a typing stop event when the inactivity timer expires', async (context) => {
-      const { room } = context;
-
-      // Subscribe to typing events
-      const receivedEvents: TypingEvent[] = [];
-      room.typing.subscribe((event: TypingEvent) => {
-        receivedEvents.push(event);
-      });
-
-      // Emulate a typing event
-      context.emulateBackendPublish({
-        name: TypingEvents.Start,
-        clientId: 'otherClient',
-      });
-
-      // Ensure that the listener received the event
-      await waitForMessages(receivedEvents, 1);
-      expect(receivedEvents).toHaveLength(1);
-      expect(receivedEvents[0]).toEqual({
-        type: TypingEvents.Start,
-        clientId: 'otherClient',
-        currentlyTyping: new Set(['otherClient']),
-      });
-
-      // Get current inactivity timer
-      const defaultTyping = room.typing as DefaultTyping;
-      const inactivity = defaultTyping.currentlyTyping.get('otherClient');
-      expect(inactivity).toBeDefined();
-
-      // Expire the inactivity timer
-      vi.advanceTimersToNextTimer();
-
-      // Ensure that the listener received the event
-      await waitForMessages(receivedEvents, 2);
-      expect(receivedEvents).toHaveLength(2);
-      expect(receivedEvents[1]).toEqual({
-        type: TypingEvents.Stop,
-        clientId: 'otherClient',
-        currentlyTyping: new Set(),
-      });
-    });
-
-    // CHA-T13b4
-    it<TestContext>('stops typing for inbound typing stop event', async (context) => {
-      const { room } = context;
-
-      // Subscribe to typing events
-      const receivedEvents: TypingEvent[] = [];
-      room.typing.subscribe((event: TypingEvent) => {
-        receivedEvents.push(event);
-      });
-
-      // Emulate a typing event
-      context.emulateBackendPublish({
-        name: TypingEvents.Start,
-        clientId: 'otherClient',
-      });
-
-      // Ensure that the listener received the event
-      await waitForMessages(receivedEvents, 1);
-      expect(receivedEvents).toHaveLength(1);
-      expect(receivedEvents[0]).toEqual({
-        type: TypingEvents.Start,
-        clientId: 'otherClient',
-        currentlyTyping: new Set(['otherClient']),
-      });
-
-      // Get current inactivity timer
-      const defaultTyping = room.typing as DefaultTyping;
-      const inactivity = defaultTyping.currentlyTyping.get('otherClient');
-      expect(inactivity).toBeDefined();
-
-      // Emulate a typing stop event
-      context.emulateBackendPublish({
-        name: TypingEvents.Stop,
-        clientId: 'otherClient',
-      });
-
-      // Ensure that the listener received the event
-      await waitForMessages(receivedEvents, 2);
-      expect(receivedEvents).toHaveLength(2);
-      expect(receivedEvents[1]).toEqual({
-        type: TypingEvents.Stop,
-        clientId: 'otherClient',
-        currentlyTyping: new Set(),
-      });
-
-      // Check that the inactivity timer has been cleared
-      expect(defaultTyping.currentlyTyping.get('otherClient')).toBeUndefined();
-    });
-
-    // CHA-T13b5
-    it<TestContext>('ignores stopped typing events for clients not currently typing', (context) => {
-      const { room } = context;
-
-      // Subscribe to typing events
-      const receivedEvents: TypingEvent[] = [];
-      room.typing.subscribe((event: TypingEvent) => {
-        receivedEvents.push(event);
-      });
-
-      // Emulate a typing stop event
-      context.emulateBackendPublish({
-        name: TypingEvents.Stop,
-        clientId: 'otherClient',
-      });
-
-      // Ensure that no typing events were received
-      expect(receivedEvents).toHaveLength(0);
-    });
-  });
-
-  it<TestContext>('has an attachment error code', (context) => {
-    expect((context.room.typing as DefaultTyping).attachmentErrorCode).toBe(102005);
-  });
-
-  it<TestContext>('has a detachment error code', (context) => {
-    expect((context.room.typing as DefaultTyping).detachmentErrorCode).toBe(102054);
   });
 });

--- a/test/core/typing.test.ts
+++ b/test/core/typing.test.ts
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 
 import { ChatClient } from '../../src/core/chat.ts';
 import { ChatApi } from '../../src/core/chat-api.ts';
+import { TypingEventPayload, TypingEvents } from '../../src/core/events.ts';
 import { Room } from '../../src/core/room.ts';
-import { DefaultTyping, TypingEvent } from '../../src/core/typing.ts';
-import { ChannelEventEmitterReturnType, channelPresenceEventEmitter } from '../helper/channel.ts';
+import { RoomOptions } from '../../src/core/room-options.ts';
+import { DefaultTyping } from '../../src/core/typing.ts';
+import { channelEventEmitter, ChannelEventEmitterReturnType } from '../helper/channel.ts';
 import { waitForArrayLength } from '../helper/common.ts';
 import { makeTestLogger } from '../helper/logger.ts';
 import { makeRandomRoom } from '../helper/room.ts';
@@ -15,43 +17,37 @@ interface TestContext {
   chat: ChatClient;
   chatApi: ChatApi;
   room: Room;
-  emulateBackendPublish: ChannelEventEmitterReturnType<Partial<Ably.PresenceMessage>>;
+  emulateBackendPublish: ChannelEventEmitterReturnType<Partial<Ably.InboundMessage>>;
+  options: RoomOptions;
 }
 
-const TEST_TYPING_TIMEOUT_MS = 100;
+const TEST_TYPING_TIMEOUT_MS = 200;
+const TEST_INACTIVITY_TIMEOUT_MS = 400;
+const TEST_HEARTBEAT_INTERVAL_MS = 100;
 
 vi.mock('ably');
 
-function presenceGetResponse(clientIds: Iterable<string>): Ably.PresenceMessage[] {
-  const res: Ably.PresenceMessage[] = [];
-  for (const clientId of clientIds) {
-    res.push({
-      clientId: clientId,
-      action: 'present',
-      timestamp: Date.now(),
-      connectionId: 'connection_' + clientId,
-      data: undefined,
-      encoding: '',
-      extras: undefined,
-      id: 'some_id_' + clientId,
-    });
-  }
-  return res;
-}
-
 describe('Typing', () => {
   beforeEach<TestContext>((context) => {
+    context.options = {
+      typing: {
+        timeoutMs: TEST_TYPING_TIMEOUT_MS,
+        inactivityTimeoutMs: TEST_INACTIVITY_TIMEOUT_MS,
+        heartbeatIntervalMs: TEST_HEARTBEAT_INTERVAL_MS,
+      },
+    };
     context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
     context.chatApi = new ChatApi(context.realtime, makeTestLogger());
     context.room = makeRandomRoom(context);
     const channel = context.room.typing.channel;
-    context.emulateBackendPublish = channelPresenceEventEmitter(channel);
+    context.emulateBackendPublish = channelEventEmitter(channel);
   });
 
   it<TestContext>('delays stop timeout while still typing', async (context) => {
     const { room } = context;
     // If stop is called, the test should fail as the timer should not have expired
     vi.spyOn(room.typing, 'stop').mockImplementation(async (): Promise<void> => {});
+    vi.spyOn(room.typing.channel, 'publish').mockImplementation(async (): Promise<void> => {});
     // Start typing - we will wait/type a few times to ensure the timer is resetting
     await room.typing.start();
     // wait for half the timers timeout
@@ -73,10 +69,10 @@ describe('Typing', () => {
   it<TestContext>('when stop is called, immediately stops typing', async (context) => {
     const { realtime, room } = context;
     const channel = room.typing.channel;
-    const presence = realtime.channels.get(channel.name).presence;
+    const realtimeChannel = realtime.channels.get(channel.name);
 
-    // If stop is called, it should call leaveClient
-    vi.spyOn(presence, 'leaveClient').mockImplementation(async (): Promise<void> => {});
+    // If stop is called, it should publish a leave message
+    vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
 
     // Start typing and then immediately stop typing
     await room.typing.start();
@@ -85,63 +81,55 @@ describe('Typing', () => {
     // The timer should be stopped and so waiting beyond timeout should not trigger stop again
     await new Promise((resolve) => setTimeout(resolve, TEST_TYPING_TIMEOUT_MS * 2));
 
-    // Ensure that leaveClient was called only once by the stop method and not again when the timer expires
-    expect(presence.leaveClient).toHaveBeenCalledOnce();
+    expect(realtimeChannel.publish).toHaveBeenCalledTimes(2);
+    // Ensure that publish was called with typing.started only once
+    expect(realtimeChannel.publish).toHaveBeenCalledWith(TypingEvents.Start, {});
+    // Ensure that publish was called with typing.stopped only once
+    expect(realtimeChannel.publish).toHaveBeenCalledWith(TypingEvents.Stop, {});
   });
 
   it<TestContext>('allows listeners to be unsubscribed', async (context) => {
     const { room } = context;
 
     // Add a listener
-    const receivedEvents: TypingEvent[] = [];
-    const { unsubscribe } = room.typing.subscribe((event: TypingEvent) => {
+    const receivedEvents: TypingEventPayload[] = [];
+    const { unsubscribe } = room.typing.subscribe((event: TypingEventPayload) => {
       receivedEvents.push(event);
     });
 
     // Another listener used to receive all events, to make sure events were emitted
-    const allEvents: TypingEvent[] = [];
-    const allSubscription = room.typing.subscribe((event: TypingEvent) => {
+    const allEvents: TypingEventPayload[] = [];
+    const allSubscription = room.typing.subscribe((event: TypingEventPayload) => {
       allEvents.push(event);
-    });
-
-    const channel = context.room.typing.channel;
-
-    let arrayToReturn = presenceGetResponse(['otherClient']);
-
-    vi.spyOn(channel.presence, 'get').mockImplementation(() => {
-      return Promise.resolve<Ably.PresenceMessage[]>(arrayToReturn);
     });
 
     // Emulate a typing event
     context.emulateBackendPublish({
+      name: TypingEvents.Start,
       clientId: 'otherClient',
-      action: 'enter',
     });
 
     await waitForArrayLength(receivedEvents, 1);
-    expect(channel.presence.get).toBeCalledTimes(1);
 
     // Ensure that the listener received the event
     expect(receivedEvents).toHaveLength(1);
     expect(receivedEvents[0]).toEqual({
+      type: TypingEvents.Start,
+      clientId: 'otherClient',
       currentlyTyping: new Set(['otherClient']),
     });
 
     // Unsubscribe the listener
     unsubscribe();
 
-    // set presence.get() to return anotherClient too
-    arrayToReturn = presenceGetResponse(['otherClient', 'anotherClient']);
-
     // Emulate another typing event for anotherClient
     context.emulateBackendPublish({
+      name: TypingEvents.Start,
       clientId: 'anotherClient',
-      action: 'enter',
     });
 
     // wait for check events to be length 2 to make sure second event was triggered
     await waitForArrayLength(allEvents, 2);
-    expect(channel.presence.get).toBeCalledTimes(2);
     expect(allEvents.length).toEqual(2);
     expect(allEvents[1]?.currentlyTyping).toEqual(new Set(['otherClient', 'anotherClient']));
 
@@ -158,35 +146,30 @@ describe('Typing', () => {
     const { room } = context;
 
     // Add a listener
-    const receivedEvents: TypingEvent[] = [];
-    const { unsubscribe } = room.typing.subscribe((event: TypingEvent) => {
+    const receivedEvents: TypingEventPayload[] = [];
+    const { unsubscribe } = room.typing.subscribe((event: TypingEventPayload) => {
       receivedEvents.push(event);
     });
 
     // Add another
-    const receivedEvents2: TypingEvent[] = [];
-    const { unsubscribe: unsubscribe2 } = room.typing.subscribe((event: TypingEvent) => {
+    const receivedEvents2: TypingEventPayload[] = [];
+    const { unsubscribe: unsubscribe2 } = room.typing.subscribe((event: TypingEventPayload) => {
       receivedEvents2.push(event);
-    });
-
-    const channel = context.room.typing.channel;
-    let arrayToReturn = presenceGetResponse(['otherClient']);
-    vi.spyOn(channel.presence, 'get').mockImplementation(() => {
-      return Promise.resolve<Ably.PresenceMessage[]>(arrayToReturn);
     });
 
     // Emulate a typing event
     context.emulateBackendPublish({
+      name: TypingEvents.Start,
       clientId: 'otherClient',
-      action: 'enter',
     });
 
     await waitForArrayLength(receivedEvents, 1);
-    expect(channel.presence.get).toBeCalledTimes(1);
 
     // Ensure that the listener received the event
     expect(receivedEvents).toHaveLength(1);
     expect(receivedEvents[0]).toEqual({
+      type: TypingEvents.Start,
+      clientId: 'otherClient',
       currentlyTyping: new Set(['otherClient']),
     });
 
@@ -194,6 +177,8 @@ describe('Typing', () => {
     // Ensure that the second listener received the event
     expect(receivedEvents2).toHaveLength(1);
     expect(receivedEvents2[0]).toEqual({
+      type: TypingEvents.Start,
+      clientId: 'otherClient',
       currentlyTyping: new Set(['otherClient']),
     });
 
@@ -201,19 +186,18 @@ describe('Typing', () => {
     room.typing.unsubscribeAll();
 
     // subscribe a check subscriber
-    const checkEvents: TypingEvent[] = [];
+    const checkEvents: TypingEventPayload[] = [];
     room.typing.subscribe((event) => {
       checkEvents.push(event);
     });
 
     // Emulate another typing event
-    arrayToReturn = presenceGetResponse(['otherClient', 'anotherClient2']);
     context.emulateBackendPublish({
+      name: TypingEvents.Start,
       clientId: 'anotherClient2',
-      action: 'enter',
     });
+
     await waitForArrayLength(checkEvents, 1);
-    expect(channel.presence.get).toBeCalledTimes(2);
     expect(checkEvents[0]?.currentlyTyping).toEqual(new Set(['otherClient', 'anotherClient2']));
 
     // Ensure that the listeners did not receive the event
@@ -225,40 +209,62 @@ describe('Typing', () => {
     unsubscribe2();
   });
 
-  type PresenceTestParam = Omit<Ably.PresenceMessage, 'action' | 'clientId'>;
-
   describe.each([
-    ['no client id', { connectionId: '', id: '', encoding: '', timestamp: 0, extras: {}, data: {} }],
-    ['empty client id', { clientId: '', connectionId: '', id: '', encoding: '', timestamp: 0, extras: {}, data: {} }],
-  ])('invalid incoming presence messages: %s', (description: string, inbound: PresenceTestParam) => {
-    const invalidPresenceTest = (context: TestContext, presenceAction: Ably.PresenceAction) => {
+    [
+      'no client id',
+      {
+        name: TypingEvents.Start,
+        connectionId: '',
+        id: '',
+        encoding: '',
+        timestamp: 0,
+        extras: {},
+        data: {},
+      } as Ably.InboundMessage,
+    ],
+    [
+      'empty client id',
+      {
+        name: TypingEvents.Start,
+        clientId: '',
+        connectionId: '',
+        id: '',
+        encoding: '',
+        timestamp: 0,
+        extras: {},
+        data: {},
+      } as Ably.InboundMessage,
+    ],
+    [
+      'unhandled event name',
+      {
+        name: 'notATypingEvent',
+        clientId: 'someClient',
+        connectionId: '',
+        id: '',
+        encoding: '',
+        timestamp: 0,
+        extras: {},
+        data: {},
+      } as Ably.InboundMessage,
+    ],
+  ])('invalid incoming typing messages: %s', (description: string, inbound: Ably.InboundMessage) => {
+    test<TestContext>(`does not process invalid incoming typing messages: ${description}`, (context) => {
       const { room } = context;
 
       // Subscribe to typing events
-      const receivedEvents: TypingEvent[] = [];
-      room.typing.subscribe((event: TypingEvent) => {
+      const receivedEvents: TypingEventPayload[] = [];
+      room.typing.subscribe((event: TypingEventPayload) => {
         receivedEvents.push(event);
       });
 
       // Emulate a typing event
       context.emulateBackendPublish({
         ...inbound,
-        action: presenceAction,
-      } as Ably.PresenceMessage);
+      } as Ably.InboundMessage);
 
       // Ensure that no typing events were received
       expect(receivedEvents).toHaveLength(0);
-    };
-
-    describe.each([
-      ['enter' as Ably.PresenceAction],
-      ['leave' as Ably.PresenceAction],
-      ['present' as Ably.PresenceAction],
-      ['update' as Ably.PresenceAction],
-    ])(`does not process invalid presence %s message: ${description}`, (presenceAction: Ably.PresenceAction) => {
-      test<TestContext>(`does not process invalid presence ${presenceAction} message: ${description}`, (context) => {
-        invalidPresenceTest(context, presenceAction);
-      });
     });
   });
 
@@ -268,136 +274,5 @@ describe('Typing', () => {
 
   it<TestContext>('has a detachment error code', (context) => {
     expect((context.room.typing as DefaultTyping).detachmentErrorCode).toBe(102054);
-  });
-
-  it<TestContext>('should not emit the same typing set twice', async (context) => {
-    const { room } = context;
-    const channel = context.room.typing.channel;
-
-    // Add a listener
-    const events: TypingEvent[] = [];
-    const { unsubscribe } = room.typing.subscribe((event: TypingEvent) => {
-      events.push(event);
-    });
-
-    const returnSet = new Set<string>();
-    vi.spyOn(channel.presence, 'get').mockImplementation(() => {
-      return Promise.resolve<Ably.PresenceMessage[]>(presenceGetResponse(returnSet));
-    });
-
-    let calledTimes = 0;
-    const simulateEnter = (clientId: string) => {
-      context.emulateBackendPublish({
-        clientId: clientId,
-        action: 'enter',
-      });
-      calledTimes++;
-    };
-
-    returnSet.add('client1');
-    simulateEnter('client1');
-    await waitForArrayLength(events, 1); // must be one event here
-
-    // these aren't faked in the presence.get() so should not trigger an event but only a call to presence.get
-    simulateEnter('client2');
-    simulateEnter('client3');
-
-    // add client4 and previously triggered client2 and client3
-    returnSet.add('client2');
-    returnSet.add('client3');
-    returnSet.add('client4');
-
-    simulateEnter('client4');
-    await waitForArrayLength(events, 2); // expecting only two events
-    expect(channel.presence.get).toBeCalledTimes(calledTimes);
-    expect(events).toHaveLength(2);
-    expect(events[0]?.currentlyTyping).toEqual(new Set(['client1'])); // first event unchanged
-    expect(events[1]?.currentlyTyping).toEqual(new Set(['client1', 'client2', 'client3', 'client4'])); // second event has all clients
-
-    await new Promise((resolve) => setTimeout(resolve, 500)); // make sure there won't be more messages
-    expect(events).toHaveLength(2);
-
-    unsubscribe();
-  });
-
-  it<TestContext>('should retry on failure', async (context) => {
-    const { room } = context;
-    const channel = context.room.typing.channel;
-
-    // Add a listener
-    const events: TypingEvent[] = [];
-    room.typing.subscribe((event: TypingEvent) => {
-      events.push(event);
-    });
-
-    let callNum = 0;
-    vi.spyOn(channel.presence, 'get').mockImplementation(() => {
-      callNum++;
-      if (callNum === 1) {
-        return Promise.reject<Ably.PresenceMessage[]>(new Error('faked error'));
-      } else {
-        return Promise.resolve<Ably.PresenceMessage[]>(presenceGetResponse(['client1']));
-      }
-    });
-
-    context.emulateBackendPublish({
-      clientId: 'client1',
-      action: 'enter',
-    });
-
-    await waitForArrayLength(events, 1, 4000); // must be one event here but extra wait time for the retry
-    expect(channel.presence.get).toBeCalledTimes(2); // second call for the retry
-    expect(events).toHaveLength(1);
-    expect(events[0]?.currentlyTyping).toEqual(new Set(['client1']));
-  });
-
-  it<TestContext>('should not return stale responses even if they resolve out of order', async (context) => {
-    const { room } = context;
-    const channel = context.room.typing.channel;
-
-    // Add a listener
-    const events: TypingEvent[] = [];
-    room.typing.subscribe((event: TypingEvent) => {
-      events.push(event);
-    });
-
-    let stopWaiting: () => void;
-    const waitForThis = new Promise<void>((accept) => {
-      stopWaiting = accept;
-    });
-
-    let callNum = 0;
-    vi.spyOn(channel.presence, 'get').mockImplementation(() => {
-      callNum++;
-      if (callNum === 1) {
-        return new Promise((accept) => {
-          setTimeout(() => {
-            accept(presenceGetResponse(['client1']));
-            setTimeout(stopWaiting, 500); // delay stopWaiting to give a chance for any messages that might happen
-          }, 500);
-        });
-      } else {
-        return new Promise((accept) => {
-          setTimeout(() => {
-            accept(presenceGetResponse(['client1', 'client2']));
-          }, 100);
-        });
-      }
-    });
-
-    context.emulateBackendPublish({
-      clientId: 'client1',
-      action: 'enter',
-    });
-
-    context.emulateBackendPublish({
-      clientId: 'client2',
-      action: 'enter',
-    });
-
-    await waitForThis; // at this point we should have exactly one message
-    expect(channel.presence.get).toBeCalledTimes(2);
-    expect(events).toHaveLength(1);
-    expect(events[0]?.currentlyTyping).toEqual(new Set(['client1', 'client2']));
   });
 });

--- a/test/core/typing.test.ts
+++ b/test/core/typing.test.ts
@@ -97,7 +97,7 @@ describe('Typing', () => {
     // Start the first typing operation
     const startPromise1 = new Promise<void>((resolve, reject) => {
       room.typing
-        .start()
+        .keystroke()
         .then(() => {
           resolveOrder.push('startPromise');
           resolve();
@@ -140,7 +140,7 @@ describe('Typing', () => {
       const { room } = context;
       vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('detached');
 
-      await expect(room.typing.start()).rejects.toBeErrorInfoWithCode(50000);
+      await expect(room.typing.keystroke()).rejects.toBeErrorInfoWithCode(50000);
     });
 
     // CHA-T4a
@@ -154,7 +154,7 @@ describe('Typing', () => {
       vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
 
       // Start typing
-      await room.typing.start();
+      await room.typing.keystroke();
 
       // Ensure that publish was called with typing.started
       expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
@@ -178,7 +178,7 @@ describe('Typing', () => {
       vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
 
       // Start typing
-      await room.typing.start();
+      await room.typing.keystroke();
 
       // Ensure that publish was called with typing.started
       expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
@@ -191,7 +191,7 @@ describe('Typing', () => {
       expect(defaultTyping.heartbeatTimerId).toBeDefined();
 
       // Start typing again
-      await room.typing.start();
+      await room.typing.keystroke();
 
       // Ensure that publish was not called again
       expect(realtimeChannel.publish).toHaveBeenCalledTimes(1);
@@ -223,7 +223,7 @@ describe('Typing', () => {
         const realtimeChannel = realtime.channels.get(channel.name);
         vi.spyOn(realtimeChannel, 'publish').mockImplementation(async (): Promise<void> => {});
         vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
-        await room.typing.start();
+        await room.typing.keystroke();
         vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('detached');
 
         await expect(room.typing.stop()).rejects.toBeErrorInfoWithCode(50000);
@@ -242,7 +242,7 @@ describe('Typing', () => {
         vi.spyOn(room.typing.channel, 'state', 'get').mockReturnValue('attached');
 
         // Start typing and then immediately stop typing
-        await room.typing.start();
+        await room.typing.keystroke();
         await room.typing.stop();
 
         expect(realtimeChannel.publish).toHaveBeenCalledTimes(2);

--- a/test/react/hooks/use-typing.integration.test.tsx
+++ b/test/react/hooks/use-typing.integration.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render, waitFor } from '@testing-library/react';
 import React, { useEffect } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { TypingEventPayload } from '../../../src/core/events.ts';
+import { TypingEvent } from '../../../src/core/events.ts';
 import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { RoomStatus } from '../../../src/core/room-status.ts';
 import { TypingListener } from '../../../src/core/typing.ts';
@@ -29,7 +29,7 @@ describe('useTyping', () => {
     await roomTwo.attach();
 
     // start listening for typing events on room two
-    const typingEventsRoomTwo: TypingEventPayload[] = [];
+    const typingEventsRoomTwo: TypingEvent[] = [];
     roomTwo.typing.subscribe((typingEvent) => typingEventsRoomTwo.push(typingEvent));
 
     const TestComponent = () => {
@@ -60,7 +60,6 @@ describe('useTyping', () => {
 
     render(<TestProvider />);
 
-
     // expect the hook to send a start, followed by a stop typing event
     await waitForArrayLength(typingEventsRoomTwo, 2);
     expect(typingEventsRoomTwo[0]?.currentlyTyping).toStrictEqual(new Set([chatClientOne.clientId]));
@@ -77,7 +76,7 @@ describe('useTyping', () => {
     await roomTwo.attach();
 
     // store the received typing events for room one
-    const typingEventsRoomOne: TypingEventPayload[] = [];
+    const typingEventsRoomOne: TypingEvent[] = [];
 
     // store the currently typing state from the hook
     let currentlyTypingSet = new Set<string>();

--- a/test/react/hooks/use-typing.integration.test.tsx
+++ b/test/react/hooks/use-typing.integration.test.tsx
@@ -33,16 +33,16 @@ describe('useTyping', () => {
     roomTwo.typing.subscribe((typingEvent) => typingEventsRoomTwo.push(typingEvent));
 
     const TestComponent = () => {
-      const { start, stop, roomStatus } = useTyping();
+      const { keystroke, stop, roomStatus } = useTyping();
 
       useEffect(() => {
         if (roomStatus !== RoomStatus.Attached) return;
-        void start().then(() => {
+        void keystroke().then(() => {
           setTimeout(() => {
             void stop();
           }, 500);
         });
-      }, [start, stop, roomStatus]);
+      }, [keystroke, stop, roomStatus]);
 
       return null;
     };
@@ -117,7 +117,7 @@ describe('useTyping', () => {
     );
 
     // send a typing started event from the second room
-    await roomTwo.typing.start();
+    await roomTwo.typing.keystroke();
 
     // expect a typing started event from the second room to be received by the test component
     await waitForArrayLength(typingEventsRoomOne, 1);

--- a/test/react/hooks/use-typing.integration.test.tsx
+++ b/test/react/hooks/use-typing.integration.test.tsx
@@ -1,10 +1,11 @@
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, render, waitFor } from '@testing-library/react';
 import React, { useEffect } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { TypingEventPayload } from '../../../src/core/events.ts';
 import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { RoomStatus } from '../../../src/core/room-status.ts';
-import { TypingEvent, TypingListener } from '../../../src/core/typing.ts';
+import { TypingListener } from '../../../src/core/typing.ts';
 import { useTyping } from '../../../src/react/hooks/use-typing.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
@@ -28,7 +29,7 @@ describe('useTyping', () => {
     await roomTwo.attach();
 
     // start listening for typing events on room two
-    const typingEventsRoomTwo: TypingEvent[] = [];
+    const typingEventsRoomTwo: TypingEventPayload[] = [];
     roomTwo.typing.subscribe((typingEvent) => typingEventsRoomTwo.push(typingEvent));
 
     const TestComponent = () => {
@@ -59,6 +60,7 @@ describe('useTyping', () => {
 
     render(<TestProvider />);
 
+
     // expect the hook to send a start, followed by a stop typing event
     await waitForArrayLength(typingEventsRoomTwo, 2);
     expect(typingEventsRoomTwo[0]?.currentlyTyping).toStrictEqual(new Set([chatClientOne.clientId]));
@@ -75,16 +77,17 @@ describe('useTyping', () => {
     await roomTwo.attach();
 
     // store the received typing events for room one
-    const typingEventsRoomOne: TypingEvent[] = [];
+    const typingEventsRoomOne: TypingEventPayload[] = [];
 
     // store the currently typing state from the hook
     let currentlyTypingSet = new Set<string>();
-
+    let currentRoomStatus: RoomStatus | undefined;
     const TestComponent = ({ listener }: { listener: TypingListener }) => {
       // subscribe to typing events received by the test component
-      const { currentlyTyping } = useTyping({ listener: listener });
+      const { currentlyTyping, roomStatus } = useTyping({ listener: listener });
 
       currentlyTypingSet = currentlyTyping;
+      currentRoomStatus = roomStatus;
 
       return null;
     };
@@ -95,12 +98,24 @@ describe('useTyping', () => {
           id={roomId}
           options={AllFeaturesEnabled}
         >
-          <TestComponent listener={(typingEvent) => typingEventsRoomOne.push(typingEvent)} />
+          <TestComponent
+            listener={(typingEvent) => {
+              typingEventsRoomOne.push(typingEvent);
+            }}
+          />
         </ChatRoomProvider>
       </ChatClientProvider>
     );
 
     render(<TestProvider />);
+
+    // ensure we are attached first
+    await waitFor(
+      () => {
+        expect(currentRoomStatus).toBe(RoomStatus.Attached);
+      },
+      { timeout: 5000 },
+    );
 
     // send a typing started event from the second room
     await roomTwo.typing.start();

--- a/test/react/hooks/use-typing.integration.test.tsx
+++ b/test/react/hooks/use-typing.integration.test.tsx
@@ -123,8 +123,12 @@ describe('useTyping', () => {
     await waitForArrayLength(typingEventsRoomOne, 1);
     expect(typingEventsRoomOne[0]?.currentlyTyping).toStrictEqual(new Set([chatClientTwo.clientId]));
 
-    // ensure the currently typing set is updated
-    expect(currentlyTypingSet).toStrictEqual(new Set([chatClientTwo.clientId]));
+    await waitFor(
+      () => {
+        expect(currentlyTypingSet).toStrictEqual(new Set([chatClientTwo.clientId]));
+      },
+      { timeout: 5000 },
+    );
 
     // expect a typing stopped event from the second room to be received by the test component
     await roomTwo.typing.stop();

--- a/test/react/hooks/use-typing.test.tsx
+++ b/test/react/hooks/use-typing.test.tsx
@@ -105,19 +105,19 @@ describe('useTyping', () => {
     expect(mockUnsubscribe).toHaveBeenCalled();
   });
 
-  it('should correctly call the typing start method', async () => {
+  it('should correctly call the typing keystroke method', async () => {
     const { result } = renderHook(() => useTyping());
 
-    // spy on the start method of the typing instance
-    const startSpy = vi.spyOn(mockRoom.typing, 'start').mockImplementation(() => Promise.resolve());
+    // spy on the keystroke method of the typing instance
+    const keystrokeSpy = vi.spyOn(mockRoom.typing, 'keystroke').mockImplementation(() => Promise.resolve());
 
-    // call the start method
+    // call the keystroke method
     await act(async () => {
-      await result.current.start();
+      await result.current.keystroke();
     });
 
-    // verify that the start method was called
-    expect(startSpy).toHaveBeenCalled();
+    // verify that the keystroke method was called
+    expect(keystrokeSpy).toHaveBeenCalled();
   });
 
   it('should correctly call the typing stop method', async () => {

--- a/test/react/hooks/use-typing.test.tsx
+++ b/test/react/hooks/use-typing.test.tsx
@@ -47,9 +47,7 @@ describe('useTyping', () => {
   beforeEach(() => {
     // create a new mock room before each test, enabling typing
     vi.resetAllMocks();
-    updateMockRoom(
-      makeRandomRoom({ options: { typing: { timeoutMs: 500, inactivityTimeoutMs: 1000, heartbeatIntervalMs: 500 } } }),
-    );
+    updateMockRoom(makeRandomRoom({ options: { typing: { heartbeatThrottleMs: 500 } } }));
     mockLogger = makeTestLogger();
   });
 
@@ -93,7 +91,10 @@ describe('useTyping', () => {
     await waitForEventualHookValueToBeDefined(result, (value) => value.typingIndicators);
 
     // verify that subscribe was called with the mock listener on mount by triggering an event
-    const typingEvent = { clientId: 'someClientId', currentlyTyping: new Set<string>(), type: TypingEvents.Stop };
+    const typingEvent = {
+      change: { clientId: 'someClientId', type: TypingEvents.Stop },
+      currentlyTyping: new Set<string>(),
+    };
     for (const listener of mockTyping.listeners) {
       listener(typingEvent);
     }
@@ -166,7 +167,7 @@ describe('useTyping', () => {
     // emit a typing event which should update the DOM
     act(() => {
       if (subscribedListener) {
-        subscribedListener({ clientId: 'user2', currentlyTyping: testSet, type: TypingEvents.Start });
+        subscribedListener({ change: { clientId: 'user2', type: TypingEvents.Start }, currentlyTyping: testSet });
       }
     });
 
@@ -213,9 +214,7 @@ describe('useTyping', () => {
       makeRandomRoom({
         options: {
           typing: {
-            timeoutMs: 500,
-            inactivityTimeoutMs: 1000,
-            heartbeatIntervalMs: 500,
+            heartbeatThrottleMs: 500,
           },
         },
       }),


### PR DESCRIPTION
### Context

* As part of the move to a single channel, we needed to rethink how typing works, since both typing and chat presence would have to use the same underlying realtimePresence instance. We played with the idea of a shared presence set, but this added a bit too much complexity in the SDK. 
* Instead, we decided to use heartbeats that will be published similar to the way room reactions are currently. 
* More information can be found in [CHADR-093]

### Description

* Updated the typing class to remove presence and use channel.publish() to send heartbeats

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

* Open the demo app and play around with the typing component.