### PR TITLE
refactor: common type for off-able subscriptions

### DIFF
--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -1,6 +1,7 @@
 import * as Ably from 'ably';
 
 import { Logger } from './logger.js';
+import { StatusSubscription } from './subscription.js';
 import EventEmitter from './utils/event-emitter.js';
 
 /**
@@ -76,16 +77,6 @@ export interface ConnectionStatusChange {
 export type ConnectionStatusListener = (change: ConnectionStatusChange) => void;
 
 /**
- * The response from the `onStatusChange` method.
- */
-export interface OnConnectionStatusChangeResponse {
-  /**
-   * Unregisters the listener that was added by the `onStatusChange` method.
-   */
-  off: () => void;
-}
-
-/**
  * Represents a connection to Ably.
  */
 export interface Connection {
@@ -104,7 +95,7 @@ export interface Connection {
    * @param listener The function to call when the status changes.
    * @returns An object that can be used to unregister the listener.
    */
-  onStatusChange(listener: ConnectionStatusListener): OnConnectionStatusChangeResponse;
+  onStatusChange(listener: ConnectionStatusListener): StatusSubscription;
 
   /**
    * Removes all listeners that were added by the `onStatusChange` method.
@@ -194,7 +185,7 @@ export class DefaultConnection extends EventEmitter<ConnectionEventsMap> impleme
   /**
    * @inheritdoc
    */
-  onStatusChange(listener: ConnectionStatusListener): OnConnectionStatusChangeResponse {
+  onStatusChange(listener: ConnectionStatusListener): StatusSubscription {
     this.on(listener);
 
     return {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,12 +4,7 @@
 
 export { ChatClient } from './chat.js';
 export type { ChatClientOptions } from './config.js';
-export type {
-  Connection,
-  ConnectionStatusChange,
-  ConnectionStatusListener,
-  OnConnectionStatusChangeResponse,
-} from './connection.js';
+export type { Connection, ConnectionStatusChange, ConnectionStatusListener } from './connection.js';
 export { ConnectionStatus } from './connection.js';
 export type { DiscontinuityListener, OnDiscontinuitySubscriptionResponse } from './discontinuity.js';
 export { ErrorCodes, errorInfoIs } from './errors.js';
@@ -52,9 +47,9 @@ export type {
 } from './room-options.js';
 export { AllFeaturesEnabled } from './room-options.js';
 export type { RoomReactionListener, RoomReactions, SendReactionParams } from './room-reactions.js';
-export type { OnRoomStatusChangeResponse, RoomStatusChange, RoomStatusListener } from './room-status.js';
+export type { RoomStatusChange, RoomStatusListener } from './room-status.js';
 export { RoomStatus } from './room-status.js';
 export type { Rooms } from './rooms.js';
-export type { Subscription } from './subscription.js';
+export type { StatusSubscription, Subscription } from './subscription.js';
 export type { Typing, TypingEvent, TypingListener } from './typing.js';
 export type { ChannelStateChange, ErrorInfo, RealtimePresenceParams } from 'ably';

--- a/src/core/room-status.ts
+++ b/src/core/room-status.ts
@@ -1,6 +1,7 @@
 import * as Ably from 'ably';
 
 import { Logger } from './logger.js';
+import { StatusSubscription } from './subscription.js';
 import EventEmitter from './utils/event-emitter.js';
 
 /**
@@ -87,16 +88,6 @@ export interface RoomStatusChange {
 export type RoomStatusListener = (change: RoomStatusChange) => void;
 
 /**
- * The response from the `onChange` method.
- */
-export interface OnRoomStatusChangeResponse {
-  /**
-   * Unregisters the listener that was added by the `onChange` method.
-   */
-  off: () => void;
-}
-
-/**
  * Represents the status of a Room.
  */
 export interface RoomLifecycle {
@@ -115,7 +106,7 @@ export interface RoomLifecycle {
    * @param listener The function to call when the status changes.
    * @returns An object that can be used to unregister the listener.
    */
-  onChange(listener: RoomStatusListener): OnRoomStatusChangeResponse;
+  onChange(listener: RoomStatusListener): StatusSubscription;
 
   /**
    * Removes all listeners that were added by the `onChange` method.
@@ -201,7 +192,7 @@ export class DefaultRoomLifecycle extends EventEmitter<RoomStatusEventsMap> impl
   /**
    * @inheritdoc
    */
-  onChange(listener: RoomStatusListener): OnRoomStatusChangeResponse {
+  onChange(listener: RoomStatusListener): StatusSubscription {
     this.on(listener);
 
     return {

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -10,13 +10,8 @@ import { DefaultPresence, Presence } from './presence.js';
 import { ContributesToRoomLifecycle, RoomLifecycleManager } from './room-lifecycle-manager.js';
 import { NormalizedRoomOptions, RoomOptions, validateRoomOptions } from './room-options.js';
 import { DefaultRoomReactions, RoomReactions } from './room-reactions.js';
-import {
-  DefaultRoomLifecycle,
-  InternalRoomLifecycle,
-  OnRoomStatusChangeResponse,
-  RoomStatus,
-  RoomStatusListener,
-} from './room-status.js';
+import { DefaultRoomLifecycle, InternalRoomLifecycle, RoomStatus, RoomStatusListener } from './room-status.js';
+import { StatusSubscription } from './subscription.js';
 import { DefaultTyping, Typing } from './typing.js';
 
 /**
@@ -85,7 +80,7 @@ export interface Room {
    * @param listener The function to call when the status changes.
    * @returns An object that can be used to unregister the listener.
    */
-  onStatusChange(listener: RoomStatusListener): OnRoomStatusChangeResponse;
+  onStatusChange(listener: RoomStatusListener): StatusSubscription;
 
   /**
    * Removes all listeners that were added by the `onStatusChange` method.
@@ -328,7 +323,7 @@ export class DefaultRoom implements Room {
   /**
    * @inheritdoc Room
    */
-  onStatusChange(listener: RoomStatusListener): OnRoomStatusChangeResponse {
+  onStatusChange(listener: RoomStatusListener): StatusSubscription {
     return this._lifecycle.onChange(listener);
   }
 

--- a/src/core/subscription.ts
+++ b/src/core/subscription.ts
@@ -19,3 +19,25 @@ export interface Subscription {
    */
   unsubscribe: () => void;
 }
+/**
+ * Represents a subscription to status change events that can be unsubscribed from. This
+ * interface provides a way to clean up and remove subscriptions when they are no longer needed.
+ *
+ * @interface
+ * @example
+ * ```typescript
+ * const s = someService.onStatusChange();
+ * const s2 = someOtherService.on()
+ * // Later when done with the subscription
+ * s.off();
+ * s2.off();
+ * ```
+ */
+export interface StatusSubscription {
+  /**
+   * Unsubscribes from the status change events. It will ensure that no
+   * further status change events will be sent to the subscriber and
+   * that references to the subscriber are cleaned up.
+   */
+  off: () => void;
+}


### PR DESCRIPTION
### Description

Following on from https://github.com/ably/ably-chat-js/pull/487, adds a common interface for subscription removal that is "off" based, e.g "onStatusChange". This allows us to remove redundant, copied types.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A
