### PR TITLE
Add Subscription interface

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -31,16 +31,9 @@ export type {
   UpdateMessageParams,
 } from './messages.js';
 export type { Metadata } from './metadata.js';
-export type { Occupancy, OccupancyEvent, OccupancyListener, OccupancySubscriptionResponse } from './occupancy.js';
+export type { Occupancy, OccupancyEvent, OccupancyListener } from './occupancy.js';
 export type { OperationMetadata } from './operation-metadata.js';
-export type {
-  Presence,
-  PresenceData,
-  PresenceEvent,
-  PresenceListener,
-  PresenceMember,
-  PresenceSubscriptionResponse,
-} from './presence.js';
+export type { Presence, PresenceData, PresenceEvent, PresenceListener, PresenceMember } from './presence.js';
 export type { PaginatedResult } from './query.js';
 export type { Reaction } from './reaction.js';
 export type { Room } from './room.js';
@@ -52,14 +45,10 @@ export type {
   TypingOptions,
 } from './room-options.js';
 export { AllFeaturesEnabled } from './room-options.js';
-export type {
-  RoomReactionListener,
-  RoomReactions,
-  RoomReactionsSubscriptionResponse,
-  SendReactionParams,
-} from './room-reactions.js';
+export type { RoomReactionListener, RoomReactions, SendReactionParams } from './room-reactions.js';
 export type { OnRoomStatusChangeResponse, RoomStatusChange, RoomStatusListener } from './room-status.js';
 export { RoomStatus } from './room-status.js';
 export type { Rooms } from './rooms.js';
-export type { Typing, TypingEvent, TypingListener, TypingSubscriptionResponse } from './typing.js';
+export type { Subscription } from './subscription.js';
+export type { Typing, TypingEvent, TypingListener } from './typing.js';
 export type { ChannelStateChange, ErrorInfo, RealtimePresenceParams } from 'ably';

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -18,6 +18,7 @@ import { DefaultMessage, Message, MessageHeaders, MessageMetadata, MessageOperat
 import { parseMessage } from './message-parser.js';
 import { PaginatedResult } from './query.js';
 import { ContributesToRoomLifecycle } from './room-lifecycle-manager.js';
+import { Subscription } from './subscription.js';
 import EventEmitter from './utils/event-emitter.js';
 
 /**
@@ -174,12 +175,7 @@ export type MessageListener = (event: MessageEventPayload) => void;
 /**
  * A response object that allows you to control a message subscription.
  */
-export interface MessageSubscriptionResponse {
-  /**
-   * Unsubscribe the listener registered with {@link Messages.subscribe} from message events.
-   */
-  unsubscribe: () => void;
-
+export interface MessageSubscriptionResponse extends Subscription {
   /**
    * Get the previous messages that were sent to the room before the listener was subscribed.
    * @param params Options for the history query.

--- a/src/core/occupancy.ts
+++ b/src/core/occupancy.ts
@@ -14,6 +14,7 @@ import {
 import { ErrorCodes } from './errors.js';
 import { Logger } from './logger.js';
 import { ContributesToRoomLifecycle } from './room-lifecycle-manager.js';
+import { Subscription } from './subscription.js';
 import EventEmitter from './utils/event-emitter.js';
 
 /**
@@ -29,7 +30,7 @@ export interface Occupancy extends EmitsDiscontinuities {
    * @param listener A listener to be called when the occupancy of the room changes.
    * @returns A promise resolves to the channel attachment state change event from the implicit channel attach operation.
    */
-  subscribe(listener: OccupancyListener): OccupancySubscriptionResponse;
+  subscribe(listener: OccupancyListener): Subscription;
 
   /**
    * Unsubscribe all listeners from the occupancy updates of the chat room.
@@ -64,16 +65,6 @@ export interface OccupancyEvent {
    * The number of presence members in the chat room - members who have entered presence.
    */
   presenceMembers: number;
-}
-
-/**
- * A response object that allows you to control an occupancy update subscription.
- */
-export interface OccupancySubscriptionResponse {
-  /**
-   * Unsubscribe the listener registered with {@link Occupancy.subscribe} from occupancy updates.
-   */
-  unsubscribe: () => void;
 }
 
 /**
@@ -134,7 +125,7 @@ export class DefaultOccupancy
   /**
    * @inheritdoc Occupancy
    */
-  subscribe(listener: OccupancyListener): OccupancySubscriptionResponse {
+  subscribe(listener: OccupancyListener): Subscription {
     this._logger.trace('Occupancy.subscribe();');
     this.on(listener);
 

--- a/src/core/presence.ts
+++ b/src/core/presence.ts
@@ -15,6 +15,7 @@ import { PresenceEvents } from './events.js';
 import { Logger } from './logger.js';
 import { ContributesToRoomLifecycle } from './room-lifecycle-manager.js';
 import { RoomOptions } from './room-options.js';
+import { Subscription } from './subscription.js';
 import EventEmitter from './utils/event-emitter.js';
 
 /**
@@ -104,16 +105,6 @@ export interface PresenceMember {
 export type PresenceListener = (event: PresenceEvent) => void;
 
 /**
- * A response object that allows you to control a presence subscription.
- */
-export interface PresenceSubscriptionResponse {
-  /**
-   * Unsubscribe the listener registered with {@link Presence.subscribe} from all presence events.
-   */
-  unsubscribe: () => void;
-}
-
-/**
  * This interface is used to interact with presence in a chat room: subscribing to presence events,
  * fetching presence members, or sending presence events (join,update,leave).
  *
@@ -160,16 +151,13 @@ export interface Presence extends EmitsDiscontinuities {
    * @param eventOrEvents {'enter' | 'leave' | 'update' | 'present'} single event name or array of events to subscribe to
    * @param listener listener to subscribe
    */
-  subscribe(
-    eventOrEvents: PresenceEvents | PresenceEvents[],
-    listener?: PresenceListener,
-  ): PresenceSubscriptionResponse;
+  subscribe(eventOrEvents: PresenceEvents | PresenceEvents[], listener?: PresenceListener): Subscription;
 
   /**
    * Subscribe the given listener to all presence events.
    * @param listener listener to subscribe
    */
-  subscribe(listener?: PresenceListener): PresenceSubscriptionResponse;
+  subscribe(listener?: PresenceListener): Subscription;
 
   /**
    * Unsubscribe all listeners from all presence events.
@@ -302,19 +290,16 @@ export class DefaultPresence
    * @param eventOrEvents {'enter' | 'leave' | 'update' | 'present'} single event name or array of events to subscribe to
    * @param listener listener to subscribe
    */
-  subscribe(
-    eventOrEvents: PresenceEvents | PresenceEvents[],
-    listener?: PresenceListener,
-  ): PresenceSubscriptionResponse;
+  subscribe(eventOrEvents: PresenceEvents | PresenceEvents[], listener?: PresenceListener): Subscription;
   /**
    * Subscribe the given listener to all presence events.
    * @param listener listener to subscribe
    */
-  subscribe(listener?: PresenceListener): PresenceSubscriptionResponse;
+  subscribe(listener?: PresenceListener): Subscription;
   subscribe(
     listenerOrEvents?: PresenceEvents | PresenceEvents[] | PresenceListener,
     listener?: PresenceListener,
-  ): PresenceSubscriptionResponse {
+  ): Subscription {
     this._logger.trace('Presence.subscribe(); listenerOrEvents', { listenerOrEvents });
     if (!listenerOrEvents && !listener) {
       this._logger.error('could not subscribe to presence; invalid arguments');

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -15,6 +15,7 @@ import { Logger } from './logger.js';
 import { Reaction, ReactionHeaders, ReactionMetadata } from './reaction.js';
 import { parseReaction } from './reaction-parser.js';
 import { ContributesToRoomLifecycle } from './room-lifecycle-manager.js';
+import { Subscription } from './subscription.js';
 import EventEmitter from './utils/event-emitter.js';
 
 /**
@@ -92,7 +93,7 @@ export interface RoomReactions extends EmitsDiscontinuities {
    * @param listener The listener function to be called when a reaction is received.
    * @returns A response object that allows you to control the subscription.
    */
-  subscribe(listener: RoomReactionListener): RoomReactionsSubscriptionResponse;
+  subscribe(listener: RoomReactionListener): Subscription;
 
   /**
    * Unsubscribe all listeners from receiving room-level reaction events.
@@ -115,16 +116,6 @@ interface RoomReactionEventsMap {
 interface ReactionPayload {
   type: string;
   metadata?: ReactionMetadata;
-}
-
-/**
- * A response object that allows you to control the subscription to room-level reactions.
- */
-export interface RoomReactionsSubscriptionResponse {
-  /**
-   * Unsubscribe the listener registered with {@link RoomReactions.subscribe} from reaction events.
-   */
-  unsubscribe: () => void;
 }
 
 /**
@@ -197,7 +188,7 @@ export class DefaultRoomReactions
   /**
    * @inheritDoc Reactions
    */
-  subscribe(listener: RoomReactionListener): RoomReactionsSubscriptionResponse {
+  subscribe(listener: RoomReactionListener): Subscription {
     this._logger.trace(`RoomReactions.subscribe();`);
     this.on(listener);
 

--- a/src/core/subscription.ts
+++ b/src/core/subscription.ts
@@ -1,0 +1,21 @@
+/**
+ * Represents a subscription that can be unsubscribed from.
+ * This interface provides a way to clean up and remove subscriptions when they
+ * are no longer needed.
+ *
+ * @interface
+ * @example
+ * ```typescript
+ * const s = someService.subscribe();
+ * // Later when done with the subscription
+ * s.unsubscribe();
+ * ```
+ */
+export interface Subscription {
+  /**
+   * This method should be called when the subscription is no longer needed,
+   * it will make sure no further events will be sent to the subscriber and
+   * that references to the subscriber are cleaned up.
+   */
+  unsubscribe: () => void;
+}

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -15,6 +15,7 @@ import { TypingEvents } from './events.js';
 import { Logger } from './logger.js';
 import { ContributesToRoomLifecycle } from './room-lifecycle-manager.js';
 import { TypingOptions } from './room-options.js';
+import { Subscription } from './subscription.js';
 import EventEmitter from './utils/event-emitter.js';
 
 const PRESENCE_GET_RETRY_INTERVAL_MS = 1500; // base retry interval, we double it each time
@@ -34,7 +35,7 @@ export interface Typing extends EmitsDiscontinuities {
    * @param listener A listener to be called when the typing state of a user in the room changes.
    * @returns A response object that allows you to control the subscription to typing events.
    */
-  subscribe(listener: TypingListener): TypingSubscriptionResponse;
+  subscribe(listener: TypingListener): Subscription;
 
   /**
    * Unsubscribe all listeners from receiving typing events.
@@ -88,16 +89,6 @@ export interface TypingEvent {
  * @param event The typing event.
  */
 export type TypingListener = (event: TypingEvent) => void;
-
-/**
- * A response object that allows you to control the subscription to typing events.
- */
-export interface TypingSubscriptionResponse {
-  /**
-   * Unsubscribe the listener registered with {@link Typing.subscribe} from typing events.
-   */
-  unsubscribe: () => void;
-}
 
 /**
  * Represents the typing events mapped to their respective event payloads.
@@ -226,7 +217,7 @@ export class DefaultTyping
   /**
    * @inheritDoc
    */
-  subscribe(listener: TypingListener): TypingSubscriptionResponse {
+  subscribe(listener: TypingListener): Subscription {
     this._logger.trace(`DefaultTyping.subscribe();`);
     this.on(listener);
 


### PR DESCRIPTION
Replace specialised `...SubscriptionResponse` types with the new `Subscription` interface where applicable.

### Context

- [CHA-885]
- CHADR-94

### Description

We currently have many identical interface types. This PR turns them into a single one. 

Note: not touching the ones that have `off()` as unsubscribe in this PR, will come back to those later.

### Checklist

* [x] QA'd by the author.
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).

### Testing Instructions (Optional)

Only types were changed, no functional changes.