### PR TITLE
test: use vi.waitFor

### DIFF
--- a/test/core/messages.integration.test.ts
+++ b/test/core/messages.integration.test.ts
@@ -10,6 +10,7 @@ import { AllFeaturesEnabled } from '../../src/core/room-options.ts';
 import { RoomStatus } from '../../src/core/room-status.ts';
 import { CHANNEL_OPTIONS_AGENT_STRING } from '../../src/core/version.ts';
 import { newChatClient } from '../helper/chat.ts';
+import { waitForArrayLength } from '../helper/common.ts';
 import { randomRoomId } from '../helper/identifier.ts';
 import { ablyRealtimeClient } from '../helper/realtime-client.ts';
 import { getRandomRoom, waitForRoomStatus } from '../helper/room.ts';
@@ -17,21 +18,6 @@ import { getRandomRoom, waitForRoomStatus } from '../helper/room.ts';
 interface TestContext {
   chat: ChatClient;
 }
-
-const waitForMessages = (messages: Message[], expectedCount: number) => {
-  return new Promise<void>((resolve, reject) => {
-    const interval = setInterval(() => {
-      if (messages.length === expectedCount) {
-        clearInterval(interval);
-        resolve();
-      }
-    }, 100);
-    setTimeout(() => {
-      clearInterval(interval);
-      reject(new Error('Timed out waiting for messages'));
-    }, 3000);
-  });
-};
 
 describe('messages integration', { timeout: 10000 }, () => {
   beforeEach<TestContext>((context) => {
@@ -65,7 +51,7 @@ describe('messages integration', { timeout: 10000 }, () => {
     const message2 = await room.messages.send({ text: 'I have the high ground!' });
 
     // Wait up to 5 seconds for the messagesPromise to resolve
-    await waitForMessages(messages, 2);
+    await waitForArrayLength(messages, 2);
 
     // Check that the messages were received
     expect(messages).toEqual([
@@ -127,8 +113,8 @@ describe('messages integration', { timeout: 10000 }, () => {
     expect(deletedMessage1.deletedBy).toEqual(deletedMessage1.operation?.clientId);
 
     // Wait up to 5 seconds for the promises to resolve
-    await waitForMessages(messages, 1);
-    await waitForMessages(deletions, 1);
+    await waitForArrayLength(messages, 1);
+    await waitForArrayLength(deletions, 1);
 
     // Check that the message was received
     expect(messages).toEqual([
@@ -192,8 +178,8 @@ describe('messages integration', { timeout: 10000 }, () => {
     expect(updated1.updatedBy).toBe(chat.clientId);
 
     // Wait up to 5 seconds for the promises to resolve
-    await waitForMessages(messages, 1);
-    await waitForMessages(updates, 1);
+    await waitForArrayLength(messages, 1);
+    await waitForArrayLength(updates, 1);
 
     // Check that the message was received
     expect(messages).toEqual([
@@ -564,7 +550,7 @@ describe('messages integration', { timeout: 10000 }, () => {
     });
 
     // Wait up to 5 seconds for the messagesPromise to resolve
-    await waitForMessages(messages, 2);
+    await waitForArrayLength(messages, 2);
 
     const expectedMessages = [
       {

--- a/test/helper/common.ts
+++ b/test/helper/common.ts
@@ -1,3 +1,5 @@
+import { expect, vi } from 'vitest';
+
 import { OccupancyEvent } from '../../src/core/occupancy.ts';
 
 export function waitForExpectedInbandOccupancy(
@@ -5,23 +7,25 @@ export function waitForExpectedInbandOccupancy(
   expectedOccupancy: OccupancyEvent,
   timeoutMs: number,
 ): Promise<void> {
-  return new Promise<void>((resolve) => {
-    const interval = setInterval(() => {
+  return vi.waitFor(
+    () => {
       const occupancy = occupancyEvents.find(
         (occupancy) =>
           occupancy.connections === expectedOccupancy.connections &&
           occupancy.presenceMembers === expectedOccupancy.presenceMembers,
       );
 
-      if (occupancy) {
-        clearInterval(interval);
-        resolve();
-      }
-    }, 1000);
-
-    setTimeout(() => {
-      clearInterval(interval);
-      resolve();
-    }, timeoutMs);
-  });
+      expect(occupancy).toBeDefined();
+    },
+    { timeout: timeoutMs, interval: 1000 },
+  );
 }
+
+export const waitForArrayLength = async (array: unknown[], expectedCount: number, timeoutMs = 3000): Promise<void> => {
+  await vi.waitFor(
+    () => {
+      expect(array.length).toBe(expectedCount);
+    },
+    { timeout: timeoutMs, interval: 100 },
+  );
+};

--- a/test/react/hooks/use-messages.integration.test.tsx
+++ b/test/react/hooks/use-messages.integration.test.tsx
@@ -12,22 +12,8 @@ import { useMessages } from '../../../src/react/hooks/use-messages.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
 import { newChatClient } from '../../helper/chat.ts';
+import { waitForArrayLength } from '../../helper/common.ts';
 import { randomRoomId } from '../../helper/identifier.ts';
-
-function waitForMessages(messages: Message[], expectedCount: number) {
-  return new Promise<void>((resolve, reject) => {
-    const interval = setInterval(() => {
-      if (messages.length === expectedCount) {
-        clearInterval(interval);
-        resolve();
-      }
-    }, 100);
-    setTimeout(() => {
-      clearInterval(interval);
-      reject(new Error('Timed out waiting for messages'));
-    }, 5000);
-  });
-}
 
 describe('useMessages', () => {
   afterEach(() => {
@@ -74,7 +60,7 @@ describe('useMessages', () => {
     render(<TestProvider />);
 
     // expect a message to be received by the second room
-    await waitForMessages(messagesRoomTwo, 1);
+    await waitForArrayLength(messagesRoomTwo, 1);
     expect(messagesRoomTwo[0]?.text).toBe('hello world');
   }, 10000);
 
@@ -127,7 +113,7 @@ describe('useMessages', () => {
     render(<TestProvider />);
 
     // expect a message to be received by the second room
-    await waitForMessages(deletionsRoomTwo, 1);
+    await waitForArrayLength(deletionsRoomTwo, 1);
     expect(deletionsRoomTwo[0]?.isDeleted).toBe(true);
     expect(deletionsRoomTwo[0]?.deletedBy).toBe(chatClientOne.clientId);
   }, 10000);
@@ -188,7 +174,7 @@ describe('useMessages', () => {
     render(<TestProvider />);
 
     // expect a message to be received by the second room
-    await waitForMessages(updatesRoomTwo, 1);
+    await waitForArrayLength(updatesRoomTwo, 1);
     expect(updatesRoomTwo.length).toBe(1);
     const update = updatesRoomTwo[0];
     expect(update?.isUpdated).toBe(true);
@@ -251,7 +237,7 @@ describe('useMessages', () => {
     await roomTwo.messages.send({ text: 'hello world' });
 
     // expect a message to be received by the first room
-    await waitForMessages(messagesRoomOne, 1);
+    await waitForArrayLength(messagesRoomOne, 1);
     expect(messagesRoomOne[0]?.text).toBe('hello world');
   }, 10000);
 

--- a/test/react/hooks/use-presence-listener.integration.test.tsx
+++ b/test/react/hooks/use-presence-listener.integration.test.tsx
@@ -9,22 +9,8 @@ import { usePresenceListener } from '../../../src/react/hooks/use-presence-liste
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
 import { newChatClient } from '../../helper/chat.ts';
+import { waitForArrayLength } from '../../helper/common.ts';
 import { randomRoomId } from '../../helper/identifier.ts';
-
-function waitForPresenceEvents(presenceEvents: PresenceEvent[], expectedCount: number) {
-  return new Promise<void>((resolve, reject) => {
-    const interval = setInterval(() => {
-      if (presenceEvents.length === expectedCount) {
-        clearInterval(interval);
-        resolve();
-      }
-    }, 100);
-    setTimeout(() => {
-      clearInterval(interval);
-      reject(new Error('Timed out waiting for presence events'));
-    }, 10000);
-  });
-}
 
 describe('usePresenceListener', () => {
   afterEach(() => {
@@ -90,7 +76,7 @@ describe('usePresenceListener', () => {
     await roomTwo.presence.update('test update');
 
     // expect a presence enter and update event from the test component to be received
-    await waitForPresenceEvents(presenceEventsReceived, 2);
+    await waitForArrayLength(presenceEventsReceived, 2);
     expect(presenceEventsReceived[0]?.clientId).toBe(chatClientTwo.clientId);
     expect(presenceEventsReceived[0]?.data).toBe('test enter');
     expect(presenceEventsReceived[1]?.clientId).toBe(chatClientTwo.clientId);

--- a/test/react/hooks/use-room-reactions.integration.test.tsx
+++ b/test/react/hooks/use-room-reactions.integration.test.tsx
@@ -10,22 +10,8 @@ import { useRoomReactions } from '../../../src/react/hooks/use-room-reactions.ts
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
 import { newChatClient } from '../../helper/chat.ts';
+import { waitForArrayLength } from '../../helper/common.ts';
 import { randomRoomId } from '../../helper/identifier.ts';
-
-function waitForReactions(reactions: Reaction[], expectedCount: number) {
-  return new Promise<void>((resolve, reject) => {
-    const interval = setInterval(() => {
-      if (reactions.length === expectedCount) {
-        clearInterval(interval);
-        resolve();
-      }
-    }, 100);
-    setTimeout(() => {
-      clearInterval(interval);
-      reject(new Error('Timed out waiting for reactions'));
-    }, 3000);
-  });
-}
 
 describe('useRoomReactions', () => {
   afterEach(() => {
@@ -77,7 +63,7 @@ describe('useRoomReactions', () => {
 
     render(<TestProvider />);
 
-    await waitForReactions(reactions, 1);
+    await waitForArrayLength(reactions, 1);
 
     // check the reaction was received
     expect(reactions.find((reaction) => reaction.type === 'like')).toBeTruthy();
@@ -133,7 +119,7 @@ describe('useRoomReactions', () => {
     // send a reaction from the second room
     await roomTwo.reactions.send({ type: 'love' });
 
-    await waitForReactions(reactions, 1);
+    await waitForArrayLength(reactions, 1);
 
     // check the reaction was received
     expect(reactions.find((reaction) => reaction.type === 'love')).toBeTruthy();

--- a/test/react/hooks/use-typing.integration.test.tsx
+++ b/test/react/hooks/use-typing.integration.test.tsx
@@ -9,22 +9,8 @@ import { useTyping } from '../../../src/react/hooks/use-typing.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
 import { newChatClient } from '../../helper/chat.ts';
+import { waitForArrayLength } from '../../helper/common.ts';
 import { randomRoomId } from '../../helper/identifier.ts';
-
-function waitForTypingEvents(typingEvents: TypingEvent[], expectedCount: number) {
-  return new Promise<void>((resolve, reject) => {
-    const interval = setInterval(() => {
-      if (typingEvents.length === expectedCount) {
-        clearInterval(interval);
-        resolve();
-      }
-    }, 100);
-    setTimeout(() => {
-      clearInterval(interval);
-      reject(new Error('Timed out waiting for typing events'));
-    }, 5000);
-  });
-}
 
 describe('useTyping', () => {
   afterEach(() => {
@@ -74,7 +60,7 @@ describe('useTyping', () => {
     render(<TestProvider />);
 
     // expect the hook to send a start, followed by a stop typing event
-    await waitForTypingEvents(typingEventsRoomTwo, 2);
+    await waitForArrayLength(typingEventsRoomTwo, 2);
     expect(typingEventsRoomTwo[0]?.currentlyTyping).toStrictEqual(new Set([chatClientOne.clientId]));
     expect(typingEventsRoomTwo[1]?.currentlyTyping).toStrictEqual(new Set());
   }, 10000);
@@ -120,7 +106,7 @@ describe('useTyping', () => {
     await roomTwo.typing.start();
 
     // expect a typing started event from the second room to be received by the test component
-    await waitForTypingEvents(typingEventsRoomOne, 1);
+    await waitForArrayLength(typingEventsRoomOne, 1);
     expect(typingEventsRoomOne[0]?.currentlyTyping).toStrictEqual(new Set([chatClientTwo.clientId]));
 
     // ensure the currently typing set is updated
@@ -128,7 +114,7 @@ describe('useTyping', () => {
 
     // expect a typing stopped event from the second room to be received by the test component
     await roomTwo.typing.stop();
-    await waitForTypingEvents(typingEventsRoomOne, 2);
+    await waitForArrayLength(typingEventsRoomOne, 2);
     expect(typingEventsRoomOne[1]?.currentlyTyping).toStrictEqual(new Set());
 
     // ensure the currently typing set is updated


### PR DESCRIPTION
### Context

[CHA-864]

### Description

We currently have a lot of methods that use custom promise loops, rather than using the vi.waitFor helper.

This change:

- Replaces promise loops with vi.waitFor
- Replaces duplicate methods, e.g. assertions that just check an array length after some time

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

Run tests!


[CHA-864]: https://ably.atlassian.net/browse/CHA-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ