### PR TITLE
fix/messages: export OrderBy fully, not as type

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -27,10 +27,10 @@ export type {
   Messages,
   MessageSubscriptionResponse,
   OperationDetails,
-  OrderBy,
   QueryOptions,
   SendMessageParams,
 } from './messages.js';
+export { OrderBy } from './messages.js';
 export type { Metadata } from './metadata.js';
 export type { Occupancy, OccupancyEvent, OccupancyListener } from './occupancy.js';
 export type { OperationMetadata } from './operation-metadata.js';


### PR DESCRIPTION
### Context

Fixes #502
[CHA-873]

### Description

We were previously exporting OrderBy as a type and not in full, This means that users cannot do things like:

const foo = OrderBy.NewestFirst;

This change changes the export type, to make it possible to use the actual enum and not just as a type hint.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

Try using a value of the `OrderBy` enum in the demo app, if it lets you, then this fix has worked!

[CHA-873]: https://ably.atlassian.net/browse/CHA-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ