### PR TITLE
add copy method to message, message update signature

### DIFF
--- a/demo/src/components/ChatBoxComponent/ChatBoxComponent.tsx
+++ b/demo/src/components/ChatBoxComponent/ChatBoxComponent.tsx
@@ -109,11 +109,13 @@ export const ChatBoxComponent: FC<ChatBoxComponentProps> = () => {
       if (!newText) {
         return;
       }
-      update(message, {
-        text: newText,
-        metadata: message.metadata,
-        headers: message.headers,
-      })
+      update(
+        message.copy({
+          text: newText,
+          metadata: message.metadata,
+          headers: message.headers,
+        }),
+      )
         .then((updatedMessage: Message) => {
           handleRESTMessageUpdate(updatedMessage);
         })

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -18,7 +18,14 @@ export { ChatMessageActions, MessageEvents, PresenceEvents } from './events.js';
 export type { Headers } from './headers.js';
 export type { LogContext, Logger, LogHandler } from './logger.js';
 export { LogLevel } from './logger.js';
-export type { Message, MessageHeaders, MessageMetadata, MessageOperationMetadata, Operation } from './message.js';
+export type {
+  Message,
+  MessageCopyParams,
+  MessageHeaders,
+  MessageMetadata,
+  MessageOperationMetadata,
+  Operation,
+} from './message.js';
 export type {
   DeleteMessageParams,
   MessageListener,
@@ -28,7 +35,6 @@ export type {
   OrderBy,
   QueryOptions,
   SendMessageParams,
-  UpdateMessageParams,
 } from './messages.js';
 export type { Metadata } from './metadata.js';
 export type { Occupancy, OccupancyEvent, OccupancyListener } from './occupancy.js';

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -230,6 +230,34 @@ export interface Message {
    *    as an event for an old version, the same message is returned (not a copy).
    */
   with(event: MessageEvent): Message;
+
+  /**
+   * Creates a copy of the message with fields replaced per the parameters.
+   *
+   * @param params The parameters to replace in the message.
+   * @return The message copy.
+   */
+  copy(params?: MessageCopyParams): Message;
+}
+
+/**
+ * Parameters for copying a message.
+ */
+export interface MessageCopyParams {
+  /**
+   * The text of the copied message.
+   */
+  text?: string;
+
+  /**
+   * The metadata of the copied message.
+   */
+  metadata?: MessageMetadata;
+
+  /**
+   * The headers of the copied message.
+   */
+  headers?: MessageHeaders;
 }
 
 /**
@@ -329,5 +357,26 @@ export class DefaultMessage implements Message {
     }
 
     return this.version >= event.message.version ? this : event.message;
+  }
+
+  copy(params: MessageCopyParams = {}): Message {
+    return DefaultMessage._clone(this, params);
+  }
+
+  // Clone a message, optionally replace the given fields
+  private static _clone(source: Message, replace?: Partial<Message>): DefaultMessage {
+    return new DefaultMessage(
+      replace?.serial ?? source.serial,
+      replace?.clientId ?? source.clientId,
+      replace?.roomId ?? source.roomId,
+      replace?.text ?? source.text,
+      replace?.metadata ?? structuredClone(source.metadata),
+      replace?.headers ?? structuredClone(source.headers),
+      replace?.action ?? source.action,
+      replace?.version ?? source.version,
+      replace?.createdAt ?? source.createdAt,
+      replace?.timestamp ?? source.timestamp,
+      replace?.operation ?? structuredClone(source.operation),
+    );
   }
 }

--- a/src/react/hooks/use-messages.ts
+++ b/src/react/hooks/use-messages.ts
@@ -10,7 +10,6 @@ import {
   OperationDetails,
   QueryOptions,
   SendMessageParams,
-  UpdateMessageParams,
 } from '../../core/messages.js';
 import { wrapRoomPromise } from '../helper/room-promise.js';
 import { useEventListenerRef } from '../helper/use-event-listener-ref.js';
@@ -117,8 +116,8 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
     [context],
   );
   const update = useCallback(
-    (message: Message, update: UpdateMessageParams, details?: OperationDetails) =>
-      context.room.then((room) => room.messages.update(message, update, details)),
+    (message: Message, details?: OperationDetails) =>
+      context.room.then((room) => room.messages.update(message, details)),
     [context],
   );
 

--- a/test/core/message.test.ts
+++ b/test/core/message.test.ts
@@ -519,4 +519,128 @@ describe('ChatMessage', () => {
       expect(newMessage === message).toBe(true);
     });
   });
+
+  describe('message copy', () => {
+    it('copies a message with updated fields', () => {
+      const originalMessage = new DefaultMessage(
+        '01672531200000-123@abcdefghij',
+        'clientId',
+        'roomId',
+        'original text',
+        { key: 'value' },
+        { headerKey: 'headerValue' },
+        ChatMessageActions.MessageCreate,
+        'version1',
+        new Date(1672531200000),
+        new Date(1672531200000),
+      );
+
+      const copiedMessage = originalMessage.copy({
+        text: 'updated text',
+        metadata: { newKey: 'newValue' },
+      });
+
+      expect(copiedMessage.text).toBe('updated text');
+      expect(copiedMessage.metadata).toEqual({ newKey: 'newValue' });
+      expect(copiedMessage.headers).toEqual({ headerKey: 'headerValue' });
+      expect(copiedMessage.serial).toBe(originalMessage.serial);
+      expect(copiedMessage.clientId).toBe(originalMessage.clientId);
+      expect(copiedMessage.roomId).toBe(originalMessage.roomId);
+      expect(copiedMessage.action).toBe(originalMessage.action);
+      expect(copiedMessage.version).toBe(originalMessage.version);
+      expect(copiedMessage.createdAt).toEqual(originalMessage.createdAt);
+      expect(copiedMessage.timestamp).toEqual(originalMessage.timestamp);
+    });
+
+    it('copies a message without changes when no parameters are provided', () => {
+      const originalMessage = new DefaultMessage(
+        '01672531200000-123@abcdefghij',
+        'clientId',
+        'roomId',
+        'original text',
+        { key: 'value' },
+        { headerKey: 'headerValue' },
+        ChatMessageActions.MessageCreate,
+        'version1',
+        new Date(1672531200000),
+        new Date(1672531200000),
+      );
+
+      const copiedMessage = originalMessage.copy();
+
+      expect(copiedMessage.text).toBe(originalMessage.text);
+      expect(copiedMessage.metadata).toEqual(originalMessage.metadata);
+      expect(copiedMessage.headers).toEqual(originalMessage.headers);
+      expect(copiedMessage.serial).toBe(originalMessage.serial);
+      expect(copiedMessage.clientId).toBe(originalMessage.clientId);
+      expect(copiedMessage.roomId).toBe(originalMessage.roomId);
+      expect(copiedMessage.action).toBe(originalMessage.action);
+      expect(copiedMessage.version).toBe(originalMessage.version);
+      expect(copiedMessage.createdAt).toEqual(originalMessage.createdAt);
+      expect(copiedMessage.timestamp).toEqual(originalMessage.timestamp);
+    });
+
+    it('ensures deep copy of metadata and headers', () => {
+      const originalMessage = new DefaultMessage(
+        '01672531200000-123@abcdefghij',
+        'clientId',
+        'roomId',
+        'original text',
+        { key: 'value', nested: { key: 'nestedValue' } },
+        { headerKey: 'headerValue' },
+        ChatMessageActions.MessageCreate,
+        'version1',
+        new Date(1672531200000),
+        new Date(1672531200000),
+      );
+
+      const copiedMessage = originalMessage.copy();
+
+      // Modify the original message's metadata and headers
+      originalMessage.metadata.key = 'newValue';
+      originalMessage.headers.headerKey = 'newHeaderValue';
+
+      // Ensure the copied message's metadata and headers remain unchanged
+      expect(copiedMessage.metadata.key).toBe('value');
+      expect(copiedMessage.headers.headerKey).toBe('headerValue');
+
+      // Check the nested data is deep copied
+      const metadata = copiedMessage.metadata as { nested: { key: string } };
+      expect(metadata.nested.key).toBe('nestedValue');
+      expect(metadata.nested).not.toBe(originalMessage.metadata.nested);
+    });
+
+    it('ensures deep replacement of metadata and headers', () => {
+      const originalMessage = new DefaultMessage(
+        '01672531200000-123@abcdefghij',
+        'clientId',
+        'roomId',
+        'original text',
+        { key: 'value', nested: { key: 'nestedValue' } },
+        { headerKey: 'headerValue' },
+        ChatMessageActions.MessageCreate,
+        'version1',
+        new Date(1672531200000),
+        new Date(1672531200000),
+      );
+
+      const copiedMessage = originalMessage.copy({
+        metadata: { key: 'newValue', nested: { key: 'newNestedValue' } },
+      });
+
+      // Modify the original message's metadata and headers
+      originalMessage.metadata.key = 'abc';
+      originalMessage.headers.headerKey = 'def';
+
+      // Ensure the copied message's metadata and headers remain unchanged
+      expect(copiedMessage.headers).not.toBe(originalMessage.headers);
+
+      // Check the nested data is deep copied
+      expect(copiedMessage.metadata).not.toBe(originalMessage.metadata);
+      expect(copiedMessage.metadata.key).toEqual('newValue');
+      const metadata = copiedMessage.metadata as { nested: { key: string } };
+      expect(metadata.nested.key).toBe('newNestedValue');
+      expect(metadata.nested).not.toBe(originalMessage.metadata.nested);
+    });
+  });
 });

--- a/test/core/messages.integration.test.ts
+++ b/test/core/messages.integration.test.ts
@@ -183,7 +183,7 @@ describe('messages integration', { timeout: 10000 }, () => {
 
     // send a message, and then update it
     const message1 = await room.messages.send({ text: 'Hello there!' });
-    const updated1 = await room.messages.update(message1, { text: 'bananas' });
+    const updated1 = await room.messages.update(message1.copy({ text: 'bananas' }));
 
     expect(updated1.text).toBe('bananas');
     expect(updated1.serial).toBe(message1.serial);
@@ -301,11 +301,9 @@ describe('messages integration', { timeout: 10000 }, () => {
     const message1 = await room.messages.send({ text: 'Hello there!' });
 
     // Update the message
-    const updatedMessage1 = await room.messages.update(
-      message1,
-      { text: 'Hello test!' },
-      { description: 'updated message' },
-    );
+    const updatedMessage1 = await room.messages.update(message1.copy({ text: 'Hello test!' }), {
+      description: 'updated message',
+    });
 
     // Do a history request to get the update message
     await new Promise((resolve) => setTimeout(resolve, 3000)); // wait for persistence - this will not be necessary in the future

--- a/test/react/hooks/use-messages.integration.test.tsx
+++ b/test/react/hooks/use-messages.integration.test.tsx
@@ -157,12 +157,11 @@ describe('useMessages', () => {
         if (roomStatus === RoomStatus.Attached) {
           void send({ text: 'hello world' }).then((message) => {
             void update(
-              message,
-              {
+              message.copy({
                 text: 'hello universe',
                 metadata: { icon: 'universe' },
                 headers: { awesome: 'yes' },
-              },
+              }),
               {
                 description: 'make it better',
                 metadata: { something: 'else' },

--- a/test/react/hooks/use-messages.test.tsx
+++ b/test/react/hooks/use-messages.test.tsx
@@ -130,6 +130,7 @@ describe('useMessages', () => {
         with: vi.fn(),
         headers: {},
         metadata: {},
+        copy: vi.fn(),
       },
     };
     for (const listener of messageListeners) listener(messageEvent);


### PR DESCRIPTION
### Context

[CHA-865]
CHADR-092

### Description

Adds a copy method to message, to allow copies to be made with different values.

Also changes the signature of messages.update to take an updated copy of message, instead of second parameter.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A


[CHA-865]: https://ably.atlassian.net/browse/CHA-865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ