### PR TITLE
feature: chat on a single channel

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -2,7 +2,7 @@ import { FC, useEffect, useState } from 'react';
 import { Chat } from './containers/Chat';
 import { OccupancyComponent } from './components/OccupancyComponent';
 import { UserPresenceComponent } from './components/UserPresenceComponent';
-import { AllFeaturesEnabled, ChatRoomProvider } from '@ably/chat';
+import { ChatRoomProvider } from '@ably/chat';
 
 // We read the roomID from the URL query string and default to 'abcd' if none
 // provided. We make sure the URL is updated to always include the roomId. This
@@ -52,7 +52,7 @@ const App: FC<AppProps> = () => {
       id={roomIdState}
       release={true}
       attach={true}
-      options={AllFeaturesEnabled}
+      options={{ occupancy: { enableInboundOccupancy: true } }}
     >
       <div
         style={{ display: 'flex', justifyContent: 'space-between', width: '800px', margin: 'auto', height: '650px' }}

--- a/src/core/channel-manager.ts
+++ b/src/core/channel-manager.ts
@@ -24,7 +24,7 @@ export class ChannelManager {
   }
 
   mergeOptions(merger: ChannelOptionsMerger): void {
-    this._logger.trace('ChannelManager.registerOptions();');
+    this._logger.trace('ChannelManager.mergeOptions();');
     if (this._resolvedChannel) {
       this._logger.error('channel options cannot be modified after the channel has been requested');
       throw new Ably.ErrorInfo('channel options cannot be modified after the channel has been requested', 40000, 400);

--- a/src/core/channel-manager.ts
+++ b/src/core/channel-manager.ts
@@ -1,5 +1,6 @@
 import * as Ably from 'ably';
 
+import { roomChannelName } from './channel.js';
 import { Logger } from './logger.js';
 import { DEFAULT_CHANNEL_OPTIONS, DEFAULT_CHANNEL_OPTIONS_REACT } from './version.js';
 
@@ -8,42 +9,46 @@ export type ChannelOptionsMerger = (options: Ably.ChannelOptions) => Ably.Channe
 export class ChannelManager {
   private readonly _realtime: Ably.Realtime;
   private readonly _logger: Logger;
-  private readonly _registeredOptions = new Map<string, Ably.ChannelOptions>();
-  private readonly _requestedChannels = new Set<string>();
-  private readonly _isReact;
+  private _registeredOptions: Ably.ChannelOptions;
+  private readonly _isReact: boolean;
+  private _resolvedChannel?: Ably.RealtimeChannel;
+  private readonly _channelId: string;
 
-  constructor(realtime: Ably.Realtime, logger: Logger, isReact: boolean) {
+  constructor(roomId: string, realtime: Ably.Realtime, logger: Logger, isReact: boolean) {
     logger.trace('ChannelManager();', { isReact });
     this._realtime = realtime;
     this._logger = logger;
     this._isReact = isReact;
+    this._registeredOptions = this._defaultChannelOptions();
+    this._channelId = roomChannelName(roomId);
   }
 
-  mergeOptions(channelName: string, merger: ChannelOptionsMerger): void {
-    this._logger.trace('ChannelManager.registerOptions();', { channelName });
-    if (this._requestedChannels.has(channelName)) {
-      this._logger.error('channel options cannot be modified after the channel has been requested', { channelName });
+  mergeOptions(merger: ChannelOptionsMerger): void {
+    this._logger.trace('ChannelManager.registerOptions();');
+    if (this._resolvedChannel) {
+      this._logger.error('channel options cannot be modified after the channel has been requested');
       throw new Ably.ErrorInfo('channel options cannot be modified after the channel has been requested', 40000, 400);
     }
 
-    const currentOpts = this._registeredOptions.get(channelName) ?? this._defaultChannelOptions();
-    this._registeredOptions.set(channelName, merger(currentOpts));
+    this._registeredOptions = merger(this._registeredOptions);
   }
 
-  get(channelName: string): Ably.RealtimeChannel {
-    this._logger.trace('ChannelManager.get();', { channelName });
-    this._requestedChannels.add(channelName);
-    return this._realtime.channels.get(
-      channelName,
-      this._registeredOptions.get(channelName) ?? this._defaultChannelOptions(),
-    );
+  get(): Ably.RealtimeChannel {
+    this._logger.trace('ChannelManager.get();');
+    if (!this._resolvedChannel) {
+      this._resolvedChannel = this._realtime.channels.get(this._channelId, this._registeredOptions);
+    }
+
+    return this._resolvedChannel;
   }
 
-  release(channelName: string): void {
-    this._logger.trace('ChannelManager.release();', { channelName });
-    this._requestedChannels.delete(channelName);
-    this._registeredOptions.delete(channelName);
-    this._realtime.channels.release(channelName);
+  release(): void {
+    this._logger.trace('ChannelManager.release();', { channelId: this._channelId });
+    if (!this._resolvedChannel) {
+      return;
+    }
+
+    this._realtime.channels.release(this._channelId);
   }
 
   private _defaultChannelOptions(): Ably.ChannelOptions {

--- a/src/core/channel.ts
+++ b/src/core/channel.ts
@@ -1,11 +1,4 @@
 /**
- * Get the channel name for the chat messages channel.
- * @param roomId The room ID.
- * @returns The channel name.
- */
-export const messagesChannelName = (roomId: string): string => `${roomId}::$chat::$chatMessages`;
-
-/**
  * Gets the single main channel for the chat room.
  *
  * @param roomId The room ID.

--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -121,7 +121,7 @@ export class ChatApi {
       }
     }
 
-    const data = await this._makeAuthorizedPaginatedRequest<Message>(`/chat/v2/rooms/${roomId}/messages`, apiParams);
+    const data = await this._makeAuthorizedPaginatedRequest<Message>(`/chat/v3/rooms/${roomId}/messages`, apiParams);
     return this._recursivePaginateMessages(data);
   }
 
@@ -163,7 +163,7 @@ export class ChatApi {
     serial = encodeURIComponent(serial);
     roomId = encodeURIComponent(roomId);
     return this._makeAuthorizedRequest<DeleteMessageResponse>(
-      `/chat/v2/rooms/${roomId}/messages/${serial}/delete`,
+      `/chat/v3/rooms/${roomId}/messages/${serial}/delete`,
       'POST',
       body,
       {},
@@ -183,14 +183,14 @@ export class ChatApi {
       body.headers = params.headers;
     }
     roomId = encodeURIComponent(roomId);
-    return this._makeAuthorizedRequest<CreateMessageResponse>(`/chat/v2/rooms/${roomId}/messages`, 'POST', body);
+    return this._makeAuthorizedRequest<CreateMessageResponse>(`/chat/v3/rooms/${roomId}/messages`, 'POST', body);
   }
 
   async updateMessage(roomId: string, serial: string, params: UpdateMessageParams): Promise<UpdateMessageResponse> {
     const encodedSerial = encodeURIComponent(serial);
     roomId = encodeURIComponent(roomId);
     return this._makeAuthorizedRequest<UpdateMessageResponse>(
-      `/chat/v2/rooms/${roomId}/messages/${encodedSerial}`,
+      `/chat/v3/rooms/${roomId}/messages/${encodedSerial}`,
       'PUT',
       params,
     );
@@ -198,7 +198,7 @@ export class ChatApi {
 
   async getOccupancy(roomId: string): Promise<OccupancyEvent> {
     roomId = encodeURIComponent(roomId);
-    return this._makeAuthorizedRequest<OccupancyEvent>(`/chat/v1/rooms/${roomId}/occupancy`, 'GET');
+    return this._makeAuthorizedRequest<OccupancyEvent>(`/chat/v3/rooms/${roomId}/occupancy`, 'GET');
   }
 
   private async _makeAuthorizedRequest<RES = undefined>(

--- a/src/core/discontinuity.ts
+++ b/src/core/discontinuity.ts
@@ -1,62 +1,8 @@
 import * as Ably from 'ably';
 
-import EventEmitter from './utils/event-emitter.js';
-
 /**
- * Represents an object that has a channel and therefore may care about discontinuities.
+ * Handler for discontinuity events
+ *
+ * @param error - The error that occurred to cause the discontinuity.
  */
-export interface HandlesDiscontinuity {
-  /**
-   * A channel that this object is associated with.
-   */
-  get channel(): Ably.RealtimeChannel;
-
-  /**
-   * Called when a discontinuity is detected on the channel.
-   * @param reason The error that caused the discontinuity.
-   */
-  discontinuityDetected(reason?: Ably.ErrorInfo): void;
-}
-
-/**
- * A response to subscribing to discontinuity events that allows control of the subscription.
- */
-export interface OnDiscontinuitySubscriptionResponse {
-  /**
-   * Unsubscribe from discontinuity events.
-   */
-  off: () => void;
-}
-
-/**
- * A listener that can be registered for discontinuity events.
- * @param reason The error that caused the discontinuity.
- */
-export type DiscontinuityListener = (reason?: Ably.ErrorInfo) => void;
-
-/**
- * An interface to be implemented by objects that can emit discontinuities to listeners.
- */
-export interface EmitsDiscontinuities {
-  /**
-   * Register a listener to be called when a discontinuity is detected.
-   * @param listener The listener to be called when a discontinuity is detected.
-   * @returns A response that allows control of the subscription.
-   */
-  onDiscontinuity(listener: DiscontinuityListener): OnDiscontinuitySubscriptionResponse;
-}
-
-interface DiscontinuityEventMap {
-  ['discontinuity']: Ably.ErrorInfo | undefined;
-}
-
-/**
- * An event emitter specialization for discontinuity events.
- */
-export type DiscontinuityEmitter = EventEmitter<DiscontinuityEventMap>;
-
-/**
- * Creates a new discontinuity emitter.
- * @returns A new discontinuity emitter.
- */
-export const newDiscontinuityEmitter = (): DiscontinuityEmitter => new EventEmitter();
+export type DiscontinuityListener = (error: Ably.ErrorInfo) => void;

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -20,58 +20,6 @@ export enum ErrorCodes {
   MessageRejectedByModeration = 42213,
 
   /**
-   * The messages feature failed to attach.
-   */
-  MessagesAttachmentFailed = 102001,
-
-  /**
-   * The presence feature failed to attach.
-   */
-  PresenceAttachmentFailed = 102002,
-
-  /**
-   * The reactions feature failed to attach.
-   */
-  ReactionsAttachmentFailed = 102003,
-
-  /**
-   * The occupancy feature failed to attach.
-   */
-  OccupancyAttachmentFailed = 102004,
-
-  /**
-   * The typing feature failed to attach.
-   */
-  TypingAttachmentFailed = 102005,
-  // 102006 - 102049 reserved for future use for attachment errors
-
-  /**
-   * The messages feature failed to detach.
-   */
-  MessagesDetachmentFailed = 102050,
-
-  /**
-   * The presence feature failed to detach.
-   */
-  PresenceDetachmentFailed = 102051,
-
-  /**
-   * The reactions feature failed to detach.
-   */
-  ReactionsDetachmentFailed = 102052,
-
-  /**
-   * The occupancy feature failed to detach.
-   */
-  OccupancyDetachmentFailed = 102053,
-
-  /**
-   * The typing feature failed to detach.
-   */
-  TypingDetachmentFailed = 102054,
-  // 102055 - 102099 reserved for future use for detachment errors
-
-  /**
    * The room has experienced a discontinuity.
    */
   RoomDiscontinuity = 102100,

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -42,16 +42,6 @@ export enum ErrorCodes {
   RoomIsReleased = 102103,
 
   /**
-   * Cannot perform operation because the previous operation failed.
-   */
-  PreviousOperationFailed = 102104,
-
-  /**
-   * An unknown error has happened in the room lifecycle.
-   */
-  RoomLifecycleError = 102105,
-
-  /**
    * Room was released before the operation could complete.
    */
   RoomReleasedBeforeOperationCompleted = 102106,

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -134,3 +134,15 @@ export interface MessageEvent {
    */
   message: Message;
 }
+
+/**
+ * Room events.
+ */
+export enum RoomEvents {
+  /**
+   * Event triggered when a discontinuity is detected in the room's channel connection.
+   * A discontinuity occurs when an attached or update event comes from the channel with resume=false,
+   * except for the first attach or attaches after explicit detach calls.
+   */
+  Discontinuity = 'room.discontinuity',
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,7 +6,7 @@ export { ChatClient } from './chat.js';
 export type { ChatClientOptions } from './config.js';
 export type { Connection, ConnectionStatusChange, ConnectionStatusListener } from './connection.js';
 export { ConnectionStatus } from './connection.js';
-export type { DiscontinuityListener, OnDiscontinuitySubscriptionResponse } from './discontinuity.js';
+export type { DiscontinuityListener } from './discontinuity.js';
 export { ErrorCodes, errorInfoIs } from './errors.js';
 export type { MessageEvent, TypingEvent, TypingEvents } from './events.js';
 export { ChatMessageActions, MessageEvents, PresenceEvents } from './events.js';
@@ -38,18 +38,11 @@ export type { Presence, PresenceData, PresenceEvent, PresenceListener, PresenceM
 export type { PaginatedResult } from './query.js';
 export type { Reaction } from './reaction.js';
 export type { Room } from './room.js';
-export type {
-  OccupancyOptions,
-  PresenceOptions,
-  RoomOptions,
-  RoomReactionsOptions,
-  TypingOptions,
-} from './room-options.js';
-export { AllFeaturesEnabled } from './room-options.js';
+export type { OccupancyOptions, PresenceOptions, RoomOptions, TypingOptions } from './room-options.js';
 export type { RoomReactionListener, RoomReactions, SendReactionParams } from './room-reactions.js';
 export type { RoomStatusChange, RoomStatusListener } from './room-status.js';
 export { RoomStatus } from './room-status.js';
 export type { Rooms } from './rooms.js';
 export type { StatusSubscription, Subscription } from './subscription.js';
 export type { Typing, TypingListener } from './typing.js';
-export type { ChannelStateChange, ErrorInfo, RealtimePresenceParams } from 'ably';
+export type { ErrorInfo, RealtimePresenceParams } from 'ably';

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -156,9 +156,19 @@ export interface MessageSubscriptionResponse extends Subscription {
   /**
    * Get the previous messages that were sent to the room before the listener was subscribed.
    *
-   * If you are subscribed to and notified of a discontinuity event, this will reset the starting point of
-   * getPreviousMessages to the point at which a new series of continuity is started. When this happens, you should
-   * re-call getPreviousMessages to fill the gap.
+   * If the client experiences a discontinuity event (i.e. the connection was lost and could not be resumed), the starting point of
+   * getPreviousMessages will be reset.
+   *
+   * Calls to getPreviousMessages will wait for continuity to be restored before resolving.
+   *
+   * Once continuity is restored, the subscription point will be set to the beginning of this new period of continuity. To
+   * ensure that no messages are missed, you should call getPreviousMessages after any period of discontinuity to
+   * fill any gaps in the message history.
+   *
+   * ```typescript
+   * const { getPreviousMessages } = room.messages.subscribe(listener);
+   * await getPreviousMessages({ limit: 10 });
+   * ```
    *
    * @param params Options for the history query.
    * @returns A promise that resolves with the paginated result of messages, in newest-to-oldest order.

--- a/src/core/occupancy.ts
+++ b/src/core/occupancy.ts
@@ -1,18 +1,10 @@
 import * as Ably from 'ably';
 
-import { messagesChannelName } from './channel.js';
+import { roomChannelName } from './channel.js';
 import { ChannelManager, ChannelOptionsMerger } from './channel-manager.js';
 import { ChatApi } from './chat-api.js';
-import {
-  DiscontinuityListener,
-  EmitsDiscontinuities,
-  HandlesDiscontinuity,
-  newDiscontinuityEmitter,
-  OnDiscontinuitySubscriptionResponse,
-} from './discontinuity.js';
-import { ErrorCodes } from './errors.js';
 import { Logger } from './logger.js';
-import { ContributesToRoomLifecycle } from './room-lifecycle-manager.js';
+import { InternalRoomOptions } from './room-options.js';
 import { Subscription } from './subscription.js';
 import EventEmitter, { wrap } from './utils/event-emitter.js';
 
@@ -22,7 +14,7 @@ import EventEmitter, { wrap } from './utils/event-emitter.js';
  *
  * Get an instance via {@link Room.occupancy}.
  */
-export interface Occupancy extends EmitsDiscontinuities {
+export interface Occupancy {
   /**
    * Subscribe a given listener to occupancy updates of the chat room.
    *
@@ -42,13 +34,6 @@ export interface Occupancy extends EmitsDiscontinuities {
    * @returns A promise that resolves to the current occupancy of the chat room.
    */
   get(): Promise<OccupancyEvent>;
-
-  /**
-   * Get underlying Ably channel for occupancy events.
-   *
-   * @returns The underlying Ably channel for occupancy events.
-   */
-  get channel(): Ably.RealtimeChannel;
 }
 
 /**
@@ -83,12 +68,11 @@ interface OccupancyEventsMap {
 /**
  * @inheritDoc
  */
-export class DefaultOccupancy implements Occupancy, HandlesDiscontinuity, ContributesToRoomLifecycle {
+export class DefaultOccupancy implements Occupancy {
   private readonly _roomId: string;
   private readonly _channel: Ably.RealtimeChannel;
   private readonly _chatApi: ChatApi;
   private readonly _logger: Logger;
-  private readonly _discontinuityEmitter = newDiscontinuityEmitter();
   private readonly _emitter = new EventEmitter<OccupancyEventsMap>();
 
   /**
@@ -100,7 +84,7 @@ export class DefaultOccupancy implements Occupancy, HandlesDiscontinuity, Contri
    */
   constructor(roomId: string, channelManager: ChannelManager, chatApi: ChatApi, logger: Logger) {
     this._roomId = roomId;
-    this._channel = this._makeChannel(roomId, channelManager);
+    this._channel = this._makeChannel(channelManager);
     this._chatApi = chatApi;
     this._logger = logger;
   }
@@ -108,8 +92,8 @@ export class DefaultOccupancy implements Occupancy, HandlesDiscontinuity, Contri
   /**
    * Creates the realtime channel for occupancy.
    */
-  private _makeChannel(roomId: string, channelManager: ChannelManager): Ably.RealtimeChannel {
-    const channel = channelManager.get(DefaultOccupancy.channelName(roomId));
+  private _makeChannel(channelManager: ChannelManager): Ably.RealtimeChannel {
+    const channel = channelManager.get();
 
     // attachOnSubscribe is set to false in the default channel options, so this call cannot fail
     void channel.subscribe(['[meta]occupancy'], this._internalOccupancyListener.bind(this));
@@ -147,13 +131,6 @@ export class DefaultOccupancy implements Occupancy, HandlesDiscontinuity, Contri
   async get(): Promise<OccupancyEvent> {
     this._logger.trace('Occupancy.get();');
     return this._chatApi.getOccupancy(this._roomId);
-  }
-
-  /**
-   * @inheritdoc Occupancy
-   */
-  get channel(): Ably.RealtimeChannel {
-    return this._channel;
   }
 
   /**
@@ -214,41 +191,11 @@ export class DefaultOccupancy implements Occupancy, HandlesDiscontinuity, Contri
       return;
     }
 
+    this._logger.debug('emitting occupancy update');
     this._emitter.emit(OccupancyEvents.Occupancy, {
       connections: connections,
       presenceMembers: presenceMembers,
     });
-  }
-
-  onDiscontinuity(listener: DiscontinuityListener): OnDiscontinuitySubscriptionResponse {
-    this._logger.trace('Occupancy.onDiscontinuity();');
-    const wrapped = wrap(listener);
-    this._discontinuityEmitter.on(wrapped);
-
-    return {
-      off: () => {
-        this._discontinuityEmitter.off(wrapped);
-      },
-    };
-  }
-
-  discontinuityDetected(reason?: Ably.ErrorInfo): void {
-    this._logger.warn('Occupancy.discontinuityDetected();', { reason });
-    this._discontinuityEmitter.emit('discontinuity', reason);
-  }
-
-  /**
-   * @inheritdoc ContributesToRoomLifecycle
-   */
-  get attachmentErrorCode(): ErrorCodes {
-    return ErrorCodes.OccupancyAttachmentFailed;
-  }
-
-  /**
-   * @inheritdoc ContributesToRoomLifecycle
-   */
-  get detachmentErrorCode(): ErrorCodes {
-    return ErrorCodes.OccupancyDetachmentFailed;
   }
 
   /**
@@ -256,8 +203,15 @@ export class DefaultOccupancy implements Occupancy, HandlesDiscontinuity, Contri
    *
    * @returns A function that merges the channel options for the room with the ones required for occupancy.
    */
-  static channelOptionMerger(): ChannelOptionsMerger {
-    return (options) => ({ ...options, params: { ...options.params, occupancy: 'metrics' } });
+  static channelOptionMerger(roomOptions: InternalRoomOptions): ChannelOptionsMerger {
+    return (options) => {
+      // Occupancy not required, so we can skip this.
+      if (!roomOptions.occupancy.enableInboundOccupancy) {
+        return options;
+      }
+
+      return { ...options, params: { ...options.params, occupancy: 'metrics' } };
+    };
   }
 
   /**
@@ -267,6 +221,6 @@ export class DefaultOccupancy implements Occupancy, HandlesDiscontinuity, Contri
    * @returns The channel name for the occupancy channel.
    */
   static channelName(roomId: string): string {
-    return messagesChannelName(roomId);
+    return roomChannelName(roomId);
   }
 }

--- a/src/core/occupancy.ts
+++ b/src/core/occupancy.ts
@@ -189,7 +189,6 @@ export class DefaultOccupancy implements Occupancy {
       return;
     }
 
-    this._logger.debug('emitting occupancy update');
     this._emitter.emit(OccupancyEvents.Occupancy, {
       connections: connections,
       presenceMembers: presenceMembers,

--- a/src/core/occupancy.ts
+++ b/src/core/occupancy.ts
@@ -1,7 +1,7 @@
 import * as Ably from 'ably';
 
 import { roomChannelName } from './channel.js';
-import { ChannelManager, ChannelOptionsMerger } from './channel-manager.js';
+import { ChannelOptionsMerger } from './channel-manager.js';
 import { ChatApi } from './chat-api.js';
 import { Logger } from './logger.js';
 import { InternalRoomOptions } from './room-options.js';
@@ -78,27 +78,25 @@ export class DefaultOccupancy implements Occupancy {
   /**
    * Constructs a new `DefaultOccupancy` instance.
    * @param roomId The unique identifier of the room.
-   * @param channelManager An instance of the ChannelManager.
+   * @param channel An instance of the Realtime channel.
    * @param chatApi An instance of the ChatApi.
    * @param logger An instance of the Logger.
    */
-  constructor(roomId: string, channelManager: ChannelManager, chatApi: ChatApi, logger: Logger) {
+  constructor(roomId: string, channel: Ably.RealtimeChannel, chatApi: ChatApi, logger: Logger) {
     this._roomId = roomId;
-    this._channel = this._makeChannel(channelManager);
+    this._channel = channel;
     this._chatApi = chatApi;
     this._logger = logger;
+
+    this._applyChannelSubscriptions();
   }
 
   /**
-   * Creates the realtime channel for occupancy.
+   * Sets up channel subscriptions for occupancy.
    */
-  private _makeChannel(channelManager: ChannelManager): Ably.RealtimeChannel {
-    const channel = channelManager.get();
-
+  private _applyChannelSubscriptions(): void {
     // attachOnSubscribe is set to false in the default channel options, so this call cannot fail
-    void channel.subscribe(['[meta]occupancy'], this._internalOccupancyListener.bind(this));
-
-    return channel;
+    void this._channel.subscribe(['[meta]occupancy'], this._internalOccupancyListener.bind(this));
   }
 
   /**

--- a/src/core/presence.ts
+++ b/src/core/presence.ts
@@ -1,6 +1,5 @@
 import * as Ably from 'ably';
 
-import { roomChannelName } from './channel.js';
 import { ChannelOptionsMerger } from './channel-manager.js';
 import { PresenceEvents } from './events.js';
 import { Logger } from './logger.js';
@@ -166,13 +165,12 @@ export class DefaultPresence implements Presence {
 
   /**
    * Constructs a new `DefaultPresence` instance.
-   * @param roomId The unique identifier of the room.
    * @param channel The Realtime channel instance.
    * @param clientId The client ID, attached to presences messages as an identifier of the sender.
    * A channel can have multiple connections using the same clientId.
    * @param logger An instance of the Logger.
    */
-  constructor(roomId: string, channel: Ably.RealtimeChannel, clientId: string, logger: Logger) {
+  constructor(channel: Ably.RealtimeChannel, clientId: string, logger: Logger) {
     this._channel = channel;
     this._clientId = clientId;
     this._logger = logger;
@@ -331,16 +329,6 @@ export class DefaultPresence implements Presence {
       );
     }
   };
-
-  /**
-   * Returns the channel name for the presence channel.
-   *
-   * @param roomId The unique identifier of the room.
-   * @returns The channel name for the presence channel.
-   */
-  static channelName(roomId: string): string {
-    return roomChannelName(roomId);
-  }
 
   /**
    * Merges the channel options for the room with the ones required for presence.

--- a/src/core/presence.ts
+++ b/src/core/presence.ts
@@ -1,7 +1,7 @@
 import * as Ably from 'ably';
 
 import { roomChannelName } from './channel.js';
-import { ChannelManager, ChannelOptionsMerger } from './channel-manager.js';
+import { ChannelOptionsMerger } from './channel-manager.js';
 import { PresenceEvents } from './events.js';
 import { Logger } from './logger.js';
 import { InternalRoomOptions } from './room-options.js';
@@ -167,27 +167,25 @@ export class DefaultPresence implements Presence {
   /**
    * Constructs a new `DefaultPresence` instance.
    * @param roomId The unique identifier of the room.
-   * @param channelManager The channel manager to use for creating the presence channel.
+   * @param channel The Realtime channel instance.
    * @param clientId The client ID, attached to presences messages as an identifier of the sender.
    * A channel can have multiple connections using the same clientId.
    * @param logger An instance of the Logger.
    */
-  constructor(roomId: string, channelManager: ChannelManager, clientId: string, logger: Logger) {
-    this._channel = this._makeChannel(channelManager);
+  constructor(roomId: string, channel: Ably.RealtimeChannel, clientId: string, logger: Logger) {
+    this._channel = channel;
     this._clientId = clientId;
     this._logger = logger;
+
+    this._applyChannelSubscriptions();
   }
 
   /**
-   * Creates the realtime channel for presence.
+   * Sets up channel subscriptions for presence.
    */
-  private _makeChannel(channelManager: ChannelManager): Ably.RealtimeChannel {
-    const channel = channelManager.get();
-
+  private _applyChannelSubscriptions(): void {
     // attachOnSubscribe is set to false in the default channel options, so this call cannot fail
-    void channel.presence.subscribe(this.subscribeToEvents.bind(this));
-
-    return channel;
+    void this._channel.presence.subscribe(this.subscribeToEvents.bind(this));
   }
 
   /**

--- a/src/core/presence.ts
+++ b/src/core/presence.ts
@@ -1,19 +1,10 @@
 import * as Ably from 'ably';
 
-import { messagesChannelName } from './channel.js';
+import { roomChannelName } from './channel.js';
 import { ChannelManager, ChannelOptionsMerger } from './channel-manager.js';
-import {
-  DiscontinuityListener,
-  EmitsDiscontinuities,
-  HandlesDiscontinuity,
-  newDiscontinuityEmitter,
-  OnDiscontinuitySubscriptionResponse,
-} from './discontinuity.js';
-import { ErrorCodes } from './errors.js';
 import { PresenceEvents } from './events.js';
 import { Logger } from './logger.js';
-import { ContributesToRoomLifecycle } from './room-lifecycle-manager.js';
-import { RoomOptions } from './room-options.js';
+import { InternalRoomOptions } from './room-options.js';
 import { Subscription } from './subscription.js';
 import EventEmitter, { wrap } from './utils/event-emitter.js';
 
@@ -109,7 +100,7 @@ export type PresenceListener = (event: PresenceEvent) => void;
  *
  * Get an instance via {@link Room.presence}.
  */
-export interface Presence extends EmitsDiscontinuities {
+export interface Presence {
   /**
    * Method to get list of the current online users and returns the latest presence messages associated to it.
    * @param {Ably.RealtimePresenceParams} params - Parameters that control how the presence set is retrieved.
@@ -162,22 +153,15 @@ export interface Presence extends EmitsDiscontinuities {
    * Unsubscribe all listeners from all presence events.
    */
   unsubscribeAll(): void;
-
-  /**
-   * Get the underlying Ably realtime channel used for presence in this chat room.
-   * @returns The realtime channel.
-   */
-  get channel(): Ably.RealtimeChannel;
 }
 
 /**
  * @inheritDoc
  */
-export class DefaultPresence implements Presence, HandlesDiscontinuity, ContributesToRoomLifecycle {
+export class DefaultPresence implements Presence {
   private readonly _channel: Ably.RealtimeChannel;
   private readonly _clientId: string;
   private readonly _logger: Logger;
-  private readonly _discontinuityEmitter = newDiscontinuityEmitter();
   private readonly _emitter = new EventEmitter<PresenceEventsMap>();
 
   /**
@@ -189,7 +173,7 @@ export class DefaultPresence implements Presence, HandlesDiscontinuity, Contribu
    * @param logger An instance of the Logger.
    */
   constructor(roomId: string, channelManager: ChannelManager, clientId: string, logger: Logger) {
-    this._channel = this._makeChannel(roomId, channelManager);
+    this._channel = this._makeChannel(channelManager);
     this._clientId = clientId;
     this._logger = logger;
   }
@@ -197,21 +181,13 @@ export class DefaultPresence implements Presence, HandlesDiscontinuity, Contribu
   /**
    * Creates the realtime channel for presence.
    */
-  private _makeChannel(roomId: string, channelManager: ChannelManager): Ably.RealtimeChannel {
-    const channel = channelManager.get(DefaultPresence.channelName(roomId));
+  private _makeChannel(channelManager: ChannelManager): Ably.RealtimeChannel {
+    const channel = channelManager.get();
 
     // attachOnSubscribe is set to false in the default channel options, so this call cannot fail
     void channel.presence.subscribe(this.subscribeToEvents.bind(this));
 
     return channel;
-  }
-
-  /**
-   * Get the underlying Ably realtime channel used for presence in this chat room.
-   * @returns The realtime channel.
-   */
-  get channel(): Ably.RealtimeChannel {
-    return this._channel;
   }
 
   /**
@@ -358,35 +334,14 @@ export class DefaultPresence implements Presence, HandlesDiscontinuity, Contribu
     }
   };
 
-  onDiscontinuity(listener: DiscontinuityListener): OnDiscontinuitySubscriptionResponse {
-    this._logger.trace('Presence.onDiscontinuity();');
-    const wrapped = wrap(listener);
-    this._discontinuityEmitter.on(wrapped);
-
-    return {
-      off: () => {
-        this._discontinuityEmitter.off(wrapped);
-      },
-    };
-  }
-
-  discontinuityDetected(reason?: Ably.ErrorInfo): void {
-    this._logger.warn('Presence.discontinuityDetected();', { reason });
-    this._discontinuityEmitter.emit('discontinuity', reason);
-  }
-
   /**
-   * @inheritDoc ContributesToRoomLifecycle
+   * Returns the channel name for the presence channel.
+   *
+   * @param roomId The unique identifier of the room.
+   * @returns The channel name for the presence channel.
    */
-  get attachmentErrorCode(): ErrorCodes {
-    return ErrorCodes.PresenceAttachmentFailed;
-  }
-
-  /**
-   * @inheritDoc
-   */
-  get detachmentErrorCode(): ErrorCodes {
-    return ErrorCodes.PresenceDetachmentFailed;
+  static channelName(roomId: string): string {
+    return roomChannelName(roomId);
   }
 
   /**
@@ -395,28 +350,18 @@ export class DefaultPresence implements Presence, HandlesDiscontinuity, Contribu
    * @param roomOptions The room options to merge for.
    * @returns A function that merges the channel options for the room with the ones required for presence.
    */
-  static channelOptionMerger(roomOptions: RoomOptions): ChannelOptionsMerger {
+  static channelOptionMerger(roomOptions: InternalRoomOptions): ChannelOptionsMerger {
     return (options) => {
-      const channelModes = ['PUBLISH', 'SUBSCRIBE'] as Ably.ChannelMode[];
-      if (roomOptions.presence?.enter === undefined || roomOptions.presence.enter) {
-        channelModes.push('PRESENCE');
+      // User wants to receive presence events, so we don't need to do anything.
+      if (roomOptions.presence.receivePresenceEvents) {
+        return options;
       }
 
-      if (roomOptions.presence?.subscribe === undefined || roomOptions.presence.subscribe) {
-        channelModes.push('PRESENCE_SUBSCRIBE');
-      }
-
-      return { ...options, modes: channelModes };
+      const modes = options.modes ?? ['PUBLISH', 'SUBSCRIBE', 'PRESENCE'];
+      return {
+        ...options,
+        modes,
+      };
     };
-  }
-
-  /**
-   * Returns the channel name for the presence channel.
-   *
-   * @param roomId The unique identifier of the room.
-   * @returns The channel name for the presence channel.
-   */
-  static channelName(roomId: string): string {
-    return messagesChannelName(roomId);
   }
 }

--- a/src/core/realtime.ts
+++ b/src/core/realtime.ts
@@ -17,3 +17,22 @@ export const ephemeralMessage = (name: string, data?: unknown): Ably.Message => 
     },
   };
 };
+
+/**
+ * Takes an existing Ably message and converts it to an ephemeral message by adding
+ * the ephemeral flag in the extras field.
+ *
+ * @param message The Ably message to convert.
+ * @returns A new Ably message with the ephemeral flag set.
+ */
+export const messageToEphemeral = (message: Ably.Message): Ably.Message => {
+  const extras = message.extras ? (message.extras as object) : {};
+
+  return {
+    ...message,
+    extras: {
+      ...extras,
+      ephemeral: true,
+    },
+  };
+};

--- a/src/core/room-lifecycle-manager.ts
+++ b/src/core/room-lifecycle-manager.ts
@@ -1,923 +1,386 @@
 import * as Ably from 'ably';
 import { Mutex } from 'async-mutex';
 
-import { HandlesDiscontinuity } from './discontinuity.js';
+import { ChannelManager } from './channel-manager.js';
+import { DiscontinuityListener } from './discontinuity.js';
 import { ErrorCodes } from './errors.js';
+import { RoomEvents } from './events.js';
 import { Logger } from './logger.js';
-import { DefaultRoomLifecycle, NewRoomStatus, RoomStatus, RoomStatusChange } from './room-status.js';
+import { InternalRoomLifecycle, RoomStatus } from './room-status.js';
+import { StatusSubscription } from './subscription.js';
+import EventEmitter, { wrap } from './utils/event-emitter.js';
 
 /**
- * An interface for features that contribute to the room status.
+ * Events that can be emitted by the RoomLifeCycleManager
  */
-export interface ContributesToRoomLifecycle extends HandlesDiscontinuity {
-  /**
-   * Gets the channel on which the feature operates.
-   */
-  get channel(): Ably.RealtimeChannel;
-
-  /**
-   * Gets the ErrorInfo code that should be used when the feature fails to attach.
-   * @returns The error that should be used when the feature fails to attach.
-   */
-  get attachmentErrorCode(): ErrorCodes;
-
-  /**
-   * Gets the ErrorInfo code that should be used when the feature fails to detach.
-   * @returns The error that should be used when the feature fails to detach.
-   */
-  get detachmentErrorCode(): ErrorCodes;
+export interface RoomLifeCycleEvents {
+  [RoomEvents.Discontinuity]: Ably.ErrorInfo;
 }
 
 /**
- * The order of precedence for lifecycle operations, passed to the mutex which allows
- * us to ensure that internal operations take precedence over user-driven operations.
- *
- * The higher the number, the higher the priority.
+ * Priority levels for operations, lower numbers are higher priority
  */
-enum LifecycleOperationPrecedence {
-  Internal = 2,
-  Release = 1,
-  AttachOrDetach = 0,
+enum OperationPriority {
+  Release = 0,
+  AttachDetach = 1,
 }
 
 /**
- * A map of contributors to pending discontinuity events.
+ * Manages the lifecycle of a room's underlying channel, handling attach, detach and release operations
+ * while maintaining the room's status.
  */
-type DiscontinuityEventMap = Map<ContributesToRoomLifecycle, Ably.ErrorInfo | undefined>;
-
-/**
- * An internal interface that represents the result of a room attachment operation.
- */
-type RoomAttachmentResult = NewRoomStatus & {
-  failedFeature?: ContributesToRoomLifecycle;
-};
-
-/**
- * An implementation of the `Status` interface.
- * @internal
- */
-export class RoomLifecycleManager {
-  /**
-   * The status of the room.
-   */
-  private readonly _lifecycle: DefaultRoomLifecycle;
-
-  /**
-   * The features that contribute to the room status.
-   */
-  private readonly _contributors: ContributesToRoomLifecycle[];
+export class RoomLifeCycleManager {
+  private readonly _channelManager: ChannelManager;
+  private readonly _roomLifecycle: InternalRoomLifecycle;
   private readonly _logger: Logger;
+  private readonly _roomId: string;
+  private readonly _eventEmitter: EventEmitter<RoomLifeCycleEvents>;
+  private _isFirstAttach: boolean;
+  private _isPostExplicitDetach: boolean;
+  private readonly _mutex: Mutex;
+  private _operationInProgress: boolean;
 
-  /**
-   * This mutex allows us to ensure the integrity and atomicity of operations that affect the room status, such as
-   * attaching, detaching, and releasing the room. It makes sure that we don't have multiple operations happening
-   * at once which could leave us in an inconsistent state.
-   */
-  private readonly _mtx = new Mutex();
-
-  /**
-   * A map of contributors to transient detach timeouts.
-   *
-   * If a channel enters the attaching state (as a result of a server initiated detach), we should initially
-   * consider it to be transient and not bother changing the room status.
-   */
-  private readonly _transientDetachTimeouts: Map<ContributesToRoomLifecycle, ReturnType<typeof setTimeout>>;
-
-  /**
-   * This flag indicates whether some sort of controlled operation is in progress (e.g. attaching, detaching, releasing).
-   *
-   * It is used to prevent the room status from being changed by individual channel state changes and ignore
-   * underlying channel events until we reach a consistent state.
-   */
-  private _operationInProgress = false;
-
-  /**
-   * A map of pending discontinuity events.
-   *
-   * When a discontinuity happens due to a failed resume, we don't want to surface that until the room is consistently
-   * attached again. This map allows us to queue up discontinuity events until we're ready to process them.
-   */
-  private _pendingDiscontinuityEvents: DiscontinuityEventMap = new Map();
-
-  /**
-   * A map of contributors to whether their first attach has completed.
-   *
-   * Used to control whether we should trigger discontinuity events.
-   */
-  private _firstAttachesCompleted = new Map<ContributesToRoomLifecycle, boolean>();
-
-  /**
-   * Are we in the process of releasing the room?
-   */
-  private _releaseInProgress = false;
-
-  /**
-   * Constructs a new `RoomLifecycleManager` instance.
-   * @param lifecycle The room lifecycle that manages status.
-   * @param contributors The features that contribute to the room status.
-   * @param logger An instance of the Logger.
-   * @param transientDetachTimeout The number of milliseconds to consider a detach to be "transient"
-   */
-  constructor(
-    lifecycle: DefaultRoomLifecycle,
-    contributors: ContributesToRoomLifecycle[],
-    logger: Logger,
-    transientDetachTimeout: number,
-  ) {
+  constructor(roomId: string, channelManager: ChannelManager, roomLifecycle: InternalRoomLifecycle, logger: Logger) {
+    this._roomId = roomId;
+    this._channelManager = channelManager;
+    this._roomLifecycle = roomLifecycle;
     this._logger = logger;
-    this._contributors = contributors;
-    this._transientDetachTimeouts = new Map();
-    this._lifecycle = lifecycle;
+    this._eventEmitter = new EventEmitter();
+    this._isFirstAttach = true;
+    this._isPostExplicitDetach = false;
+    this._mutex = new Mutex();
+    this._operationInProgress = false;
 
-    this._setupContributorListeners(transientDetachTimeout);
+    // Start monitoring channel state changes
+    this._startMonitoringChannelState();
+    this._startMonitoringDiscontinuity();
   }
 
   /**
-   * Sets up listeners for each contributor to the room status.
-   *
-   * @param transientDetachTimeout The number of milliseconds to consider a detach to be "transient"
+   * Sets up monitoring of channel state changes to keep room status in sync.
+   * If an operation is in progress (attach/detach/release), state changes are ignored.
+   * @private
    */
-  private _setupContributorListeners(transientDetachTimeout: number): void {
-    for (const contributor of this._contributors) {
-      // Update events are one way to get a discontinuity
-      // The occur when the server sends another attach message to the client
-      contributor.channel.on(['update'], (change: Ably.ChannelStateChange) => {
-        // If this is our first attach, we should ignore the event
-        if (!this._firstAttachesCompleted.has(contributor)) {
-          this._logger.debug('RoomLifecycleManager() on update; ignoring update event for feature as first attach', {
-            channel: contributor.channel.name,
-            change,
-          });
-          return;
-        }
+  private _startMonitoringChannelState(): void {
+    const channel = this._channelManager.get();
 
-        // If the resumed flag is set, this is not a discontinuity
-        if (change.resumed) {
-          this._logger.debug('RoomLifecycleManager(); update event received but was resume');
-          return;
-        }
-
-        // If we're ignoring contributor detachments, we should queue the event if we don't already have one
-        if (this._operationInProgress) {
-          if (this._pendingDiscontinuityEvents.has(contributor)) {
-            this._logger.debug('RoomLifecycleManager(); subsequent update event for feature received, ignoring', {
-              channel: contributor.channel.name,
-              change,
-            });
-            return;
-          }
-
-          this._logger.debug(
-            'RoomLifecycleManager(); queuing pending update event for feature as operation in progress',
-            {
-              channel: contributor.channel.name,
-              change,
-            },
-          );
-          this._pendingDiscontinuityEvents.set(contributor, change.reason);
-          return;
-        }
-
-        // If we're not ignoring contributor detachments, we should process the event
-        this._logger.debug('RoomLifecycleManager(); update event received', {
-          channel: contributor.channel.name,
-          change,
-        });
-        contributor.discontinuityDetected(change.reason);
+    channel.on((stateChange: Ably.ChannelStateChange) => {
+      this._logger.debug('channel state changed', {
+        roomId: this._roomId,
+        oldState: stateChange.previous,
+        newState: stateChange.current,
+        reason: stateChange.reason,
+        resumed: stateChange.resumed,
       });
 
-      // We handle all events except update events here
-      contributor.channel.on(
-        ['initialized', 'attaching', 'attached', 'detaching', 'detached', 'suspended', 'failed'],
-        (change: Ably.ChannelStateChange) => {
-          // If we're supposed to be ignoring contributor changes, then we should do nothing except check for
-          // resume failures
-          if (this._operationInProgress) {
-            this._logger.debug(
-              'RoomLifecycleManager() on all events; ignoring contributor state change due to operation in progress',
-              {
-                channel: contributor.channel.name,
-                current: change.current,
-              },
-            );
-
-            // If we've had a resume failure, we should process it by adding it to the pending discontinuity events
-            // Only do this if we've managed to complete the first attach successfully
-            if (
-              change.current === RoomStatus.Attached &&
-              !change.resumed &&
-              this._firstAttachesCompleted.has(contributor)
-            ) {
-              this._logger.debug('RoomLifecycleManager(); resume failure detected', {
-                channel: contributor.channel.name,
-              });
-              if (!this._pendingDiscontinuityEvents.has(contributor)) {
-                this._pendingDiscontinuityEvents.set(contributor, change.reason);
-              }
-            }
-
-            return;
-          }
-
-          // If any channel goes to failed, then it's game over for the room
-          if (change.current === RoomStatus.Failed) {
-            this._logger.debug('RoomLifecycleManager(); detected channel failure', {
-              channel: contributor.channel.name,
-            });
-            this._clearAllTransientDetachTimeouts();
-            this._startLifecycleOperation();
-            this._lifecycle.setStatus({
-              status: RoomStatus.Failed,
-              error: change.reason,
-            });
-
-            // We'll make a best effort at detaching all the other channels
-            this._doChannelWindDown(contributor).catch((error: unknown) => {
-              this._logger.error('RoomLifecycleManager(); failed to detach all channels following failure', {
-                contributor: contributor.channel.name,
-                error,
-              });
-            });
-
-            return;
-          }
-
-          // If we're in attached, we want to clear the transient detach timeout
-          if (change.current === RoomStatus.Attached) {
-            if (this._transientDetachTimeouts.has(contributor)) {
-              this._logger.debug('RoomLifecycleManager(); detected transient detach', {
-                channel: contributor.channel.name,
-              });
-              clearTimeout(this._transientDetachTimeouts.get(contributor));
-              this._transientDetachTimeouts.delete(contributor);
-            }
-
-            // If everything is attached, set the room status to attached
-            if (
-              this._lifecycle.status !== RoomStatus.Attached &&
-              this._contributors.every((contributor) => contributor.channel.state === 'attached')
-            ) {
-              this._logger.debug('RoomLifecycleManager(); all features attached, setting room status to attached');
-              this._lifecycle.setStatus({ status: RoomStatus.Attached });
-            }
-
-            return;
-          }
-
-          // If we enter suspended, we should consider the room to be suspended, detach other channels
-          // and wait for the offending channel to reattach.
-          if (change.current === RoomStatus.Suspended) {
-            this._logger.debug('RoomLifecycleManager(); detected channel suspension', {
-              channel: contributor.channel.name,
-            });
-            this._onChannelSuspension(contributor, change.reason);
-            return;
-          }
-
-          // If we're in detached, we want to set a timeout to consider it transient
-          // If we don't already have one.
-          if (change.current === RoomStatus.Attaching && !this._transientDetachTimeouts.has(contributor)) {
-            this._logger.debug('RoomLifecycleManager(); detected channel detach', {
-              channel: contributor.channel.name,
-            });
-            const timeout = setTimeout(() => {
-              // If we get here, then we're still in the attaching state, so set the room status to attaching.
-              // We'll have the status as attaching and be optimistic that the channel will reattach, eventually.
-              // We'll let ably-js sort out the rest.
-              this._lifecycle.setStatus({ status: RoomStatus.Attaching, error: change.reason });
-              this._transientDetachTimeouts.delete(contributor);
-              clearTimeout(timeout);
-            }, transientDetachTimeout);
-
-            this._transientDetachTimeouts.set(contributor, timeout);
-
-            return;
-          }
-        },
-      );
-    }
-  }
-
-  /**
-   * _onChannelSuspension is called when a contributing channel enters the suspended state, which means
-   * that the room is also suspended and we should wind-down channels until things recover.
-   *
-   * We transition the room status to the status of this contributor and provide the original
-   * error that caused the detachment.
-   *
-   * @param contributor The contributor that has detached.
-   * @param detachError The error that caused the detachment.
-   */
-  private _onChannelSuspension(contributor: ContributesToRoomLifecycle, detachError?: Ably.ErrorInfo): void {
-    this._logger.debug('RoomLifecycleManager._onChannelSuspension();', {
-      channel: contributor.channel.name,
-      error: detachError,
-    });
-
-    // We freeze our state, so that individual channel state changes do not affect the room status
-    // We also set our room state to the state of the contributor
-    // We clear all the transient detach timeouts, because we're closing all the channels
-    this._startLifecycleOperation();
-    this._clearAllTransientDetachTimeouts();
-
-    // We enter the protected block with priority Internal, so take precedence over user-driven actions
-    // This process is looping and will continue until a conclusion is reached.
-    void this._mtx
-      .runExclusive(() => {
-        this._logger.error('RoomLifecycleManager._onChannelSuspension(); setting room status to contributor status', {
-          status: contributor.channel.state as RoomStatus,
-          error: detachError,
+      // If we're in the middle of an operation, ignore state changes
+      if (this._operationInProgress) {
+        this._logger.debug('ignoring channel state change - operation in progress', {
+          roomId: this._roomId,
+          roomStatus: this._roomLifecycle.status,
         });
-        this._lifecycle.setStatus({
-          status: contributor.channel.state as RoomStatus,
-          error: detachError,
-        });
-
-        return this._doRetry(contributor);
-      }, LifecycleOperationPrecedence.Internal)
-      .catch((error: unknown) => {
-        this._logger.error('RoomLifecycleManager._onChannelSuspension(); unexpected error thrown', { error });
-      });
-  }
-
-  /**
-   * Given some contributor that has entered a suspended state:
-   *
-   * - Wind down any other channels
-   * - Wait for our contributor to recover
-   * - Attach everything else
-   *
-   * Repeat until either of the following happens:
-   *
-   * - Our contributor reattaches and we can attach everything else (repeat with the next contributor to break if necessary)
-   * - The room enters a failed state
-   *
-   * @param contributor The contributor that has entered a suspended state.
-   * @returns A promise that resolves when the room is attached, or the room enters a failed state.
-   */
-  private async _doRetry(contributor: ContributesToRoomLifecycle): Promise<void> {
-    // A helper that allows us to retry the attach operation
-    // eslint-disable-next-line unicorn/consistent-function-scoping
-    const doAttachWithRetry = () => {
-      this._logger.debug('RoomLifecycleManager.doAttachWithRetry();');
-      this._lifecycle.setStatus({ status: RoomStatus.Attaching });
-
-      return this._doAttach().then((result: RoomAttachmentResult) => {
-        this._logger.debug('RoomLifecycleManager.doAttachWithRetry(); attach result', {
-          status: result.status,
-          error: result.error,
-          failedFeature: result.failedFeature?.channel.name,
-        });
-        // If we're in failed, then we should wind down all the channels, eventually - but we're done here
-        if (result.status === RoomStatus.Failed) {
-          void this._mtx.runExclusive(
-            () =>
-              this._runDownChannelsOnFailedAttach().finally(() => {
-                this._endLifecycleOperation();
-              }),
-            LifecycleOperationPrecedence.Internal,
-          );
-          return;
-        }
-
-        // If we're in suspended, then we should wait for the channel to reattach and then try again
-        if (result.status === RoomStatus.Suspended) {
-          const failedFeature = result.failedFeature;
-          if (!failedFeature) {
-            throw new Ably.ErrorInfo('no failed feature in _doRetry', ErrorCodes.RoomLifecycleError, 500);
-          }
-
-          this._logger.debug('RoomLifecycleManager.doAttachWithRetry(); feature suspended, retrying attach', {
-            feature: failedFeature.channel.name,
-          });
-          return this._doRetry(failedFeature).catch();
-        }
-
-        // We attached, huzzah! It's the end of the loop
-        this._endLifecycleOperation();
-      });
-    };
-
-    // Handle the channel wind-down.
-    this._logger.debug('RoomLifecycleManager._doRetry(); winding down channels except problem', {
-      channel: contributor.channel.name,
-    });
-    try {
-      await this._doChannelWindDown(contributor).catch(() => {
-        // If in doing the wind down, we've entered failed state, then it's game over anyway
-        // TODO: Another PR, but in the even if we get a failed channel, we still need to do the wind down
-        // of other channels for atomicity.
-        // https://github.com/ably/ably-chat-js/issues/416
-        if (this._lifecycle.status === RoomStatus.Failed) {
-          throw new Error('room is in a failed state');
-        }
-
-        // If not, we wait a short period and then try again
-        return new Promise<unknown>((resolve) => {
-          setTimeout(() => {
-            resolve(this._doChannelWindDown(contributor));
-          }, 250);
-        });
-      });
-    } catch {
-      // If an error gets through here, then the room has entered the failed state, we're done.
-      this._endLifecycleOperation();
-      return;
-    }
-
-    // If our problem channel has reattached, then we can retry the attach
-    if (contributor.channel.state === 'attached') {
-      this._logger.debug('RoomLifecycleManager._doRetry(); feature reattached, retrying attach');
-      return doAttachWithRetry();
-    }
-
-    // Otherwise, wait for our problem channel to re-attach and try again
-    return new Promise<void>((resolve) => {
-      const listener = (change: Ably.ChannelStateChange) => {
-        if (change.current === 'attached') {
-          contributor.channel.off(listener);
-          resolve();
-          return;
-        }
-
-        if (change.current === 'failed') {
-          contributor.channel.off(listener);
-          this._lifecycle.setStatus({ status: RoomStatus.Failed, error: change.reason });
-
-          // Its ok to just set operation in progress = false and return here
-          // As every other channel is wound down.
-          this._endLifecycleOperation();
-          throw change.reason ?? new Ably.ErrorInfo('unknown error in _doRetry', ErrorCodes.RoomLifecycleError, 500);
-        }
-      };
-      contributor.channel.on(listener);
-    }).then(() => {
-      this._logger.debug('RoomLifecycleManager._doRetry(); feature reattached via listener, retrying attach');
-      return doAttachWithRetry();
-    });
-  }
-
-  /**
-   * Clears all transient detach timeouts - used when some event supersedes the transient detach such
-   * as a failed channel or suspension.
-   */
-  private _clearAllTransientDetachTimeouts(): void {
-    for (const timeout of this._transientDetachTimeouts.values()) {
-      clearTimeout(timeout);
-    }
-    this._transientDetachTimeouts.clear();
-  }
-
-  /**
-   * Try to attach all the channels in a room.
-   *
-   * If the operation succeeds, the room enters the attached state and this promise resolves.
-   * If a channel enters the suspended state, then we reject, but we will retry after a short delay as is the case
-   * in the core SDK.
-   * If a channel enters the failed state, we reject and then begin to wind down the other channels.
-   */
-  attach(): Promise<void> {
-    this._logger.trace('RoomLifecycleManager.attach();');
-    return this._mtx.runExclusive(async () => {
-      // If the room status is attached, this is a no-op
-      if (this._lifecycle.status === RoomStatus.Attached) {
         return;
       }
 
-      // If the room is released, we can't attach
-      if (this._lifecycle.status === RoomStatus.Released) {
-        throw new Ably.ErrorInfo('unable to attach room; room is released', ErrorCodes.RoomIsReleased, 500);
-      }
-
-      // If the room is releasing, we can't attach
-      if (this._lifecycle.status === RoomStatus.Releasing) {
-        throw new Ably.ErrorInfo('unable to attach room; room is releasing', ErrorCodes.RoomIsReleasing, 500);
-      }
-
-      // At this point, we force the room status to be attaching
-      this._clearAllTransientDetachTimeouts();
-      this._startLifecycleOperation();
-      this._lifecycle.setStatus({ status: RoomStatus.Attaching });
-
-      return this._doAttach().then((result: RoomAttachmentResult) => {
-        // If we're in a failed state, then we should wind down all the channels, eventually
-        if (result.status === RoomStatus.Failed) {
-          this._logger.debug('RoomLifecycleManager.attach(); room entered failed, winding down channels', { result });
-          void this._mtx.runExclusive(
-            () => this._runDownChannelsOnFailedAttach().finally(() => (this._operationInProgress = false)),
-            LifecycleOperationPrecedence.Internal,
-          );
-
-          throw result.error ?? new Ably.ErrorInfo('unknown error in attach', ErrorCodes.RoomLifecycleError, 500);
-        }
-
-        // If we're in suspended, then this attach should fail, but we'll retry after a short delay async
-        if (result.status === RoomStatus.Suspended) {
-          this._logger.debug('RoomLifecycleManager.attach(); room entered suspended, will retry', {
-            error: result.error,
-            contributor: result.failedFeature?.channel.name,
-          });
-          const failedFeature = result.failedFeature;
-          if (!failedFeature) {
-            throw new Ably.ErrorInfo('no failed feature in attach', ErrorCodes.RoomLifecycleError, 500);
-          }
-
-          void this._mtx.runExclusive(
-            () => this._doRetry(failedFeature).catch(),
-            LifecycleOperationPrecedence.Internal,
-          );
-
-          throw (
-            result.error ?? new Ably.ErrorInfo('unknown error in attach then block', ErrorCodes.RoomLifecycleError, 500)
-          );
-        }
-
-        // We attached, huzzah!
-      });
-    }, LifecycleOperationPrecedence.AttachOrDetach);
+      // Map channel state to room state and update
+      const newStatus = this._mapChannelStateToRoomStatus(stateChange.current);
+      this._setStatus(newStatus, stateChange.reason);
+    });
   }
 
-  private async _doAttach(): Promise<RoomAttachmentResult> {
-    this._logger.trace('RoomLifecycleManager._doAttach();');
-    const attachResult: RoomAttachmentResult = {
-      status: RoomStatus.Attached,
-    };
+  /**
+   * Sets up monitoring for channel discontinuities.
+   * A discontinuity exists when an attached or update event comes from the channel with resume=false.
+   * The first time we attach, or if we attach after an explicit detach call are not considered discontinuities.
+   * @private
+   */
+  private _startMonitoringDiscontinuity(): void {
+    const channel = this._channelManager.get();
 
-    for (const feature of this._contributors) {
-      try {
-        this._logger.debug('RoomLifecycleManager._doAttach(); attaching', { channel: feature.channel.name });
-        await feature.channel.attach();
-        this._logger.debug('RoomLifecycleManager._doAttach(); attached', { channel: feature.channel.name });
-
-        // Set ourselves into the first attach list - so we can track discontinuity from now on
-        this._firstAttachesCompleted.set(feature, true);
-      } catch (error: unknown) {
-        this._logger.error('RoomLifecycleManager._doAttach(); failed to attach', { error: attachResult.error });
-        attachResult.failedFeature = feature;
-
-        // We take the status to be whatever caused the error
-        attachResult.error = new Ably.ErrorInfo(
-          'failed to attach feature',
-          feature.attachmentErrorCode,
-          500,
-          error as Ably.ErrorInfo,
+    channel.on('attached', (stateChange: Ably.ChannelStateChange) => {
+      if (!stateChange.resumed && !this._isFirstAttach && !this._isPostExplicitDetach) {
+        const error = new Ably.ErrorInfo(
+          'discontinuity detected',
+          ErrorCodes.RoomDiscontinuity,
+          stateChange.reason?.statusCode ?? 0,
+          stateChange.reason,
         );
 
-        // The current feature should be in one of two states, it will be either suspended or failed
-        // If it's in suspended, we wind down the other channels and wait for the reattach
-        // If it's failed, we can fail the entire room
-        switch (feature.channel.state) {
-          case 'suspended': {
-            attachResult.status = RoomStatus.Suspended;
-            break;
-          }
-          case 'failed': {
-            // If we failed, the room status should be failed
-            attachResult.status = RoomStatus.Failed;
-            break;
-          }
-          default: {
-            this._logger.error(`Unexpected channel state`, { state: feature.channel.state });
-            attachResult.status = RoomStatus.Failed;
-            attachResult.error = new Ably.ErrorInfo(
-              `unexpected channel state in doAttach ${feature.channel.state}`,
-              ErrorCodes.RoomLifecycleError,
-              500,
-              attachResult.error,
-            );
-          }
-        }
-
-        // Regardless of whether we're suspended or failed, run-down the other channels
-        // The wind-down procedure will take mutex precedence over any user-driven actions
-        this._lifecycle.setStatus(attachResult);
-
-        return attachResult;
-      }
-    }
-
-    // We successfully attached all the channels - set our status to attached, start listening changes in channel status
-    this._lifecycle.setStatus(attachResult);
-    this._endLifecycleOperation();
-
-    // Iterate the pending discontinuity events and trigger them
-    for (const [contributor, error] of this._pendingDiscontinuityEvents) {
-      contributor.discontinuityDetected(error);
-    }
-    this._pendingDiscontinuityEvents.clear();
-
-    return attachResult;
-  }
-
-  /**
-   * If we've failed to attach, then we're in the failed state and all that is left to do is to detach all the channels.
-   *
-   * @returns A promise that resolves when all channels are detached. We do not throw.
-   */
-  private _runDownChannelsOnFailedAttach(): Promise<unknown> {
-    // At this point, we have control over the channel lifecycle, so we can hold onto it until things are resolved
-    // Keep trying to detach the channels until they're all detached.
-    return this._doChannelWindDown().catch(() => {
-      // Something went wrong during the wind down. After a short delay, to give others a turn, we should run down
-      // again until we reach a suitable conclusion.
-      this._logger.debug('RoomLifecycleManager._runDownChannelsOnFailedAttach(); wind down failed, retrying');
-      return new Promise<unknown>((resolve) => {
-        setTimeout(() => {
-          resolve(this._runDownChannelsOnFailedAttach());
-        }, 250);
-      });
-    });
-  }
-
-  /**
-   * Detach all features except the one exception provided.
-   * If the room is in a failed state, then all channels should either reach the failed state or be detached.
-   *
-   * @param except The contributor to exclude from the detachment.
-   * @returns A promise that resolves when all channels are detached.
-   */
-  private _doChannelWindDown(except?: ContributesToRoomLifecycle): Promise<unknown> {
-    return Promise.all(
-      this._contributors.map(async (contributor) => {
-        // If its the contributor we want to wait for a conclusion on, then we should not detach it
-        // Unless we're in a failed state, in which case we should detach it
-        if (contributor.channel === except?.channel && this._lifecycle.status !== RoomStatus.Failed) {
-          return;
-        }
-
-        // If the room's already in the failed state, or it's releasing, we should not detach a failed channel
-        if (
-          (this._lifecycle.status === RoomStatus.Failed ||
-            this._lifecycle.status === RoomStatus.Releasing ||
-            this._lifecycle.status === RoomStatus.Released) &&
-          contributor.channel.state === 'failed'
-        ) {
-          this._logger.debug('RoomLifecycleManager._doChannelWindDown(); ignoring failed channel', {
-            channel: contributor.channel.name,
-          });
-          return;
-        }
-
-        try {
-          this._logger.debug('RoomLifecycleManager._doChannelWindDown(); detaching', {
-            channel: contributor.channel.name,
-          });
-          await contributor.channel.detach();
-          this._logger.debug('RoomLifecycleManager._doChannelWindDown(); detached', {
-            channel: contributor.channel.name,
-          });
-        } catch (error: unknown) {
-          // If the contributor is in a failed state and we're not ignoring failed states, we should fail the room
-          if (
-            contributor.channel.state === 'failed' &&
-            this._lifecycle.status !== RoomStatus.Failed &&
-            this._lifecycle.status !== RoomStatus.Releasing &&
-            this._lifecycle.status !== RoomStatus.Released
-          ) {
-            const contributorError = new Ably.ErrorInfo(
-              'failed to detach feature',
-              contributor.detachmentErrorCode,
-              500,
-              error as Ably.ErrorInfo,
-            );
-            this._lifecycle.setStatus({ status: RoomStatus.Failed, error: contributorError });
-            throw contributorError;
-          }
-
-          // We throw an error so that the promise rejects
-          throw new Ably.ErrorInfo('detach failure, retry', -1, -1, error as Ably.ErrorInfo);
-        }
-      }),
-    );
-  }
-
-  /**
-   * Detaches the room. If the room is already detached, this is a no-op.
-   * If one of the channels fails to detach, the room status will be set to failed.
-   * If the room is in the process of detaching, this will wait for the detachment to complete.
-   *
-   * @returns A promise that resolves when the room is detached.
-   */
-  detach(): Promise<void> {
-    this._logger.trace('RoomLifecycleManager.detach();');
-    return this._mtx.runExclusive(async () => {
-      // If we're already detached, this is a no-op
-      if (this._lifecycle.status === RoomStatus.Detached) {
-        return;
-      }
-
-      // If the room is released, we can't detach
-      if (this._lifecycle.status === RoomStatus.Released) {
-        throw new Ably.ErrorInfo('unable to detach room; room is released', ErrorCodes.RoomIsReleased, 500);
-      }
-
-      // If the room is releasing, we can't detach
-      if (this._lifecycle.status === RoomStatus.Releasing) {
-        throw new Ably.ErrorInfo('unable to detach room; room is releasing', ErrorCodes.RoomIsReleasing, 500);
-      }
-
-      // If we're in failed, we should not attempt to detach
-      if (this._lifecycle.status === RoomStatus.Failed) {
-        throw new Ably.ErrorInfo('unable to detach room; room has failed', ErrorCodes.RoomInFailedState, 500);
-      }
-
-      // We force the room status to be detaching
-      this._startLifecycleOperation();
-      this._clearAllTransientDetachTimeouts();
-      this._lifecycle.setStatus({ status: RoomStatus.Detaching });
-
-      // We now perform an all-channel wind down.
-      // We keep trying until we reach a suitable conclusion.
-      return this._doDetach();
-    }, LifecycleOperationPrecedence.AttachOrDetach);
-  }
-
-  /**
-   * Perform a detach.
-   *
-   * If detaching a channel fails, we should retry until every channel is either in the detached state, or in the failed state.
-   */
-  private async _doDetach(): Promise<void> {
-    this._logger.trace('RoomLifecycleManager._doDetach();');
-    let detachError: Ably.ErrorInfo | undefined;
-    let done = false;
-    while (!done) {
-      // First we try to detach all channels, if it fails, then we see if it's an Ably.ErrorInfo with code -1,
-      // If it's -1, it means that we need to retry the detach operation
-      // If it isn't -1, then we have a failure condition
-      try {
-        this._logger.debug('RoomLifecycleManager._doDetach(); detaching all channels');
-        await this._doChannelWindDown();
-      } catch (error: unknown) {
-        this._logger.error('RoomLifecycleManager._doDetach(); failed to detach all channels', { error });
-        if (error instanceof Ably.ErrorInfo && error.code === -1) {
-          this._logger.debug('RoomLifecycleManager._doDetach(); retrying detach', { error });
-          await new Promise<void>((resolve) => setTimeout(resolve, 250));
-          continue;
-        }
-
-        // If we have an error, then this is a failed state error, save it for later
-        if (!detachError) {
-          this._logger.debug('RoomLifecycleManager._doDetach(); channel failed on detach', { error });
-          detachError = error as Ably.ErrorInfo;
-        }
-
-        // Wait for a short period and then try again to complete the detach
-        await new Promise<void>((resolve) => setTimeout(resolve, 250));
-        this._logger.debug('RoomLifecycleManager._doDetach(); retrying detach after failed channel');
-        continue;
-      }
-
-      // If we've made it this far, then we're done
-      done = true;
-    }
-
-    // The process is finished, so set operationInProgress to false
-    this._endLifecycleOperation();
-
-    // If we aren't in the failed state, then we're detached
-    if (this._lifecycle.status !== RoomStatus.Failed) {
-      this._lifecycle.setStatus({ status: RoomStatus.Detached });
-      return;
-    }
-
-    // If we're in the failed state, then we need to throw the error
-    throw detachError ?? new Ably.ErrorInfo('unknown error in _doDetach', ErrorCodes.RoomLifecycleError, 500);
-  }
-
-  /**
-   * Releases the room. If the room is already released, this is a no-op.
-   * Any channel that detaches into the failed state is ok. But any channel that fails to detach
-   * will cause the room status to be set to failed.
-   *
-   * @returns Returns a promise that resolves when the room is released. If a channel detaches into a non-terminated
-   * state (e.g. attached), the promise will reject.
-   */
-  release(): Promise<void> {
-    this._logger.trace('RoomLifecycleManager.release();');
-    return this._mtx.runExclusive(async () => {
-      // If we're already released, this is a no-op
-      if (this._lifecycle.status === RoomStatus.Released) {
-        return;
-      }
-
-      // If we're already detached, or we never attached in the first place, then we can transition to released immediately
-      if (this._lifecycle.status === RoomStatus.Detached || this._lifecycle.status === RoomStatus.Initialized) {
-        this._lifecycle.setStatus({ status: RoomStatus.Released });
-        return;
-      }
-
-      // If we're in the process of releasing, we should wait for it to complete
-      if (this._releaseInProgress) {
-        return new Promise<void>((resolve, reject) => {
-          this._lifecycle.onChangeOnce((change: RoomStatusChange) => {
-            if (change.current === RoomStatus.Released) {
-              resolve();
-              return;
-            }
-
-            this._logger.error('RoomLifecycleManager.release(); expected a non-attached state', change);
-            reject(
-              new Ably.ErrorInfo(
-                'failed to release room; existing attempt failed',
-                ErrorCodes.PreviousOperationFailed,
-                500,
-                change.error,
-              ),
-            );
-          });
+        this._logger.warn('discontinuity detected', {
+          roomId: this._roomId,
+          error,
         });
+        this._eventEmitter.emit(RoomEvents.Discontinuity, error);
+      }
+    });
+
+    channel.on('update', (stateChange: Ably.ChannelStateChange) => {
+      if (
+        !stateChange.resumed &&
+        !this._isFirstAttach &&
+        !this._isPostExplicitDetach &&
+        stateChange.current === 'attached' &&
+        stateChange.previous === 'attached'
+      ) {
+        const error = new Ably.ErrorInfo(
+          'discontinuity detected',
+          ErrorCodes.RoomDiscontinuity,
+          stateChange.reason?.statusCode ?? 0,
+          stateChange.reason,
+        );
+
+        this._logger.warn('discontinuity detected', {
+          roomId: this._roomId,
+          error,
+        });
+        this._eventEmitter.emit(RoomEvents.Discontinuity, error);
+      }
+    });
+  }
+
+  /**
+   * Registers a handler for discontinuity events.
+   * @param handler The function to be called when a discontinuity is detected
+   * @returns An object with an off() method to deregister the handler
+   */
+  onDiscontinuity(handler: DiscontinuityListener): StatusSubscription {
+    this._logger.trace('RoomLifecycleManager.onDiscontinuity()');
+    const wrapped = wrap(handler);
+    this._eventEmitter.on(RoomEvents.Discontinuity, wrapped);
+    return {
+      off: () => {
+        this._eventEmitter.off(RoomEvents.Discontinuity, wrapped);
+      },
+    };
+  }
+
+  /**
+   * Attaches to the channel and updates room status accordingly.
+   * If the room is released/releasing, this operation fails.
+   * If already attached, this is a no-op.
+   */
+  async attach(): Promise<void> {
+    await this._mutex.runExclusive(async () => {
+      this._logger.trace('RoomLifeCycleManager.attach();', { roomId: this._roomId });
+
+      // Check if we're in a terminal state
+      this._checkRoomNotReleasing('attach');
+
+      // No-op if already attached
+      if (this._roomStatusIs(RoomStatus.Attached)) {
+        this._logger.debug('room already attached, no-op', { roomId: this._roomId });
+        return;
       }
 
-      // We force the room status to be releasing
-      this._clearAllTransientDetachTimeouts();
-      this._startLifecycleOperation();
-      this._releaseInProgress = true;
-      this._lifecycle.setStatus({ status: RoomStatus.Releasing });
+      this._operationInProgress = true;
+      const channel = this._channelManager.get();
+      this._logger.debug('attaching room', { roomId: this._roomId, channelState: channel.state });
 
-      // Do the release until it completes
-      this._logger.debug('RoomLifecycleManager.release(); releasing room');
-      return this._releaseChannels();
-    }, LifecycleOperationPrecedence.Release);
+      try {
+        this._setStatus(RoomStatus.Attaching);
+        await channel.attach();
+        this._setStatus(RoomStatus.Attached);
+        this._isPostExplicitDetach = false;
+        this._isFirstAttach = false;
+        this._logger.debug('room attached successfully', { roomId: this._roomId });
+      } catch (error) {
+        const errInfo = error as Ably.ErrorInfo;
+        const attachError = new Ably.ErrorInfo(
+          `failed to attach room: ${errInfo.message}`,
+          errInfo.code,
+          errInfo.statusCode,
+          errInfo,
+        );
+
+        // Map channel state to room state
+        const newStatus = this._mapChannelStateToRoomStatus(channel.state);
+        this._setStatus(newStatus, attachError);
+        throw attachError;
+      } finally {
+        this._operationInProgress = false;
+      }
+    }, OperationPriority.AttachDetach);
   }
 
   /**
-   *  Releases the room by detaching all channels. If the release operation fails, we wait
-   *  a short period and then try again.
+   * Detaches from the channel and updates room status accordingly.
+   * If the room is released/releasing, this operation fails.
+   * If already detached, this is a no-op.
    */
-  private _releaseChannels(): Promise<void> {
-    return this._doRelease().catch((error: unknown) => {
-      this._logger.error('RoomLifecycleManager._releaseChannels(); failed to release room, retrying', { error });
+  async detach(): Promise<void> {
+    await this._mutex.runExclusive(async () => {
+      this._logger.trace('RoomLifeCycleManager.detach();', { roomId: this._roomId });
 
-      // Wait a short period and then try again
-      return new Promise<void>((resolve) => {
-        setTimeout(() => {
-          resolve(this._releaseChannels());
-        }, 250);
+      // Check if room is in failed state
+      if (this._roomStatusIs(RoomStatus.Failed)) {
+        throw new Ably.ErrorInfo('cannot detach room, room is in failed state', ErrorCodes.RoomInFailedState, 400);
+      }
+
+      // Check if we're in a terminal state
+      this._checkRoomNotReleasing('detach');
+
+      // No-op if already detached
+      if (this._roomStatusIs(RoomStatus.Detached)) {
+        this._logger.debug('room already detached, no-op', { roomId: this._roomId });
+        return;
+      }
+
+      this._operationInProgress = true;
+      const channel = this._channelManager.get();
+      this._logger.debug('detaching room', { roomId: this._roomId, channelState: channel.state });
+
+      try {
+        this._setStatus(RoomStatus.Detaching);
+        await channel.detach();
+        this._isPostExplicitDetach = true;
+        this._setStatus(RoomStatus.Detached);
+        this._logger.debug('room detached successfully', { roomId: this._roomId });
+      } catch (error) {
+        const errInfo = error as Ably.ErrorInfo;
+        const detachError = new Ably.ErrorInfo(
+          `failed to detach room: ${errInfo.message}`,
+          errInfo.code,
+          errInfo.statusCode,
+          errInfo,
+        );
+
+        // Map channel state to room state
+        const newStatus = this._mapChannelStateToRoomStatus(channel.state);
+        this._setStatus(newStatus, detachError);
+        throw detachError;
+      } finally {
+        this._operationInProgress = false;
+      }
+    }, OperationPriority.AttachDetach);
+  }
+
+  /**
+   * Releases the room by detaching the channel and releasing it from the channel manager.
+   * If the channel is in a failed state, skips the detach operation.
+   * Will retry detach until successful unless in failed state.
+   */
+  async release(): Promise<void> {
+    await this._mutex.runExclusive(async () => {
+      this._logger.trace('RoomLifeCycleManager.release();', { roomId: this._roomId });
+
+      // If released, this is no-op
+      if (this._roomStatusIs(RoomStatus.Released)) {
+        this._logger.debug('room already released, no-op', { roomId: this._roomId });
+        return;
+      }
+
+      // If we're already detached or initialized, we go straight to released
+      if (this._roomStatusIs(RoomStatus.Initialized) || this._roomStatusIs(RoomStatus.Detached)) {
+        this._logger.debug('room is initialized or detached, releasing immediately', {
+          roomId: this._roomId,
+          status: this._roomLifecycle.status,
+        });
+        this._releaseChannel();
+        return;
+      }
+
+      this._operationInProgress = true;
+      this._setStatus(RoomStatus.Releasing);
+      const channel = this._channelManager.get();
+
+      // If channel is not in failed state, try to detach
+      this._logger.debug('attempting channel detach before release', {
+        roomId: this._roomId,
+        channelState: channel.state,
       });
+      await this._channelDetachLoop(channel);
+
+      // Release the channel
+      this._releaseChannel();
+      this._operationInProgress = false;
+    }, OperationPriority.Release);
+  }
+
+  /**
+   * Maps an Ably channel state to a room status
+   */
+  private _mapChannelStateToRoomStatus(channelState: Ably.ChannelState): RoomStatus {
+    switch (channelState) {
+      case 'initialized': {
+        return RoomStatus.Initialized;
+      }
+      case 'attaching': {
+        return RoomStatus.Attaching;
+      }
+      case 'attached': {
+        return RoomStatus.Attached;
+      }
+      case 'detaching': {
+        return RoomStatus.Detaching;
+      }
+      case 'detached': {
+        return RoomStatus.Detached;
+      }
+      case 'suspended': {
+        return RoomStatus.Suspended;
+      }
+      case 'failed': {
+        return RoomStatus.Failed;
+      }
+      default: {
+        this._logger.error('unknown channel state', { roomId: this._roomId, channelState });
+        return RoomStatus.Failed;
+      }
+    }
+  }
+
+  private _checkRoomNotReleasing(op: string) {
+    switch (this._roomLifecycle.status) {
+      case RoomStatus.Released: {
+        throw new Ably.ErrorInfo(`cannot ${op} room, room is released`, ErrorCodes.RoomIsReleased, 400);
+      }
+      case RoomStatus.Releasing: {
+        throw new Ably.ErrorInfo(`cannot ${op} room, room is currently releasing`, ErrorCodes.RoomIsReleasing, 400);
+      }
+    }
+  }
+
+  private _roomStatusIs(status: RoomStatus) {
+    return this._roomLifecycle.status === status;
+  }
+
+  private async _channelDetachLoop(channel: Ably.RealtimeChannel) {
+    for (;;) {
+      // If channel is now failed, we can stop trying to detach
+      const currentState: Ably.ChannelState = channel.state;
+      if (currentState === 'failed') {
+        this._logger.debug('channel is failed, skipping detach', { roomId: this._roomId });
+        break;
+      }
+
+      try {
+        await channel.detach();
+        break;
+      } catch (error) {
+        // keep trying
+        this._logger.error('failed to detach channel during release', { roomId: this._roomId, error });
+        await new Promise((resolve) => setTimeout(resolve, 250)); // Wait 250ms before retry
+      }
+    }
+  }
+
+  private _setStatus(status: RoomStatus, error?: Ably.ErrorInfo) {
+    this._logger.debug('updating room status', {
+      roomId: this._roomId,
+      oldStatus: this._roomLifecycle.status,
+      newStatus: status,
+      hasError: !!error,
     });
+    this._roomLifecycle.setStatus({ status, error });
   }
 
-  /**
-   * Performs the release operation. This will detach all channels in the room that aren't
-   * already detached or in the failed state.
-   */
-  private _doRelease(): Promise<void> {
-    return Promise.all(
-      this._contributors.map(async (contributor) => {
-        // Failed channels, we can ignore
-        if (contributor.channel.state === 'failed') {
-          this._logger.debug('RoomLifecycleManager.release(); ignoring failed channel', {
-            channel: contributor.channel.name,
-          });
-          return;
-        }
-
-        // Detached channels, we can ignore
-        if (contributor.channel.state === 'detached') {
-          this._logger.debug('RoomLifecycleManager.release(); ignoring detached channel', {
-            channel: contributor.channel.name,
-          });
-          return;
-        }
-
-        try {
-          this._logger.debug('RoomLifecycleManager.release(); detaching', {
-            channel: contributor.channel.name,
-          });
-          await contributor.channel.detach();
-          this._logger.debug('RoomLifecycleManager.release(); detached', {
-            channel: contributor.channel.name,
-          });
-        } catch (error: unknown) {
-          this._logger.error('RoomLifecycleManager.release(); failed to detach', {
-            error,
-            channel: contributor.channel.name,
-            state: contributor.channel.state,
-          });
-          throw error as Ably.ErrorInfo;
-        }
-      }),
-    ).then(() => {
-      this._releaseInProgress = false;
-      this._endLifecycleOperation();
-      this._lifecycle.setStatus({ status: RoomStatus.Released });
-    });
+  private _releaseChannel() {
+    this._channelManager.release();
+    this._setStatus(RoomStatus.Released);
+    this._logger.debug('room released successfully', { roomId: this._roomId });
   }
 
-  /**
-   * Starts the room lifecycle operation.
-   */
-  private _startLifecycleOperation(): void {
-    this._logger.debug('RoomLifecycleManager._startLifecycleOperation();');
-    this._operationInProgress = true;
-  }
-
-  /**
-   * Ends the room lifecycle operation.
-   */
-  private _endLifecycleOperation(): void {
-    this._logger.debug('RoomLifecycleManager._endLifecycleOperation();');
-    this._operationInProgress = false;
+  testForceFirstAttach(firstAttach: boolean) {
+    this._isFirstAttach = firstAttach;
   }
 }

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -1,19 +1,10 @@
 import * as Ably from 'ably';
 
 import { ChannelManager } from './channel-manager.js';
-import {
-  DiscontinuityListener,
-  EmitsDiscontinuities,
-  HandlesDiscontinuity,
-  newDiscontinuityEmitter,
-  OnDiscontinuitySubscriptionResponse,
-} from './discontinuity.js';
-import { ErrorCodes } from './errors.js';
 import { RoomReactionEvents } from './events.js';
 import { Logger } from './logger.js';
 import { Reaction, ReactionHeaders, ReactionMetadata } from './reaction.js';
 import { parseReaction } from './reaction-parser.js';
-import { ContributesToRoomLifecycle } from './room-lifecycle-manager.js';
 import { Subscription } from './subscription.js';
 import EventEmitter, { wrap } from './utils/event-emitter.js';
 
@@ -71,7 +62,7 @@ export type RoomReactionListener = (reaction: Reaction) => void;
  *
  * Get an instance via {@link Room.reactions}.
  */
-export interface RoomReactions extends EmitsDiscontinuities {
+export interface RoomReactions {
   /**
    * Send a reaction to the room including some metadata.
    *
@@ -98,21 +89,13 @@ export interface RoomReactions extends EmitsDiscontinuities {
    * Unsubscribe all listeners from receiving room-level reaction events.
    */
   unsubscribeAll(): void;
-
-  /**
-   * Returns an instance of the Ably realtime channel used for room-level reactions.
-   * Avoid using this directly unless special features that cannot otherwise be implemented are needed.
-   *
-   * @returns The Ably realtime channel.
-   */
-  get channel(): Ably.RealtimeChannel;
 }
 
 interface RoomReactionEventsMap {
   [RoomReactionEvents.Reaction]: Reaction;
 }
 
-interface ReactionEvent {
+interface ReactionPayload {
   type: string;
   metadata?: ReactionMetadata;
 }
@@ -120,12 +103,12 @@ interface ReactionEvent {
 /**
  * @inheritDoc
  */
-export class DefaultRoomReactions implements RoomReactions, HandlesDiscontinuity, ContributesToRoomLifecycle {
+export class DefaultRoomReactions implements RoomReactions {
   private readonly _channel: Ably.RealtimeChannel;
   private readonly _clientId: string;
   private readonly _logger: Logger;
-  private readonly _discontinuityEmitter = newDiscontinuityEmitter();
   private readonly _emitter = new EventEmitter<RoomReactionEventsMap>();
+  private readonly _roomId: string;
 
   /**
    * Constructs a new `DefaultRoomReactions` instance.
@@ -135,7 +118,8 @@ export class DefaultRoomReactions implements RoomReactions, HandlesDiscontinuity
    * @param logger An instance of the Logger.
    */
   constructor(roomId: string, channelManager: ChannelManager, clientId: string, logger: Logger) {
-    this._channel = this._makeChannel(roomId, channelManager);
+    this._roomId = roomId;
+    this._channel = this._makeChannel(channelManager);
     this._clientId = clientId;
     this._logger = logger;
   }
@@ -143,8 +127,8 @@ export class DefaultRoomReactions implements RoomReactions, HandlesDiscontinuity
   /**
    * Creates the realtime channel for room reactions.
    */
-  private _makeChannel(roomId: string, channelManager: ChannelManager): Ably.RealtimeChannel {
-    const channel = channelManager.get(`${roomId}::$chat::$reactions`);
+  private _makeChannel(channelManager: ChannelManager): Ably.RealtimeChannel {
+    const channel = channelManager.get();
 
     // attachOnSubscribe is set to false in the default channel options, so this call cannot fail
     void channel.subscribe([RoomReactionEvents.Reaction], this._forwarder.bind(this));
@@ -164,7 +148,7 @@ export class DefaultRoomReactions implements RoomReactions, HandlesDiscontinuity
       return Promise.reject(new Ably.ErrorInfo('unable to send reaction; type not set and it is required', 40001, 400));
     }
 
-    const payload: ReactionEvent = {
+    const payload: ReactionPayload = {
       type: type,
       metadata: metadata ?? {},
     };
@@ -184,13 +168,13 @@ export class DefaultRoomReactions implements RoomReactions, HandlesDiscontinuity
    * @inheritDoc Reactions
    */
   subscribe(listener: RoomReactionListener): Subscription {
-    this._logger.trace(`RoomReactions.subscribe();`);
+    this._logger.trace(`RoomReactions.subscribe();`, { roomId: this._roomId });
     const wrapped = wrap(listener);
     this._emitter.on(wrapped);
 
     return {
       unsubscribe: () => {
-        this._logger.trace('RoomReactions.unsubscribe();');
+        this._logger.trace('RoomReactions.unsubscribe();', { roomId: this._roomId });
         this._emitter.off(wrapped);
       },
     };
@@ -200,7 +184,7 @@ export class DefaultRoomReactions implements RoomReactions, HandlesDiscontinuity
    * @inheritDoc Reactions
    */
   unsubscribeAll() {
-    this._logger.trace(`RoomReactions.unsubscribeAll();`);
+    this._logger.trace(`RoomReactions.unsubscribeAll();`, { roomId: this._roomId });
     this._emitter.off();
   }
 
@@ -214,46 +198,15 @@ export class DefaultRoomReactions implements RoomReactions, HandlesDiscontinuity
     this._emitter.emit(RoomReactionEvents.Reaction, reaction);
   };
 
-  get channel(): Ably.RealtimeChannel {
-    return this._channel;
-  }
-
   private _parseNewReaction(inbound: Ably.InboundMessage, clientId: string): Reaction | undefined {
     try {
       return parseReaction(inbound, clientId);
     } catch (error: unknown) {
-      this._logger.error(`failed to parse incoming reaction;`, { inbound, error: error as Ably.ErrorInfo });
+      this._logger.error(`failed to parse incoming reaction;`, {
+        inbound,
+        error: error as Ably.ErrorInfo,
+        roomId: this._roomId,
+      });
     }
-  }
-
-  discontinuityDetected(reason?: Ably.ErrorInfo): void {
-    this._logger.warn('RoomReactions.discontinuityDetected();', { reason });
-    this._discontinuityEmitter.emit('discontinuity', reason);
-  }
-
-  onDiscontinuity(listener: DiscontinuityListener): OnDiscontinuitySubscriptionResponse {
-    this._logger.trace('RoomReactions.onDiscontinuity();');
-    const wrapped = wrap(listener);
-    this._discontinuityEmitter.on(wrapped);
-
-    return {
-      off: () => {
-        this._discontinuityEmitter.off(wrapped);
-      },
-    };
-  }
-
-  /**
-   * @inheritdoc ContributesToRoomLifecycle
-   */
-  get attachmentErrorCode(): ErrorCodes {
-    return ErrorCodes.ReactionsAttachmentFailed;
-  }
-
-  /**
-   * @inheritdoc ContributesToRoomLifecycle
-   */
-  get detachmentErrorCode(): ErrorCodes {
-    return ErrorCodes.ReactionsDetachmentFailed;
   }
 }

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -4,6 +4,7 @@ import { RoomReactionEvents } from './events.js';
 import { Logger } from './logger.js';
 import { Reaction, ReactionHeaders, ReactionMetadata } from './reaction.js';
 import { parseReaction } from './reaction-parser.js';
+import { messageToEphemeral } from './realtime.js';
 import { Subscription } from './subscription.js';
 import EventEmitter, { wrap } from './utils/event-emitter.js';
 
@@ -158,7 +159,7 @@ export class DefaultRoomReactions implements RoomReactions {
       },
     };
 
-    return this._channel.publish(realtimeMessage);
+    return this._channel.publish(messageToEphemeral(realtimeMessage));
   }
 
   /**

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -1,6 +1,5 @@
 import * as Ably from 'ably';
 
-import { ChannelManager } from './channel-manager.js';
 import { RoomReactionEvents } from './events.js';
 import { Logger } from './logger.js';
 import { Reaction, ReactionHeaders, ReactionMetadata } from './reaction.js';
@@ -113,27 +112,25 @@ export class DefaultRoomReactions implements RoomReactions {
   /**
    * Constructs a new `DefaultRoomReactions` instance.
    * @param roomId The unique identifier of the room.
-   * @param channelManager The ChannelManager instance.
+   * @param channel The Realtime channel instance.
    * @param clientId The client ID of the user.
    * @param logger An instance of the Logger.
    */
-  constructor(roomId: string, channelManager: ChannelManager, clientId: string, logger: Logger) {
+  constructor(roomId: string, channel: Ably.RealtimeChannel, clientId: string, logger: Logger) {
     this._roomId = roomId;
-    this._channel = this._makeChannel(channelManager);
+    this._channel = channel;
     this._clientId = clientId;
     this._logger = logger;
+
+    this._applyChannelSubscriptions();
   }
 
   /**
-   * Creates the realtime channel for room reactions.
+   * Sets up channel subscriptions for room reactions.
    */
-  private _makeChannel(channelManager: ChannelManager): Ably.RealtimeChannel {
-    const channel = channelManager.get();
-
+  private _applyChannelSubscriptions(): void {
     // attachOnSubscribe is set to false in the default channel options, so this call cannot fail
-    void channel.subscribe([RoomReactionEvents.Reaction], this._forwarder.bind(this));
-
-    return channel;
+    void this._channel.subscribe([RoomReactionEvents.Reaction], this._forwarder.bind(this));
   }
 
   /**

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -190,7 +190,7 @@ export class DefaultRoom implements Room {
 
     // Set the lifecycle manager last, so it becomes the last thing to find out about channel state changes
     // This is to allow Messages to reset subscription points before users get told of a discontinuity
-    this._lifecycleManager = new RoomLifecycleManager(roomId, channelManager, this._lifecycle, this._logger));
+    this._lifecycleManager = new RoomLifecycleManager(roomId, channelManager, this._lifecycle, this._logger);
 
     // Setup a finalization function to clean up resources
     let finalized = false;

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -35,7 +35,6 @@ export interface Room {
   /**
    * Allows you to subscribe to presence events in the room.
    *
-   * @throws {@link ErrorInfo}} if presence is not enabled for the room.
    * @returns The presence instance for the room.
    */
   get presence(): Presence;
@@ -43,7 +42,6 @@ export interface Room {
   /**
    * Allows you to interact with room-level reactions.
    *
-   * @throws {@link ErrorInfo} if reactions are not enabled for the room.
    * @returns The room reactions instance for the room.
    */
   get reactions(): RoomReactions;
@@ -51,7 +49,6 @@ export interface Room {
   /**
    * Allows you to interact with typing events in the room.
    *
-   * @throws {@link ErrorInfo} if typing is not enabled for the room.
    * @returns The typing instance for the room.
    */
   get typing(): Typing;
@@ -59,7 +56,6 @@ export interface Room {
   /**
    * Allows you to interact with occupancy metrics for the room.
    *
-   * @throws {@link ErrorInfo} if occupancy is not enabled for the room.
    * @returns The occupancy instance for the room.
    */
   get occupancy(): Occupancy;
@@ -347,13 +343,6 @@ export class DefaultRoom implements Room {
    */
   get lifecycle(): InternalRoomLifecycle {
     return this._lifecycle;
-  }
-
-  /**
-   * @internal
-   */
-  get channelManager(): ChannelManager {
-    return this._channelManager;
   }
 
   /**

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -8,7 +8,7 @@ import { Logger } from './logger.js';
 import { DefaultMessages, Messages } from './messages.js';
 import { DefaultOccupancy, Occupancy } from './occupancy.js';
 import { DefaultPresence, Presence } from './presence.js';
-import { RoomLifeCycleManager } from './room-lifecycle-manager.js';
+import { RoomLifecycleManager } from './room-lifecycle-manager.js';
 import { InternalRoomOptions, RoomOptions, validateRoomOptions } from './room-options.js';
 import { DefaultRoomReactions, RoomReactions } from './room-reactions.js';
 import { DefaultRoomLifecycle, InternalRoomLifecycle, RoomStatus, RoomStatusListener } from './room-status.js';
@@ -139,7 +139,7 @@ export class DefaultRoom implements Room {
   private readonly _occupancy: DefaultOccupancy;
   private readonly _logger: Logger;
   private readonly _lifecycle: DefaultRoomLifecycle;
-  private readonly _lifecycleManager: RoomLifeCycleManager;
+  private readonly _lifecycleManager: RoomLifecycleManager;
   private readonly _finalizer: () => Promise<void>;
   private readonly _channelManager: ChannelManager;
 
@@ -190,7 +190,7 @@ export class DefaultRoom implements Room {
 
     // Set the lifecycle manager last, so it becomes the last thing to find out about channel state changes
     // This is to allow Messages to reset subscription points before users get told of a discontinuity
-    this._lifecycleManager = new RoomLifeCycleManager(roomId, channelManager, this._lifecycle, this._logger);
+    this._lifecycleManager = new RoomLifecycleManager(roomId, channelManager, this._lifecycle, this._logger));
 
     // Setup a finalization function to clean up resources
     let finalized = false;
@@ -347,7 +347,7 @@ export class DefaultRoom implements Room {
   /**
    * @internal
    */
-  get lifecycleManager(): RoomLifeCycleManager {
+  get lifecycleManager(): RoomLifecycleManager {
     return this._lifecycleManager;
   }
 

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -183,8 +183,7 @@ export class DefaultRoom implements Room {
 
     // Setup features
     this._messages = new DefaultMessages(roomId, channel, this._chatApi, realtime.auth.clientId, this._logger);
-
-    this._presence = new DefaultPresence(roomId, channel, realtime.auth.clientId, this._logger);
+    this._presence = new DefaultPresence(channel, realtime.auth.clientId, this._logger);
     this._typing = new DefaultTyping(roomId, options.typing, channel, realtime.auth.clientId, this._logger);
     this._reactions = new DefaultRoomReactions(roomId, channel, realtime.auth.clientId, this._logger);
     this._occupancy = new DefaultOccupancy(roomId, channel, this._chatApi, this._logger);

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -183,14 +183,15 @@ export class DefaultRoom implements Room {
     this._lifecycle = new DefaultRoomLifecycle(roomId, this._logger);
 
     const channelManager = (this._channelManager = this._getChannelManager(options, realtime, this._logger));
+    const channel = channelManager.get();
 
     // Setup features
-    this._messages = new DefaultMessages(roomId, channelManager, this._chatApi, realtime.auth.clientId, this._logger);
+    this._messages = new DefaultMessages(roomId, channel, this._chatApi, realtime.auth.clientId, this._logger);
 
-    this._presence = new DefaultPresence(roomId, channelManager, realtime.auth.clientId, this._logger);
-    this._typing = new DefaultTyping(roomId, options.typing, channelManager, realtime.auth.clientId, this._logger);
-    this._reactions = new DefaultRoomReactions(roomId, channelManager, realtime.auth.clientId, this._logger);
-    this._occupancy = new DefaultOccupancy(roomId, channelManager, this._chatApi, this._logger);
+    this._presence = new DefaultPresence(roomId, channel, realtime.auth.clientId, this._logger);
+    this._typing = new DefaultTyping(roomId, options.typing, channel, realtime.auth.clientId, this._logger);
+    this._reactions = new DefaultRoomReactions(roomId, channel, realtime.auth.clientId, this._logger);
+    this._occupancy = new DefaultOccupancy(roomId, channel, this._chatApi, this._logger);
 
     // Set the lifecycle manager last, so it becomes the last thing to find out about channel state changes
     // This is to allow Messages to reset subscription points before users get told of a discontinuity

--- a/src/core/rooms.ts
+++ b/src/core/rooms.ts
@@ -31,7 +31,7 @@ export interface Rooms {
    * @throws {@link ErrorInfo} if a room with the same ID but different options already exists.
    * @returns Room A promise to a new or existing Room object.
    */
-  get(roomId: string, options: RoomOptions): Promise<Room>;
+  get(roomId: string, options?: RoomOptions): Promise<Room>;
 
   /**
    * Release the Room object if it exists. This method only releases the reference
@@ -71,7 +71,7 @@ interface RoomMapEntry {
   /**
    * The options for the room.
    */
-  options: RoomOptions;
+  options: RoomOptions | undefined;
 
   /**
    * An abort controller to abort the get operation if the room is released before the get operation completes.
@@ -108,7 +108,7 @@ export class DefaultRooms implements Rooms {
   /**
    * @inheritDoc
    */
-  get(roomId: string, options: RoomOptions): Promise<Room> {
+  get(roomId: string, options?: RoomOptions): Promise<Room> {
     this._logger.trace('Rooms.get();', { roomId });
 
     const existing = this._rooms.get(roomId);
@@ -254,7 +254,7 @@ export class DefaultRooms implements Rooms {
    *
    * @returns DefaultRoom A new room object.
    */
-  private _makeRoom(roomId: string, nonce: string, options: RoomOptions): DefaultRoom {
+  private _makeRoom(roomId: string, nonce: string, options: RoomOptions | undefined): DefaultRoom {
     return new DefaultRoom(
       roomId,
       nonce,

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -1,22 +1,11 @@
 import * as Ably from 'ably';
 import { E_CANCELED, Mutex } from 'async-mutex';
 
-import { roomChannelName } from './channel.js';
 import { ChannelManager } from './channel-manager.js';
-import {
-  DiscontinuityEmitter,
-  DiscontinuityListener,
-  EmitsDiscontinuities,
-  HandlesDiscontinuity,
-  newDiscontinuityEmitter,
-  OnDiscontinuitySubscriptionResponse,
-} from './discontinuity.js';
-import { ErrorCodes } from './errors.js';
 import { TypingEvent, TypingEvents } from './events.js';
 import { Logger } from './logger.js';
 import { ephemeralMessage } from './realtime.js';
-import { ContributesToRoomLifecycle } from './room-lifecycle-manager.js';
-import { TypingOptions } from './room-options.js';
+import { InternalTypingOptions } from './room-options.js';
 import { Subscription } from './subscription.js';
 import EventEmitter, { wrap } from './utils/event-emitter.js';
 
@@ -26,7 +15,7 @@ import EventEmitter, { wrap } from './utils/event-emitter.js';
  *
  * Get an instance via {@link Room.typing}.
  */
-export interface Typing extends EmitsDiscontinuities {
+export interface Typing {
   /**
    * Subscribe a given listener to all typing events from users in the chat room.
    *
@@ -84,14 +73,7 @@ export interface Typing extends EmitsDiscontinuities {
    * @throws If the operation fails to send the event to the server.
    * @throws If there is a problem acquiring the mutex that controls serialization.
    */
-
   stop(): Promise<void>;
-
-  /**
-   * Get the Ably realtime channel underpinning typing events.
-   * @returns The Ably realtime channel.
-   */
-  channel: Ably.RealtimeChannel;
 }
 
 /**
@@ -116,14 +98,11 @@ type TypingTimerHandle = ReturnType<typeof setTimeout> | undefined;
 /**
  * @inheritDoc
  */
-export class DefaultTyping
-  extends EventEmitter<TypingEventsMap>
-  implements Typing, HandlesDiscontinuity, ContributesToRoomLifecycle
-{
+export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typing {
+  private readonly _roomId: string;
   private readonly _clientId: string;
   private readonly _channel: Ably.RealtimeChannel;
   private readonly _logger: Logger;
-  private readonly _discontinuityEmitter: DiscontinuityEmitter = newDiscontinuityEmitter();
 
   // Throttle for the heartbeat, how often we should emit a typing event with repeated calls to keystroke()
   // CHA-T10
@@ -148,14 +127,15 @@ export class DefaultTyping
    */
   constructor(
     roomId: string,
-    options: TypingOptions,
+    options: InternalTypingOptions,
     channelManager: ChannelManager,
     clientId: string,
     logger: Logger,
   ) {
     super();
+    this._roomId = roomId;
     this._clientId = clientId;
-    this._channel = this._makeChannel(roomId, channelManager);
+    this._channel = this._makeChannel(channelManager);
 
     // Interval for the heartbeat, how often we should emit a typing event with repeated calls to start()
     this._heartbeatThrottleMs = options.heartbeatThrottleMs;
@@ -168,9 +148,9 @@ export class DefaultTyping
   /**
    * Creates the realtime channel for typing indicators.
    */
-  private _makeChannel(roomId: string, channelManager: ChannelManager): Ably.RealtimeChannel {
+  private _makeChannel(channelManager: ChannelManager): Ably.RealtimeChannel {
     // CHA-T8
-    const channel = channelManager.get(roomChannelName(roomId));
+    const channel = channelManager.get();
 
     // attachOnSubscribe is set to false in the default channel options, so this call cannot fail
     void channel.subscribe([TypingEvents.Start, TypingEvents.Stop], this._internalSubscribeToEvents.bind(this));
@@ -183,7 +163,7 @@ export class DefaultTyping
    * @inheritDoc
    */
   get(): Set<string> {
-    this._logger.trace(`DefaultTyping.get();`);
+    this._logger.trace(`DefaultTyping.get();`, { roomId: this._roomId });
     return new Set<string>(this._currentlyTyping.keys());
   }
 
@@ -199,9 +179,9 @@ export class DefaultTyping
    */
   private _startHeartbeatTimer(): void {
     if (!this._heartbeatTimerId) {
-      this._logger.trace(`DefaultTyping.startHeartbeatTimer();`);
+      this._logger.trace(`DefaultTyping.startHeartbeatTimer();`, { roomId: this._roomId });
       const timer = (this._heartbeatTimerId = setTimeout(() => {
-        this._logger.debug(`DefaultTyping.startHeartbeatTimer(); heartbeat timer expired`);
+        this._logger.debug(`DefaultTyping.startHeartbeatTimer(); heartbeat timer expired`, { roomId: this._roomId });
         // CHA-T2a
         if (timer === this._heartbeatTimerId) {
           this._heartbeatTimerId = undefined;
@@ -214,13 +194,15 @@ export class DefaultTyping
    * @inheritDoc
    */
   async keystroke(): Promise<void> {
-    this._logger.trace(`DefaultTyping.keystroke();`);
+    this._logger.trace(`DefaultTyping.keystroke();`, { roomId: this._roomId });
     this._mutex.cancel();
 
     // Acquire a mutex
     await this._mutex.acquire().catch((error: unknown) => {
       if (error === E_CANCELED) {
-        this._logger.debug(`DefaultTyping.keystroke(); mutex was canceled by a later operation`);
+        this._logger.debug(`DefaultTyping.keystroke(); mutex was canceled by a later operation`, {
+          roomId: this._roomId,
+        });
         return;
       }
       throw new Ably.ErrorInfo('mutex acquisition failed', 50000, 500);
@@ -230,7 +212,8 @@ export class DefaultTyping
       // Ensure room is attached
       if (this.channel.state !== 'attached' && this.channel.state !== 'attaching') {
         this._logger.error(`DefaultTyping.keystroke(); room is not in the correct state `, {
-          State: this.channel.state,
+          roomId: this._roomId,
+          state: this.channel.state,
         });
         throw new Ably.ErrorInfo('cannot type, room is not in the correct state', 50000, 500);
       }
@@ -238,7 +221,9 @@ export class DefaultTyping
       // Check whether user is already typing before publishing again
       // CHA-T4c1, CHA-T4c2
       if (this._heartbeatTimerId) {
-        this._logger.debug(`DefaultTyping.keystroke(); no-op, already typing and heartbeat timer has not expired`);
+        this._logger.debug(`DefaultTyping.keystroke(); no-op, already typing and heartbeat timer has not expired`, {
+          roomId: this._roomId,
+        });
         return;
       }
 
@@ -249,9 +234,9 @@ export class DefaultTyping
       // Start the timer after publishing
       // CHA-T4a5
       this._startHeartbeatTimer();
-      this._logger.trace(`DefaultTyping.keystroke(); starting timers`);
+      this._logger.trace(`DefaultTyping.keystroke(); starting timers`, { roomId: this._roomId });
     } finally {
-      this._logger.trace(`DefaultTyping.keystroke(); releasing mutex`);
+      this._logger.trace(`DefaultTyping.keystroke(); releasing mutex`, { roomId: this._roomId });
       this._mutex.release();
     }
   }
@@ -260,13 +245,13 @@ export class DefaultTyping
    * @inheritDoc
    */
   async stop(): Promise<void> {
-    this._logger.trace(`DefaultTyping.stop();`);
+    this._logger.trace(`DefaultTyping.stop();`, { roomId: this._roomId });
 
     this._mutex.cancel();
     // Acquire a mutex
     await this._mutex.acquire().catch((error: unknown) => {
       if (error === E_CANCELED) {
-        this._logger.debug(`DefaultTyping.stop(); mutex was canceled by a later operation`);
+        this._logger.debug(`DefaultTyping.stop(); mutex was canceled by a later operation`, { roomId: this._roomId });
         return;
       }
       throw new Ably.ErrorInfo('mutex acquisition failed', 50000, 500);
@@ -274,27 +259,30 @@ export class DefaultTyping
     try {
       // CHA-T5c
       if (this.channel.state !== 'attached' && this.channel.state !== 'attaching') {
-        this._logger.error(`DefaultTyping.stop(); room is not in the correct state `, { State: this.channel.state });
+        this._logger.error(`DefaultTyping.stop(); room is not in the correct state `, {
+          roomId: this._roomId,
+          state: this.channel.state,
+        });
         throw new Ably.ErrorInfo('cannot stop typing, room is not in the correct state', 50000, 500);
       }
 
       // If the user is not typing, do nothing.
       // CHA-T5a
       if (!this._heartbeatTimerId) {
-        this._logger.debug(`DefaultTyping.stop(); no-op, not currently typing`);
+        this._logger.debug(`DefaultTyping.stop(); no-op, not currently typing`, { roomId: this._roomId });
         return;
       }
 
       // CHA-T5d
       await this._channel.publish(ephemeralMessage(TypingEvents.Stop));
-      this._logger.trace(`DefaultTyping.stop(); clearing timers`);
+      this._logger.trace(`DefaultTyping.stop(); clearing timers`, { roomId: this._roomId });
 
       // CHA-T5e
       // Clear the heartbeat timer
       clearTimeout(this._heartbeatTimerId);
       this._heartbeatTimerId = undefined;
     } finally {
-      this._logger.trace(`DefaultTyping.stop(); releasing mutex`);
+      this._logger.trace(`DefaultTyping.stop(); releasing mutex`, { roomId: this._roomId });
       this._mutex.release();
     }
   }
@@ -303,13 +291,13 @@ export class DefaultTyping
    * @inheritDoc
    */
   subscribe(listener: TypingListener): Subscription {
-    this._logger.trace(`DefaultTyping.subscribe();`);
+    this._logger.trace(`DefaultTyping.subscribe();`, { roomId: this._roomId });
     const wrapped = wrap(listener);
     this.on(wrapped);
 
     return {
       unsubscribe: () => {
-        this._logger.trace('DefaultTyping.unsubscribe();');
+        this._logger.trace('DefaultTyping.unsubscribe();', { roomId: this._roomId });
         this.off(wrapped);
       },
     };
@@ -319,7 +307,7 @@ export class DefaultTyping
    * @inheritDoc
    */
   unsubscribeAll(): void {
-    this._logger.trace(`DefaultTyping.unsubscribeAll();`);
+    this._logger.trace(`DefaultTyping.unsubscribeAll();`, { roomId: this._roomId });
     this.off();
   }
 
@@ -330,7 +318,7 @@ export class DefaultTyping
    * @param event The typing event.
    */
   private _updateCurrentlyTyping(clientId: string, event: TypingEvents): void {
-    this._logger.trace(`DefaultTyping._updateCurrentlyTyping();`, { clientId, event });
+    this._logger.trace(`DefaultTyping._updateCurrentlyTyping();`, { roomId: this._roomId, clientId, event });
 
     if (event === TypingEvents.Start) {
       this._handleTypingStart(clientId);
@@ -346,13 +334,20 @@ export class DefaultTyping
    * @param clientId
    */
   private _startNewClientInactivityTimer(clientId: string): ReturnType<typeof setTimeout> {
-    this._logger.trace(`DefaultTyping._startNewClientInactivityTimer(); starting new inactivity timer`, { clientId });
+    this._logger.trace(`DefaultTyping._startNewClientInactivityTimer(); starting new inactivity timer`, {
+      roomId: this._roomId,
+      clientId,
+    });
     // Set or reset the typing timeout for this client
     const timeoutId = setTimeout(() => {
-      this._logger.trace(`DefaultTyping._startNewClientInactivityTimer(); client typing timeout expired`, { clientId });
+      this._logger.trace(`DefaultTyping._startNewClientInactivityTimer(); client typing timeout expired`, {
+        roomId: this._roomId,
+        clientId,
+      });
       // Verify the timer is still valid (it might have been reset)
       if (this._currentlyTyping.get(clientId) !== timeoutId) {
         this._logger.debug(`DefaultTyping._startNewClientInactivityTimer(); timeout already cleared; ignoring`, {
+          roomId: this._roomId,
           clientId,
         });
         return;
@@ -376,7 +371,7 @@ export class DefaultTyping
    * @param clientId
    */
   private _handleTypingStart(clientId: string): void {
-    this._logger.debug(`DefaultTyping._handleTypingStart();`, { clientId });
+    this._logger.debug(`DefaultTyping._handleTypingStart();`, { roomId: this._roomId, clientId });
     // Start a new timeout for the client
     const timeoutId = this._startNewClientInactivityTimer(clientId);
 
@@ -388,12 +383,16 @@ export class DefaultTyping
     if (existingTimeout) {
       // Heartbeat - User is already typing, we just need to clear the existing timeout
       this._logger.debug(`DefaultTyping._handleTypingStart(); received heartbeat for currently typing client`, {
+        roomId: this._roomId,
         clientId,
       });
       clearTimeout(existingTimeout);
     } else {
       // Otherwise, we need to emit a new typing event
-      this._logger.debug(`DefaultTyping._handleTypingStart(); new client started typing`, { clientId });
+      this._logger.debug(`DefaultTyping._handleTypingStart(); new client started typing`, {
+        roomId: this._roomId,
+        clientId,
+      });
       this.emit(TypingEvents.Start, {
         currentlyTyping: new Set<string>(this._currentlyTyping.keys()),
         change: {
@@ -415,13 +414,13 @@ export class DefaultTyping
       // Stop requested for a client that isn't currently typing
       this._logger.trace(
         `DefaultTyping._handleTypingStop(); received "Stop" event for client not in currentlyTyping list`,
-        { clientId },
+        { roomId: this._roomId, clientId },
       );
       return;
     }
 
     // Stop typing: clear their timeout and remove from the currently typing set
-    this._logger.debug(`DefaultTyping._handleTypingStop(); client stopped typing`, { clientId });
+    this._logger.debug(`DefaultTyping._handleTypingStop(); client stopped typing`, { roomId: this._roomId, clientId });
     clearTimeout(existingTimeout);
     this._currentlyTyping.delete(clientId);
     // Emit stop event only when the client is removed
@@ -439,10 +438,17 @@ export class DefaultTyping
    */
   private _internalSubscribeToEvents = (inbound: Ably.InboundMessage): void => {
     const { name, clientId } = inbound;
-    this._logger.trace(`DefaultTyping._internalSubscribeToEvents(); received event`, { name, clientId });
+    this._logger.trace(`DefaultTyping._internalSubscribeToEvents(); received event`, {
+      roomId: this._roomId,
+      name,
+      clientId,
+    });
 
     if (!clientId) {
-      this._logger.error(`DefaultTyping._internalSubscribeToEvents(); invalid clientId in received event`, { inbound });
+      this._logger.error(`DefaultTyping._internalSubscribeToEvents(); invalid clientId in received event`, {
+        roomId: this._roomId,
+        inbound,
+      });
       return;
     }
 
@@ -450,42 +456,14 @@ export class DefaultTyping
     if (name === TypingEvents.Start || name === TypingEvents.Stop) {
       this._updateCurrentlyTyping(clientId, name);
     } else {
-      this._logger.warn(`DefaultTyping._internalSubscribeToEvents(); unrecognized event`, { name });
+      this._logger.warn(`DefaultTyping._internalSubscribeToEvents(); unrecognized event`, {
+        roomId: this._roomId,
+        name,
+      });
     }
   };
 
-  onDiscontinuity(listener: DiscontinuityListener): OnDiscontinuitySubscriptionResponse {
-    this._logger.trace(`DefaultTyping.onDiscontinuity();`);
-    const wrapped = wrap(listener);
-    this._discontinuityEmitter.on(wrapped);
-
-    return {
-      off: () => {
-        this._discontinuityEmitter.off(wrapped);
-      },
-    };
-  }
-
-  discontinuityDetected(reason?: Ably.ErrorInfo): void {
-    this._logger.warn(`DefaultTyping.discontinuityDetected();`, { reason });
-    this._discontinuityEmitter.emit('discontinuity', reason);
-  }
-
   get heartbeatThrottleMs(): number {
     return this._heartbeatThrottleMs;
-  }
-
-  /**
-   * @inheritdoc ContributesToRoomLifecycle
-   */
-  get attachmentErrorCode(): ErrorCodes {
-    return ErrorCodes.TypingAttachmentFailed;
-  }
-
-  /**
-   * @inheritdoc ContributesToRoomLifecycle
-   */
-  get detachmentErrorCode(): ErrorCodes {
-    return ErrorCodes.TypingDetachmentFailed;
   }
 }

--- a/src/react/contexts/chat-room-context.tsx
+++ b/src/react/contexts/chat-room-context.tsx
@@ -21,7 +21,7 @@ export interface ChatRoomContextType {
   /**
    * Options used to create the room.
    */
-  options: RoomOptions;
+  options?: RoomOptions;
 
   /**
    * The chat client used to create the room.

--- a/src/react/hooks/use-messages.ts
+++ b/src/react/hooks/use-messages.ts
@@ -172,7 +172,7 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
       context.room,
       (room) => {
         logger.debug('useMessages(); applying onDiscontinuity listener');
-        const { off } = room.messages.onDiscontinuity(onDiscontinuityRef);
+        const { off } = room.onDiscontinuity(onDiscontinuityRef);
         return () => {
           logger.debug('useMessages(); removing onDiscontinuity listener');
           off();

--- a/src/react/hooks/use-occupancy.ts
+++ b/src/react/hooks/use-occupancy.ts
@@ -76,7 +76,7 @@ export const useOccupancy = (params?: UseOccupancyParams): UseOccupancyResponse 
       context.room,
       (room) => {
         logger.debug('useOccupancy(); applying onDiscontinuity listener');
-        const { off } = room.occupancy.onDiscontinuity(onDiscontinuityRef);
+        const { off } = room.onDiscontinuity(onDiscontinuityRef);
         return () => {
           logger.debug('useOccupancy(); removing onDiscontinuity listener');
           off();

--- a/src/react/hooks/use-presence-listener.ts
+++ b/src/react/hooks/use-presence-listener.ts
@@ -285,7 +285,7 @@ export const usePresenceListener = (params?: UsePresenceListenerParams): UsePres
       context.room,
       (room) => {
         logger.debug('usePresenceListener(); applying onDiscontinuity listener');
-        const { off } = room.presence.onDiscontinuity(onDiscontinuityRef);
+        const { off } = room.onDiscontinuity(onDiscontinuityRef);
 
         return () => {
           logger.debug('usePresenceListener(); removing onDiscontinuity listener');

--- a/src/react/hooks/use-presence.ts
+++ b/src/react/hooks/use-presence.ts
@@ -161,7 +161,7 @@ export const usePresence = (params?: UsePresenceParams): UsePresenceResponse => 
     return wrapRoomPromise(
       context.room,
       (room: Room) => {
-        const { off } = room.presence.onDiscontinuity(onDiscontinuityRef);
+        const { off } = room.onDiscontinuity(onDiscontinuityRef);
         return () => {
           logger.debug('usePresence(); removing onDiscontinuity listener');
           off();

--- a/src/react/hooks/use-room-reactions.ts
+++ b/src/react/hooks/use-room-reactions.ts
@@ -65,7 +65,7 @@ export const useRoomReactions = (params?: UseRoomReactionsParams): UseRoomReacti
       context.room,
       (room) => {
         logger.debug('useRoomReactions(); applying onDiscontinuity listener');
-        const { off } = room.reactions.onDiscontinuity(onDiscontinuityRef);
+        const { off } = room.onDiscontinuity(onDiscontinuityRef);
         return () => {
           logger.debug('useRoomReactions(); removing onDiscontinuity listener');
           off();

--- a/src/react/hooks/use-typing.ts
+++ b/src/react/hooks/use-typing.ts
@@ -130,13 +130,8 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
     return wrapRoomPromise(
       context.room,
       (room) => {
-<<<<<<< HEAD
         logger.debug('useTyping(); applying onDiscontinuity listener');
-        const { off } = room.typing.onDiscontinuity(onDiscontinuityRef);
-=======
-        logger.debug('useTyping(); applying onDiscontinuity listener', { roomId: context.roomId });
         const { off } = room.onDiscontinuity(onDiscontinuityRef);
->>>>>>> ccf7094 (feat: consolidate onto a single channel)
         return () => {
           logger.debug('useTyping(); removing onDiscontinuity listener');
           off();

--- a/src/react/hooks/use-typing.ts
+++ b/src/react/hooks/use-typing.ts
@@ -88,17 +88,6 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
       return new Set<string>();
     });
 
-    void context.room
-      .then((room) => {
-        // If we're not attached, we can't call typing.get() right now
-        if (room.status === RoomStatus.Attached) {
-          const typing = room.typing.get();
-          logger.debug('useTyping(); room attached, getting initial typers', { typing });
-          setCurrentlyTyping(typing);
-        }
-      })
-      .catch();
-
     return wrapRoomPromise(
       context.room,
       (room) => {
@@ -106,6 +95,13 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
         const { unsubscribe } = room.typing.subscribe((event) => {
           setCurrentlyTyping(event.currentlyTyping);
         });
+
+        // If we're not attached, we can't call typing.get() right now
+        if (room.status === RoomStatus.Attached) {
+          const typing = room.typing.get();
+          logger.debug('useTyping(); room attached, getting initial typers', { typing });
+          setCurrentlyTyping(typing);
+        }
 
         return () => {
           logger.debug('useTyping(); unsubscribing from typing events');

--- a/src/react/hooks/use-typing.ts
+++ b/src/react/hooks/use-typing.ts
@@ -92,14 +92,13 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
 
     void context.room
       .then((room) => {
-        if (!mounted) return;
-
         // If we're not attached, we can't call typing.get() right now
         if (room.status === RoomStatus.Attached) {
           const typing = room.typing.get();
           logger.debug('useTyping(); room attached, getting initial typers', { typing });
           setCurrentlyTyping(typing);
         } else {
+          if (!mounted) return;
           logger.debug('useTyping(); room not attached, setting currentlyTyping to empty');
           setCurrentlyTyping(new Set());
         }
@@ -131,8 +130,13 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
     return wrapRoomPromise(
       context.room,
       (room) => {
+<<<<<<< HEAD
         logger.debug('useTyping(); applying onDiscontinuity listener');
         const { off } = room.typing.onDiscontinuity(onDiscontinuityRef);
+=======
+        logger.debug('useTyping(); applying onDiscontinuity listener', { roomId: context.roomId });
+        const { off } = room.onDiscontinuity(onDiscontinuityRef);
+>>>>>>> ccf7094 (feat: consolidate onto a single channel)
         return () => {
           logger.debug('useTyping(); removing onDiscontinuity listener');
           off();

--- a/src/react/hooks/use-typing.ts
+++ b/src/react/hooks/use-typing.ts
@@ -88,8 +88,6 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
       return new Set<string>();
     });
 
-    let mounted = true;
-
     void context.room
       .then((room) => {
         // If we're not attached, we can't call typing.get() right now
@@ -97,10 +95,6 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
           const typing = room.typing.get();
           logger.debug('useTyping(); room attached, getting initial typers', { typing });
           setCurrentlyTyping(typing);
-        } else {
-          if (!mounted) return;
-          logger.debug('useTyping(); room not attached, setting currentlyTyping to empty');
-          setCurrentlyTyping(new Set());
         }
       })
       .catch();
@@ -115,7 +109,6 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
 
         return () => {
           logger.debug('useTyping(); unsubscribing from typing events');
-          mounted = false;
           unsubscribe();
         };
       },

--- a/src/react/providers/chat-room-provider.tsx
+++ b/src/react/providers/chat-room-provider.tsx
@@ -4,8 +4,7 @@ import React, { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { ChatClient } from '../../core/chat.js';
 import { Logger } from '../../core/logger.js';
 import { Room } from '../../core/room.js';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { type AllFeaturesEnabled, RoomOptions } from '../../core/room-options.js';
+import { RoomOptions } from '../../core/room-options.js';
 import { ChatRoomContext, ChatRoomContextType } from '../contexts/chat-room-context.js';
 import { useChatClient } from '../hooks/use-chat-client.js';
 import { useLogger } from '../hooks/use-logger.js';
@@ -18,23 +17,12 @@ export interface ChatRoomProviderProps {
   id: string;
 
   /**
-   * The options to use when creating the room. A convenient default value is
-   * provided by {@link AllFeaturesEnabled}, but it must explicitly be set
-   * here.
-   *
-   * {@link AllFeaturesEnabled} can also be used partially, for example:
-   *
-   * ```tsx
-   * <ChatRoomProvider id="room-id" options={{
-   *   presence: AllFeaturesEnabled.presence,
-   *   reactions: AllFeaturesEnabled.reactions,
-   * }} />
-   * ```
+   * Overriding options to use when creating the room.
    *
    * NOTE: This value is not memoized by the provider. It must be memoized in your component to prevent
    * re-renders of a parent component from causing the room to be recreated.
    */
-  options: RoomOptions;
+  options?: RoomOptions;
 
   /**
    * Set to `false` to disable auto-releasing the room when component unmounts,
@@ -68,7 +56,7 @@ export interface ChatRoomProviderProps {
 
 interface RoomReleaseOp {
   id: string;
-  options: RoomOptions;
+  options: RoomOptions | undefined;
   abort: AbortController;
 }
 
@@ -80,7 +68,7 @@ class RoomReleaseQueue {
     this._logger = logger;
   }
 
-  enqueue(client: ChatClient, id: string, options: RoomOptions) {
+  enqueue(client: ChatClient, id: string, options: RoomOptions | undefined) {
     const abort = new AbortController();
     const op: RoomReleaseOp = { id, options, abort };
     this._queue.push(op);
@@ -103,7 +91,7 @@ class RoomReleaseQueue {
       });
   }
 
-  abort(id: string, options: RoomOptions) {
+  abort(id: string, options: RoomOptions | undefined) {
     this._logger.debug(`RoomReleaseQueue(); checking for abort`, { id, options, length: this._queue.length });
     const op = this._queue.find((op) => op.id === id && op.options === options);
     if (op) {

--- a/src/react/types/status-params.ts
+++ b/src/react/types/status-params.ts
@@ -1,6 +1,5 @@
-import * as Ably from 'ably';
-
 import { ConnectionStatusChange } from '../../core/connection.js';
+import { DiscontinuityListener } from '../../core/discontinuity.js';
 import { RoomStatusChange } from '../../core/room-status.js';
 
 /**
@@ -34,5 +33,5 @@ export interface StatusParams {
    * you might choose to fetch missing messages.
    * @param error The error that caused the discontinuity.
    */
-  onDiscontinuity?: (error?: Ably.ErrorInfo) => void;
+  onDiscontinuity?: DiscontinuityListener;
 }

--- a/test/core/channel-manager.test.ts
+++ b/test/core/channel-manager.test.ts
@@ -1,8 +1,9 @@
 import * as Ably from 'ably';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { roomChannelName } from '../../src/core/channel.ts';
 import { ChannelManager, ChannelOptionsMerger } from '../../src/core/channel-manager.ts';
-import { DEFAULT_CHANNEL_OPTIONS } from '../../src/core/version.ts';
+import { DEFAULT_CHANNEL_OPTIONS, DEFAULT_CHANNEL_OPTIONS_REACT } from '../../src/core/version.ts';
 import { randomClientId } from '../helper/identifier.ts';
 import { makeTestLogger } from '../helper/logger.ts';
 
@@ -16,42 +17,50 @@ vi.mock('ably');
 describe('ChannelManager', () => {
   beforeEach<TestContext>((context) => {
     context.mockRealtime = new Ably.Realtime({ clientId: randomClientId() });
-    context.channelManager = new ChannelManager(context.mockRealtime, makeTestLogger(), false);
+    context.channelManager = new ChannelManager('test-room', context.mockRealtime, makeTestLogger(), false);
 
     vi.spyOn(context.mockRealtime.channels, 'get').mockReturnValue({} as Ably.RealtimeChannel);
     vi.spyOn(context.mockRealtime.channels, 'release');
   });
 
   it<TestContext>('requests channel with default options', (context) => {
-    const channelName = 'test-channel';
-    context.channelManager.get(channelName);
+    context.channelManager.get();
+    expect(context.mockRealtime.channels.get).toHaveBeenCalledWith(
+      roomChannelName('test-room'),
+      DEFAULT_CHANNEL_OPTIONS,
+    );
+  });
 
-    expect(context.mockRealtime.channels.get).toHaveBeenCalledWith(channelName, DEFAULT_CHANNEL_OPTIONS);
+  it<TestContext>('requests channel with default react options', (context) => {
+    context.channelManager = new ChannelManager('test-room', context.mockRealtime, makeTestLogger(), true);
+    context.channelManager.get();
+    expect(context.mockRealtime.channels.get).toHaveBeenCalledWith(
+      roomChannelName('test-room'),
+      DEFAULT_CHANNEL_OPTIONS_REACT,
+    );
   });
 
   it<TestContext>('should merge options correctly', (context) => {
-    const channelName = 'test-channel';
     const merger: ChannelOptionsMerger = (options) => ({ ...options, mode: 'presence' });
 
-    context.channelManager.mergeOptions(channelName, merger);
+    context.channelManager.mergeOptions(merger);
 
-    context.channelManager.get(channelName);
-    expect(context.mockRealtime.channels.get).toHaveBeenCalledWith(channelName, {
+    context.channelManager.get();
+    expect(context.mockRealtime.channels.get).toHaveBeenCalledWith(roomChannelName('test-room'), {
       ...DEFAULT_CHANNEL_OPTIONS,
       mode: 'presence',
     });
   });
 
   it<TestContext>('should merge options multiple times over', (context) => {
-    const channelName = 'test-channel';
     const merger: ChannelOptionsMerger = (options) => ({ ...options, mode: 'presence' });
     const merger2: ChannelOptionsMerger = (options) => ({ ...options, presence: 'enter' });
 
-    context.channelManager.mergeOptions(channelName, merger);
-    context.channelManager.mergeOptions(channelName, merger2);
+    context.channelManager.mergeOptions(merger);
+    context.channelManager.mergeOptions(merger2);
 
-    context.channelManager.get(channelName);
-    expect(context.mockRealtime.channels.get).toHaveBeenCalledWith(channelName, {
+    context.channelManager.get();
+    expect(context.mockRealtime.channels.get).toHaveBeenCalledWith(roomChannelName('test-room'), {
       ...DEFAULT_CHANNEL_OPTIONS,
       mode: 'presence',
       presence: 'enter',
@@ -59,23 +68,22 @@ describe('ChannelManager', () => {
   });
 
   it<TestContext>('should throw error if trying to merge options for a requested channel', (context) => {
-    const channelName = 'test-channel';
     const merger: ChannelOptionsMerger = (options) => ({ ...options, mode: 'presence' });
     const merger2: ChannelOptionsMerger = (options) => ({ ...options, presence: 'enter' });
 
-    context.channelManager.mergeOptions(channelName, merger);
-    context.channelManager.get(channelName);
+    context.channelManager.mergeOptions(merger);
+    context.channelManager.get();
 
     // Should have been called once
     expect(context.mockRealtime.channels.get).toHaveBeenCalledTimes(1);
-    expect(context.mockRealtime.channels.get).toHaveBeenCalledWith(channelName, {
+    expect(context.mockRealtime.channels.get).toHaveBeenCalledWith(roomChannelName('test-room'), {
       ...DEFAULT_CHANNEL_OPTIONS,
       mode: 'presence',
     });
 
     // Now try to merge again, should error
     expect(() => {
-      context.channelManager.mergeOptions(channelName, merger2);
+      context.channelManager.mergeOptions(merger2);
     }).toThrowErrorInfo({ code: 40000, statusCode: 400 });
 
     // And we shouldn't have called get again
@@ -83,21 +91,19 @@ describe('ChannelManager', () => {
   });
 
   it<TestContext>('should get a channel singleton', (context) => {
-    const channelName = 'test-channel';
     const merger: ChannelOptionsMerger = (options) => ({ ...options, mode: 'presence' });
 
-    context.channelManager.mergeOptions(channelName, merger);
-    const channel1 = context.channelManager.get(channelName);
-    const channel2 = context.channelManager.get(channelName);
+    context.channelManager.mergeOptions(merger);
+    const channel1 = context.channelManager.get();
+    const channel2 = context.channelManager.get();
 
     expect(channel1).toBe(channel2);
   });
 
   it<TestContext>('should release a channel', (context) => {
-    const channelName = 'test-channel';
-    context.channelManager.get(channelName);
+    context.channelManager.get();
 
-    context.channelManager.release(channelName);
-    expect(context.mockRealtime.channels.release).toHaveBeenCalledWith(channelName);
+    context.channelManager.release();
+    expect(context.mockRealtime.channels.release).toHaveBeenCalledWith(roomChannelName('test-room'));
   });
 });

--- a/test/core/chat-api.test.ts
+++ b/test/core/chat-api.test.ts
@@ -27,7 +27,7 @@ describe('config', () => {
         statusCode: 400,
       })
       .then(() => {
-        expect(realtime.request).toHaveBeenCalledWith('GET', '/chat/v1/rooms/test/occupancy', 3, undefined, undefined);
+        expect(realtime.request).toHaveBeenCalledWith('GET', '/chat/v3/rooms/test/occupancy', 3, undefined, undefined);
       });
   });
 

--- a/test/core/chat.integration.test.ts
+++ b/test/core/chat.integration.test.ts
@@ -6,7 +6,6 @@ import { ConnectionStatus } from '../../src/core/connection.ts';
 import { LogLevel } from '../../src/core/logger.ts';
 import { RealtimeWithOptions } from '../../src/core/realtime-extensions.ts';
 import { CHANNEL_OPTIONS_AGENT_STRING_REACT, VERSION } from '../../src/core/version.ts';
-import { AllFeaturesEnabled } from '../../src/index.ts';
 import { newChatClient } from '../helper/chat.ts';
 import { testClientOptions } from '../helper/options.ts';
 import { ablyRealtimeClient } from '../helper/realtime-client.ts';
@@ -48,9 +47,9 @@ describe('Chat', () => {
     const chat = newChatClient(testClientOptions());
     chat.addReactAgent();
 
-    const room = await chat.rooms.get('room', AllFeaturesEnabled);
+    const room = await chat.rooms.get('room');
 
-    const channelOptions = (room.messages.channel as unknown as { channelOptions: Ably.ChannelOptions }).channelOptions;
+    const channelOptions = (room.channel as unknown as { channelOptions: Ably.ChannelOptions }).channelOptions;
     expect(channelOptions.params).toEqual(
       expect.objectContaining({
         agent: CHANNEL_OPTIONS_AGENT_STRING_REACT,

--- a/test/core/occupancy.integration.test.ts
+++ b/test/core/occupancy.integration.test.ts
@@ -1,14 +1,12 @@
-import * as Ably from 'ably';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatClient } from '../../src/core/chat.ts';
 import { OccupancyEvent } from '../../src/core/occupancy.ts';
 import { Room } from '../../src/core/room.ts';
-import { RoomStatus } from '../../src/core/room-status.ts';
 import { newChatClient } from '../helper/chat.ts';
 import { waitForExpectedInbandOccupancy } from '../helper/common.ts';
 import { ablyRealtimeClientWithToken } from '../helper/realtime-client.ts';
-import { getRandomRoom, waitForRoomStatus } from '../helper/room.ts';
+import { getRandomRoom } from '../helper/room.ts';
 
 interface TestContext {
   chat: ChatClient;
@@ -45,7 +43,7 @@ describe('occupancy', () => {
       presenceMembers: 0,
     });
 
-    const { name: channelName } = room.messages.channel;
+    const { name: channelName } = room.channel;
 
     // In a separate realtime client, attach to the same room
     const realtimeClient = ablyRealtimeClientWithToken();
@@ -92,7 +90,7 @@ describe('occupancy', () => {
   it<TestContext>('allows subscriptions to inband occupancy', { timeout: TEST_TIMEOUT }, async (context) => {
     const { chat } = context;
 
-    const room = await getRandomRoom(chat);
+    const room = await getRandomRoom(chat, { occupancy: { enableInboundOccupancy: true } });
 
     // Subscribe to occupancy
     const occupancyUpdates: OccupancyEvent[] = [];
@@ -115,7 +113,7 @@ describe('occupancy', () => {
 
     // In a separate realtime client, attach to the same room
     const realtimeClient = ablyRealtimeClientWithToken();
-    const { name: channelName } = room.messages.channel;
+    const { name: channelName } = room.channel;
     const realtimeChannel = realtimeClient.channels.get(channelName);
     await realtimeChannel.attach();
     await realtimeChannel.presence.enter();
@@ -129,54 +127,5 @@ describe('occupancy', () => {
       },
       TEST_TIMEOUT,
     );
-  });
-
-  it<TestContext>('handles discontinuities', async (context) => {
-    const { chat } = context;
-
-    const room = await getRandomRoom(chat);
-
-    // Attach the room
-    await room.attach();
-
-    // Subscribe discontinuity events
-    const discontinuityErrors: (Ably.ErrorInfo | undefined)[] = [];
-    const { off } = room.occupancy.onDiscontinuity((error: Ably.ErrorInfo | undefined) => {
-      discontinuityErrors.push(error);
-    });
-
-    const channelSuspendable = room.messages.channel as Ably.RealtimeChannel & {
-      notifyState(state: 'suspended' | 'attached'): void;
-    };
-
-    // Simulate a discontinuity by forcing a channel into suspended state
-    channelSuspendable.notifyState('suspended');
-
-    // Wait for the room to go into suspended
-    await waitForRoomStatus(room, RoomStatus.Suspended);
-
-    // Force the channel back into attached state - to simulate recovery
-    channelSuspendable.notifyState('attached');
-
-    // Wait for the room to go into attached
-    await waitForRoomStatus(room, RoomStatus.Attached);
-
-    // Wait for a discontinuity event to be received
-    expect(discontinuityErrors.length).toBe(1);
-
-    // Unsubscribe from discontinuity events
-    off();
-
-    // Simulate a discontinuity by forcing a channel into suspended state
-    channelSuspendable.notifyState('suspended');
-
-    // Wait for the room to go into suspended
-    await waitForRoomStatus(room, RoomStatus.Suspended);
-
-    // We shouldn't get any more discontinuity events
-    expect(discontinuityErrors.length).toBe(1);
-
-    // Calling off again should be a no-op
-    off();
   });
 });

--- a/test/core/presence.test.ts
+++ b/test/core/presence.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatApi } from '../../src/core/chat-api.ts';
 import { DefaultPresence, PresenceData, PresenceEvent } from '../../src/core/presence.ts';
 import { Room } from '../../src/core/room.ts';
-import { PresenceEvents } from '../../src/index.ts';
+import { PresenceEvents, RoomOptions } from '../../src/index.ts';
 import { makeTestLogger } from '../helper/logger.ts';
 import { makeRandomRoom } from '../helper/room.ts';
 
@@ -12,6 +12,7 @@ interface TestContext {
   realtime: Ably.Realtime;
   chatApi: ChatApi;
   room: Room;
+  makeRoom: (options?: RoomOptions) => Room;
   currentChannelOptions: Ably.ChannelOptions;
 }
 
@@ -21,93 +22,95 @@ describe('Presence', () => {
   beforeEach<TestContext>((context) => {
     context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
     context.chatApi = new ChatApi(context.realtime, makeTestLogger());
-    context.room = makeRandomRoom({ chatApi: context.chatApi, realtime: context.realtime });
+    context.makeRoom = (options) => makeRandomRoom({ chatApi: context.chatApi, realtime: context.realtime, options });
+    context.room = context.makeRoom();
   });
 
-  it<TestContext>('has an attachment error code', (context) => {
-    expect((context.room.presence as DefaultPresence).attachmentErrorCode).toBe(102002);
-  });
+  describe<TestContext>('subscribe', () => {
+    it<TestContext>('throws ErrorInfo if subscribing with no arguments', (context) => {
+      expect(() => {
+        context.room.presence.subscribe();
+      }).toThrowErrorInfo({
+        message: 'could not subscribe listener: invalid arguments',
+        code: 40000,
+      });
+    });
 
-  it<TestContext>('has a detachment error code', (context) => {
-    expect((context.room.presence as DefaultPresence).detachmentErrorCode).toBe(102051);
-  });
+    it<TestContext>('should only unsubscribe the correct subscription', (context) => {
+      const { room } = context;
+      const received: PresenceEvent[] = [];
 
-  it<TestContext>('throws ErrorInfo if subscribing with no arguments', (context) => {
-    expect(() => {
-      context.room.presence.subscribe();
-    }).toThrowErrorInfo({
-      message: 'could not subscribe listener: invalid arguments',
-      code: 40000,
+      const emulatePresenceEvent = (clientId: string, action: PresenceEvents, data?: PresenceData) => {
+        const presenceMessage: Ably.PresenceMessage = {
+          action,
+          clientId,
+          timestamp: Date.now(),
+          data: data ? { userCustomData: data } : undefined,
+          connectionId: 'connection-id',
+          encoding: '',
+          id: 'message-id',
+          extras: null,
+        };
+
+        // Call the subscribeToEvents handler directly
+        (room.presence as DefaultPresence).subscribeToEvents(presenceMessage);
+      };
+
+      const listener = (event: PresenceEvent) => {
+        received.push(event);
+      };
+
+      // Subscribe the same listener twice
+      const subscription1 = room.presence.subscribe(listener);
+      const subscription2 = room.presence.subscribe(listener);
+
+      // Both subscriptions should trigger the listener
+      emulatePresenceEvent('user1', PresenceEvents.Enter, { foo: 'bar' });
+      expect(received).toHaveLength(2);
+
+      // Unsubscribe first subscription
+      subscription1.unsubscribe();
+
+      // One subscription should still trigger the listener
+      emulatePresenceEvent('user2', PresenceEvents.Enter, { baz: 'qux' });
+      expect(received).toHaveLength(3);
+
+      // Unsubscribe second subscription
+      subscription2.unsubscribe();
+
+      // No subscriptions should trigger the listener
+      emulatePresenceEvent('user3', PresenceEvents.Enter, { test: 'data' });
+      expect(received).toHaveLength(3);
     });
   });
 
-  it<TestContext>('should only unsubscribe the correct subscription', (context) => {
-    const { room } = context;
-    const received: PresenceEvent[] = [];
+  describe<TestContext>('room configuration', () => {
+    it<TestContext>('removes the presence channel mode if room option disabled', (context) => {
+      vi.spyOn(context.realtime.channels, 'get');
+      const room = context.makeRoom({ presence: { receivePresenceEvents: false } });
 
-    const emulatePresenceEvent = (clientId: string, action: PresenceEvents, data?: PresenceData) => {
-      const presenceMessage: Ably.PresenceMessage = {
-        action,
-        clientId,
-        timestamp: Date.now(),
-        data: data ? { userCustomData: data } : undefined,
-        connectionId: 'connection-id',
-        encoding: '',
-        id: 'message-id',
-        extras: null,
-      };
-
-      // Call the subscribeToEvents handler directly
-      (room.presence as DefaultPresence).subscribeToEvents(presenceMessage);
-    };
-
-    const listener = (event: PresenceEvent) => {
-      received.push(event);
-    };
-
-    // Subscribe the same listener twice
-    const subscription1 = room.presence.subscribe(listener);
-    const subscription2 = room.presence.subscribe(listener);
-
-    // Both subscriptions should trigger the listener
-    emulatePresenceEvent('user1', PresenceEvents.Enter, { foo: 'bar' });
-    expect(received).toHaveLength(2);
-
-    // Unsubscribe first subscription
-    subscription1.unsubscribe();
-
-    // One subscription should still trigger the listener
-    emulatePresenceEvent('user2', PresenceEvents.Enter, { baz: 'qux' });
-    expect(received).toHaveLength(3);
-
-    // Unsubscribe second subscription
-    subscription2.unsubscribe();
-
-    // No subscriptions should trigger the listener
-    emulatePresenceEvent('user3', PresenceEvents.Enter, { test: 'data' });
-    expect(received).toHaveLength(3);
+      // Check the channel was called as planned
+      expect(context.realtime.channels.get).toHaveBeenCalledOnce();
+      expect(context.realtime.channels.get).toHaveBeenCalledWith(
+        room.channel.name,
+        expect.objectContaining({
+          modes: ['PUBLISH', 'SUBSCRIBE', 'PRESENCE'],
+        }),
+      );
+    });
   });
 
-  it<TestContext>('should only unsubscribe the correct subscription for discontinuities', (context) => {
-    const { room } = context;
+  it<TestContext>('does not remove mode if option enabled', (context) => {
+    vi.spyOn(context.realtime.channels, 'get');
+    const room = context.makeRoom({ presence: { receivePresenceEvents: true } });
 
-    const received: string[] = [];
-    const listener = (error?: Ably.ErrorInfo) => {
-      received.push(error?.message ?? 'no error');
-    };
-
-    const subscription1 = room.presence.onDiscontinuity(listener);
-    const subscription2 = room.presence.onDiscontinuity(listener);
-
-    (room.presence as DefaultPresence).discontinuityDetected(new Ably.ErrorInfo('error1', 0, 0));
-    expect(received).toEqual(['error1', 'error1']);
-
-    subscription1.off();
-    (room.presence as DefaultPresence).discontinuityDetected(new Ably.ErrorInfo('error2', 0, 0));
-    expect(received).toEqual(['error1', 'error1', 'error2']);
-
-    subscription2.off();
-    (room.presence as DefaultPresence).discontinuityDetected(new Ably.ErrorInfo('error3', 0, 0));
-    expect(received).toEqual(['error1', 'error1', 'error2']);
+    // Check the channel was called as planned
+    expect(context.realtime.channels.get).toHaveBeenCalledOnce();
+    expect(context.realtime.channels.get).toHaveBeenCalledWith(
+      room.channel.name,
+      expect.not.objectContaining({
+        modes: ['PUBLISH', 'SUBSCRIBE', 'PRESENCE'],
+      }),
+    );
   });
 });

--- a/test/core/room-lifecycle-manager.test.ts
+++ b/test/core/room-lifecycle-manager.test.ts
@@ -1,2858 +1,803 @@
 import * as Ably from 'ably';
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, test, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ErrorCodes } from '../../src/core/errors.ts';
-import { ContributesToRoomLifecycle, RoomLifecycleManager } from '../../src/core/room-lifecycle-manager.ts';
-import { DefaultRoomLifecycle, RoomStatus } from '../../src/core/room-status.ts';
-import { makeTestLogger } from '../helper/logger.ts';
-import { waitForRoomError, waitForRoomLifecycleStatus } from '../helper/room.ts';
+import { ChannelManager } from '../../src/core/channel-manager.js';
+import { ErrorCodes } from '../../src/core/errors.js';
+import { Logger } from '../../src/core/logger.js';
+import { RoomLifeCycleManager } from '../../src/core/room-lifecycle-manager.js';
+import { DefaultRoomLifecycle, InternalRoomLifecycle, RoomStatus } from '../../src/core/room-status.js';
+import { ErrorInfoCompareType } from '../helper/expectations.js';
+import { makeTestLogger } from '../helper/logger.js';
 
 interface TestContext {
-  realtime: Ably.Realtime;
-  firstContributor: MockContributor;
-  secondContributor: MockContributor;
-  thirdContributor: MockContributor;
+  roomLifeCycleManager: RoomLifeCycleManager;
+  channelManager: ChannelManager;
+  roomStatus: InternalRoomLifecycle;
+  logger: Logger;
+  mockChannel: Partial<Ably.RealtimeChannel> & {
+    attach: () => Promise<Ably.ChannelStateChange | null>;
+    detach?: () => Promise<Ably.ChannelStateChange | null>;
+    on?: (event: string | string[], handler: (stateChange: Ably.ChannelStateChange) => void) => void;
+    _stateChangeHandlers: Map<Ably.ChannelEvent, ((stateChange: Ably.ChannelStateChange) => void)[]>;
+    _stateChangeHandlersForAll: ((stateChange: Ably.ChannelStateChange) => void)[];
+    invokeStateChange: (stateChange: Ably.ChannelStateChange, isUpdate?: boolean) => void;
+  };
 }
 
 vi.mock('ably');
 
-interface MockContributor extends ContributesToRoomLifecycle {
-  emulateStateChange: (change: Ably.ChannelStateChange, update?: boolean) => void;
-
-  // We override the channel so that it can be set in some scenarios
-  channel: Ably.RealtimeChannel;
-}
-
-const baseError = new Ably.ErrorInfo('error', 500, 50000);
-const baseError2 = new Ably.ErrorInfo('error2', 500, 50000);
-
-enum AblyChannelState {
-  Initialized = 'initialized',
-  Attached = 'attached',
-  Detached = 'detached',
-  Failed = 'failed',
-  Suspended = 'suspended',
-  Attaching = 'attaching',
-  Detaching = 'detaching',
-}
-
-const mockChannelAttachSuccess = (channel: Ably.RealtimeChannel): void => {
-  vi.spyOn(channel, 'attach').mockImplementation(() => {
-    vi.spyOn(channel, 'state', 'get').mockReturnValue(AblyChannelState.Attached);
-    vi.spyOn(channel, 'errorReason', 'get').mockReturnValue(baseError);
-
-    return Promise.resolve(null);
-  });
-};
-
-const mockChannelAttachSuccessWithResumeFailure = (channel: Ably.RealtimeChannel, error?: Ably.ErrorInfo): void => {
-  vi.spyOn(channel, 'attach').mockImplementation(() => {
-    vi.spyOn(channel, 'state', 'get').mockReturnValue(AblyChannelState.Attached);
-    vi.spyOn(channel, 'errorReason', 'get').mockReturnValue(baseError);
-
-    (
-      channel as Ably.RealtimeChannel & {
-        emit: (event: AblyChannelState | 'update', change: Ably.ChannelStateChange) => void;
-      }
-    ).emit(AblyChannelState.Attached, {
-      current: AblyChannelState.Attached,
-      previous: 'initialized',
-      resumed: false,
-      reason: error ?? baseError,
-    });
-
-    return Promise.resolve(null);
-  });
-};
-
-const mockChannelAttachFailureThenSuccess = (
-  channel: Ably.RealtimeChannel,
-  status: AblyChannelState,
-  sequenceNumber: number,
-): void => {
-  vi.spyOn(channel, 'attach')
-    .mockImplementationOnce(() => {
-      const error = new Ably.ErrorInfo('error', sequenceNumber, 500);
-      vi.spyOn(channel, 'state', 'get').mockImplementation(() => {
-        vi.spyOn(channel, 'state', 'get').mockReturnValue(AblyChannelState.Attached);
-
-        return status;
-      });
-      vi.spyOn(channel, 'errorReason', 'get').mockReturnValue(error);
-
-      return Promise.reject(error);
-    })
-    .mockImplementationOnce(() => {
-      vi.spyOn(channel, 'state', 'get').mockReturnValue(AblyChannelState.Attached);
-      vi.spyOn(channel, 'errorReason', 'get').mockReturnValue(baseError);
-
-      return Promise.resolve(null);
-    });
-};
-
-const mockChannelAttachFailureThenFailed = (
-  channel: Ably.RealtimeChannel,
-  status: AblyChannelState,
-  sequenceNumber: number,
-): void => {
-  vi.spyOn(channel, 'attach')
-    .mockImplementationOnce(() => {
-      const error = new Ably.ErrorInfo('error', sequenceNumber, 500);
-      vi.spyOn(channel, 'state', 'get').mockImplementation(() => {
-        vi.spyOn(channel, 'state', 'get').mockReturnValue(AblyChannelState.Attached);
-
-        return status;
-      });
-      vi.spyOn(channel, 'errorReason', 'get').mockReturnValue(error);
-
-      return Promise.reject(error);
-    })
-    .mockImplementationOnce(() => {
-      const error2 = new Ably.ErrorInfo('error 2', 500, 50000);
-      vi.spyOn(channel, 'state', 'get').mockReturnValue(AblyChannelState.Failed);
-      vi.spyOn(channel, 'errorReason', 'get').mockReturnValue(error2);
-
-      return Promise.reject(error2);
-    });
-};
-
-const mockChannelAttachFailure = (
-  channel: Ably.RealtimeChannel,
-  status: AblyChannelState,
-  sequenceNumber: number,
-): void => {
-  vi.spyOn(channel, 'attach').mockImplementation(() => {
-    const error = new Ably.ErrorInfo('error', sequenceNumber, 500);
-    vi.spyOn(channel, 'state', 'get').mockReturnValue(status);
-    vi.spyOn(channel, 'errorReason', 'get').mockReturnValue(error);
-
-    return Promise.reject(error);
-  });
-};
-
-const mockChannelDetachNotCalled = (channel: Ably.RealtimeChannel): void => {
-  vi.spyOn(channel, 'detach').mockRejectedValue(new Error('detach should not be called'));
-};
-
-const mockChannelDetachSuccess = (channel: Ably.RealtimeChannel): void => {
-  vi.spyOn(channel, 'detach').mockImplementation(() => {
-    vi.spyOn(channel, 'state', 'get').mockReturnValue(AblyChannelState.Detached);
-    vi.spyOn(channel, 'errorReason', 'get').mockReturnValue(baseError);
-    return Promise.resolve();
-  });
-};
-
-const mockChannelDetachFailure = (
-  channel: Ably.RealtimeChannel,
-  status: AblyChannelState,
-  sequenceNumber: number,
-): void => {
-  vi.spyOn(channel, 'detach').mockImplementation(() => {
-    const error = new Ably.ErrorInfo('error', sequenceNumber, 500);
-    vi.spyOn(channel, 'state', 'get').mockReturnValue(status);
-    vi.spyOn(channel, 'errorReason', 'get').mockReturnValue(error);
-    throw error;
-  });
-};
-
-const mockChannelDetachFailureSucceedAfter = (
-  channel: Ably.RealtimeChannel,
-  status: AblyChannelState,
-  sequenceNumber: number,
-  succeedAfter: number,
-): MockInstance => {
-  // For some reason, typescript can't tell that attempts is being used
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let attempts = 0;
-  const spy = vi.spyOn(channel, 'detach');
-
-  // Mock a number of failures before we succeed
-  for (let i = 0; i < succeedAfter; i++) {
-    spy.mockImplementationOnce(() => {
-      attempts++;
-      const error = new Ably.ErrorInfo('error', sequenceNumber, 500);
-      vi.spyOn(channel, 'state', 'get').mockReturnValue(status);
-      vi.spyOn(channel, 'errorReason', 'get').mockReturnValue(error);
-      throw error;
-    });
-  }
-
-  // Mock the success
-  spy.mockImplementationOnce(() => {
-    attempts++;
-    vi.spyOn(channel, 'state', 'get').mockReturnValue(AblyChannelState.Detached);
-    vi.spyOn(channel, 'errorReason', 'get').mockReturnValue(baseError);
-    return Promise.resolve();
-  });
-
-  return spy;
-};
-
-const makeMockContributor = (
-  channel: Ably.RealtimeChannel,
-  attachmentErrorCode: ErrorCodes,
-  detachmentErrorCode: ErrorCodes,
-): MockContributor => {
-  const contributor: MockContributor = {
-    channel: channel,
-    discontinuityDetected() {},
-    attachmentErrorCode,
-    detachmentErrorCode,
-    emulateStateChange(change: Ably.ChannelStateChange, update?: boolean) {
-      vi.spyOn(contributor.channel, 'state', 'get').mockReturnValue(change.current);
-      vi.spyOn(contributor.channel, 'errorReason', 'get').mockReturnValue(change.reason ?? baseError);
-
-      (
-        contributor.channel as Ably.RealtimeChannel & {
-          emit: (event: AblyChannelState | 'update', change: Ably.ChannelStateChange) => void;
-        }
-      ).emit(update ? 'update' : (change.current as AblyChannelState), change);
-    },
-  };
-  vi.spyOn(
-    channel as Ably.RealtimeChannel & {
-      on: (events: (AblyChannelState & 'update')[], listener: Ably.channelEventCallback) => void;
-    },
-    'on',
-  );
-  vi.spyOn(channel, 'state', 'get').mockReturnValue('initialized');
-  vi.spyOn(channel, 'errorReason', 'get').mockReturnValue(new Ably.ErrorInfo('error', 500, 50000));
-  vi.spyOn(contributor, 'discontinuityDetected');
-
-  return contributor;
-};
-
-// TODO: Make initial setup (into attached) and initial listener setup a method
-describe('room lifecycle manager', () => {
+describe('RoomLifeCycleManager', () => {
   beforeEach<TestContext>((context) => {
-    context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
-
-    context.firstContributor = makeMockContributor(
-      context.realtime.channels.get('foo1'),
-      ErrorCodes.MessagesAttachmentFailed,
-      ErrorCodes.MessagesDetachmentFailed,
-    );
-    context.secondContributor = makeMockContributor(
-      context.realtime.channels.get('foo2'),
-      ErrorCodes.PresenceAttachmentFailed,
-      ErrorCodes.PresenceDetachmentFailed,
-    );
-    context.thirdContributor = makeMockContributor(
-      context.realtime.channels.get('foo3'),
-      ErrorCodes.OccupancyAttachmentFailed,
-      ErrorCodes.OccupancyDetachmentFailed,
-    );
-  });
-
-  describe('attachment lifecycle', () => {
-    it<TestContext>('resolves to attached immediately if already attached', (context) =>
-      new Promise<void>((resolve, reject) => {
-        // Force our status and contributors into attached
-        const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-        context.firstContributor.emulateStateChange({
-          current: AblyChannelState.Attached,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError,
-        });
-        status.setStatus({ status: RoomStatus.Attached });
-        vi.spyOn(context.firstContributor.channel, 'attach');
-
-        const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
-
-        monitor
-          .attach()
-          .then(() => {
-            expect(status.status).toEqual(RoomStatus.Attached);
-            expect(context.firstContributor.channel.attach).not.toHaveBeenCalled();
-            resolve();
-          })
-          .catch((error: unknown) => {
-            reject(error as Error);
-          });
-      }));
-
-    it<TestContext>('resolves to attached if existing attempt completes', async (context) =>
-      new Promise<void>((resolve, reject) => {
-        // Force our status and contributors into attached
-        const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-        context.firstContributor.emulateStateChange({
-          current: AblyChannelState.Attached,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError,
-        });
-        status.setStatus({ status: RoomStatus.Attaching });
-        vi.spyOn(context.firstContributor.channel, 'attach');
-
-        const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
-        let completionTriggered = false;
-
-        monitor
-          .attach()
-          .then(() => {
-            expect(completionTriggered).toBeTruthy();
-            expect(status.status).toEqual(RoomStatus.Attached);
-            expect(context.firstContributor.channel.attach).not.toHaveBeenCalled();
-            resolve();
-          })
-          .catch((error: unknown) => {
-            reject(error as Error);
-          });
-
-        completionTriggered = true;
-        status.setStatus({ status: RoomStatus.Attached });
-      }));
-
-    it<TestContext>('fails if the room is in the released state', async (context) => {
-      // Force our status into released
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Detached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Released });
-      vi.spyOn(context.firstContributor.channel, 'attach');
-
-      const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
-
-      await expect(monitor.attach()).rejects.toBeErrorInfoWithCode(ErrorCodes.RoomIsReleased);
-      expect(status.status).toEqual(RoomStatus.Released);
-      expect(context.firstContributor.channel.attach).not.toHaveBeenCalled();
-    });
-
-    it<TestContext>('fails if the room is in the releasing state', async (context) => {
-      // Force our status into released
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Detached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Releasing });
-      vi.spyOn(context.firstContributor.channel, 'attach');
-
-      const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
-
-      await expect(monitor.attach()).rejects.toBeErrorInfoWithCode(ErrorCodes.RoomIsReleasing);
-      expect(status.status).toEqual(RoomStatus.Releasing);
-      expect(context.firstContributor.channel.attach).not.toHaveBeenCalled();
-    });
-
-    it<TestContext>('goes via the attaching state', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Mock channel attachment results
-      mockChannelAttachSuccess(context.firstContributor.channel);
-      mockChannelAttachSuccess(context.secondContributor.channel);
-      mockChannelAttachSuccess(context.thirdContributor.channel);
-
-      const observedStatuses: RoomStatus[] = [];
-      status.onChange((newStatus) => {
-        observedStatuses.push(newStatus.current);
-      });
-
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-      await monitor.attach();
-
-      // We should have gone through attaching
-      expect(observedStatuses).toEqual([RoomStatus.Attaching, RoomStatus.Attached]);
-    });
-
-    it<TestContext>('attaches channels in sequence', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Mock channel attachment results
-      mockChannelAttachSuccess(context.firstContributor.channel);
-      mockChannelAttachSuccess(context.secondContributor.channel);
-      mockChannelAttachSuccess(context.thirdContributor.channel);
-
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-      const attachResult = monitor.attach();
-
-      // We should be in the attached state
-      await waitForRoomLifecycleStatus(status, RoomStatus.Attached);
-
-      // The channel attach methods should have been called
-      expect(context.firstContributor.channel.attach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.attach).toHaveBeenCalled();
-      expect(context.thirdContributor.channel.attach).toHaveBeenCalled();
-
-      // The attachResult should have resolved successfully
-      await attachResult;
-    });
-
-    it<TestContext>('rolls back channel attachments on channel suspending and retries', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Mock channel attachment results
-      mockChannelAttachSuccess(context.firstContributor.channel);
-      mockChannelAttachFailure(context.secondContributor.channel, AblyChannelState.Suspended, 1001);
-      mockChannelAttachSuccess(context.thirdContributor.channel);
-
-      // As the second channel will enter suspended, we expect a call to detach on the first channel and the second
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      mockChannelDetachSuccess(context.secondContributor.channel);
-
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Attach result should reject
-      await expect(monitor.attach()).rejects.toBeErrorInfo({
-        code: ErrorCodes.PresenceAttachmentFailed,
-        cause: {
-          code: 1001,
-        },
-      });
-
-      // We should be in the detached state because the second channel failed to attach
-      await waitForRoomLifecycleStatus(status, RoomStatus.Suspended);
-
-      // The third channel should not have been called as the second channel failed to attach
-      expect(context.firstContributor.channel.attach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.attach).toHaveBeenCalled();
-      expect(context.thirdContributor.channel.attach).not.toHaveBeenCalled();
-
-      // We expect the first channels detach to have been called
-      expect(context.firstContributor.channel.detach).toHaveBeenCalled();
-
-      // Retry is expecting the second contributor to become attached, so we mock that - but lets make the third fail
-      mockChannelAttachFailure(context.thirdContributor.channel, AblyChannelState.Suspended, 1002);
-      mockChannelAttachSuccess(context.secondContributor.channel);
-
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-      });
-
-      // We should be back in suspended
-      // Wait til the room error is ErrorCodes.OccupancyAttachmentFailed to ensure everything has
-      // had time to cycle
-      await waitForRoomError(status, ErrorCodes.OccupancyAttachmentFailed);
-      await waitForRoomLifecycleStatus(status, RoomStatus.Suspended);
-
-      // Now let the third channel succeed
-      mockChannelAttachSuccess(context.thirdContributor.channel);
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-      });
-
-      // Now we wait for ourselves to enter the attached state
-      await waitForRoomLifecycleStatus(status, RoomStatus.Attached);
-    });
-
-    it<TestContext>('rolls back channel attachments on channel failure', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Mock channel attachment results
-      mockChannelAttachSuccess(context.firstContributor.channel);
-      mockChannelAttachSuccess(context.secondContributor.channel);
-      mockChannelAttachFailure(context.thirdContributor.channel, AblyChannelState.Failed, 1003);
-
-      // As the third channel will enter failed, we expect a call to detach on the first channel and the second
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      mockChannelDetachSuccess(context.secondContributor.channel);
-
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Attach result should reject
-      await expect(monitor.attach()).rejects.toBeErrorInfo({
-        code: ErrorCodes.OccupancyAttachmentFailed,
-        cause: {
-          code: 1003,
-        },
-      });
-
-      // We should be in the failed state because the second channel failed to attach
-      await waitForRoomLifecycleStatus(status, RoomStatus.Failed);
-
-      // All channels should have been called
-      expect(context.firstContributor.channel.attach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.attach).toHaveBeenCalled();
-      expect(context.thirdContributor.channel.attach).toHaveBeenCalled();
-
-      // We expect both first and second channels to have had detach called
-      expect(context.firstContributor.channel.detach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.detach).toHaveBeenCalled();
-    });
-
-    it<TestContext>('rolls back channel attachments on channel entering unexpected state', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Mock channel attachment results
-      mockChannelAttachSuccess(context.firstContributor.channel);
-      mockChannelAttachSuccess(context.secondContributor.channel);
-      mockChannelAttachFailure(context.thirdContributor.channel, AblyChannelState.Detached, 1003);
-
-      // As the third channel will enter failed, we expect a call to detach on the first channel and the second
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      mockChannelDetachSuccess(context.secondContributor.channel);
-
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Attach result should reject
-      await expect(monitor.attach()).rejects.toBeErrorInfo({
-        code: ErrorCodes.RoomLifecycleError,
-        cause: {
-          code: ErrorCodes.OccupancyAttachmentFailed,
-        },
-      });
-
-      // We should be in the failed state because the second channel failed to attach
-      await waitForRoomLifecycleStatus(status, RoomStatus.Failed);
-
-      // All channels should have been called
-      expect(context.firstContributor.channel.attach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.attach).toHaveBeenCalled();
-      expect(context.thirdContributor.channel.attach).toHaveBeenCalled();
-
-      // We expect both first and second channels to have had detach called
-      expect(context.firstContributor.channel.detach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.detach).toHaveBeenCalled();
-    });
-
-    it<TestContext>('rolls back until everything completes', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Mock channel attachment results
-      mockChannelAttachSuccess(context.firstContributor.channel);
-      mockChannelAttachSuccess(context.secondContributor.channel);
-      mockChannelAttachFailure(context.thirdContributor.channel, AblyChannelState.Failed, 1003);
-
-      // As the third channel will enter suspend, we expect a call to detach on the first channel and the second
-      // But lets have the second detach fail
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      const contributor2DetachSpy = mockChannelDetachFailureSucceedAfter(
-        context.secondContributor.channel,
-        AblyChannelState.Attached,
-        1004,
-        5,
-      );
-      mockChannelDetachSuccess(context.thirdContributor.channel);
-
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Attach result should reject
-      await expect(monitor.attach()).rejects.toBeErrorInfo({
-        code: ErrorCodes.OccupancyAttachmentFailed,
-        cause: {
-          code: 1003,
-        },
-      });
-
-      // We should be in the failed state
-      await waitForRoomLifecycleStatus(status, RoomStatus.Failed);
-
-      // Wait until we've had a couple of attempts to detach the second channel
-      await vi.waitUntil(() => contributor2DetachSpy.mock.calls.length > 5, { timeout: 5000, interval: 50 });
-
-      // We should still be in the failed state
-      await waitForRoomLifecycleStatus(status, RoomStatus.Failed);
-
-      // But the function calls should be correct
-      expect(context.firstContributor.channel.attach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.attach).toHaveBeenCalled();
-      expect(context.thirdContributor.channel.attach).toHaveBeenCalled();
-      expect(context.firstContributor.channel.detach).toHaveBeenCalled();
-      expect(context.thirdContributor.channel.detach).not.toHaveBeenCalled();
-    });
-
-    it<TestContext>('sets status to failed if rollback fails', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Mock channel attachment results
-      mockChannelAttachSuccess(context.firstContributor.channel);
-      mockChannelAttachSuccess(context.secondContributor.channel);
-      mockChannelAttachFailure(context.thirdContributor.channel, AblyChannelState.Suspended, 1003);
-
-      // As the third channel will enter failed, we expect a call to detach on the first channel and the second
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      mockChannelDetachFailure(context.secondContributor.channel, AblyChannelState.Failed, 1004);
-
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Attach result should reject - we should still get the error from the third channel
-      await expect(monitor.attach()).rejects.toBeErrorInfo({
-        code: ErrorCodes.OccupancyAttachmentFailed,
-        cause: {
-          code: 1003,
-        },
-      });
-
-      // We should be in the detached state because the second channel failed its rollback
-      await waitForRoomLifecycleStatus(status, RoomStatus.Failed);
-
-      // All channels should have been called
-      expect(context.firstContributor.channel.attach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.attach).toHaveBeenCalled();
-      expect(context.thirdContributor.channel.attach).toHaveBeenCalled();
-
-      // We expect both first and second channels to have had detach called
-      expect(context.firstContributor.channel.detach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.detach).toHaveBeenCalled();
-    });
-
-    it<TestContext>('ignores channel status changes during the attach cycle', async (context) => {
-      vi.useFakeTimers();
-
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // For the first channel, we'll do an attach that only completes after a timer has happened, so that we
-      // can simulate a channel state change during the attach cycle
-      vi.spyOn(context.firstContributor.channel, 'attach').mockImplementation(() => {
-        return new Promise((resolve) => {
-          setTimeout(() => {
-            vi.spyOn(context.firstContributor.channel, 'state', 'get').mockReturnValue(AblyChannelState.Attached);
-            vi.spyOn(context.firstContributor.channel, 'errorReason', 'get').mockReturnValue(baseError);
-            resolve(null);
-          }, 1000);
-        });
-      });
-
-      // For argument's sake, the second channel will go from suspended to attached when the attach call is made.
-      mockChannelAttachSuccess(context.secondContributor.channel);
-
-      // Observe the statuses that go by
-      const observedStatuses: RoomStatus[] = [];
-      status.onChange((newStatus) => {
-        observedStatuses.push(newStatus.current);
-      });
-
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Start the attach and wait until the first channel attach is called to ensure the op is in-progress
-      const attachPromise = monitor.attach();
-      await vi.waitFor(() => {
-        expect(context.firstContributor.channel.attach).toHaveBeenCalled();
-      });
-
-      // Simulate a channel state change on the second channel
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Suspended,
-        previous: 'attached',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Wait until the second contributors channel enters the suspended state
-      await new Promise<void>((resolve) => {
-        if (context.secondContributor.channel.state === AblyChannelState.Suspended) {
-          resolve();
+    const logger = makeTestLogger();
+
+    context.mockChannel = {
+      attach: vi.fn().mockImplementation(() => Promise.resolve(null)),
+      detach: vi.fn().mockImplementation(() => Promise.resolve(null)),
+      state: 'initialized',
+      invokeStateChange: (stateChange: Ably.ChannelStateChange, isUpdate = false) => {
+        for (const handler of context.mockChannel._stateChangeHandlersForAll) {
+          handler(stateChange);
         }
 
-        context.secondContributor.channel.on((change) => {
-          if (change.current === AblyChannelState.Suspended) {
-            resolve();
-          }
-        });
-      });
-
-      // Now we let the first channel complete its attach
-      await vi.advanceTimersToNextTimerAsync();
-
-      // Attach result should resolve
-      await expect(attachPromise).resolves.toBeUndefined();
-
-      // We should be in the attached state now
-      await waitForRoomLifecycleStatus(status, RoomStatus.Attached);
-
-      // The states we should have seen are attaching and attached
-      expect(observedStatuses).toEqual([RoomStatus.Attaching, RoomStatus.Attached]);
-
-      // But if we suspend now, the room should go into suspended
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Suspended,
-        previous: 'attached',
-        resumed: false,
-        reason: baseError,
-      });
-
-      await waitForRoomLifecycleStatus(status, RoomStatus.Suspended);
-
-      vi.useRealTimers();
-    });
-  });
-
-  describe('detachment lifecycle', () => {
-    it<TestContext>('resolves to detached immediately if already detached', async (context) => {
-      // Force our status and contributors into detached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Detached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Detached });
-      vi.spyOn(context.firstContributor.channel, 'detach');
-
-      const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
-
-      await monitor.detach();
-      expect(status.status).toEqual(RoomStatus.Detached);
-      expect(context.firstContributor.channel.detach).not.toHaveBeenCalled();
-    });
-
-    it<TestContext>('rejects detach if already in failed state', async (context) => {
-      // Force our status and contributors into detached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Detached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Failed });
-      vi.spyOn(context.firstContributor.channel, 'detach');
-
-      const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
-
-      await expect(monitor.detach()).rejects.toBeErrorInfoWithCode(ErrorCodes.RoomInFailedState);
-      expect(status.status).toEqual(RoomStatus.Failed);
-      expect(context.firstContributor.channel.detach).not.toHaveBeenCalled();
-    });
-
-    it<TestContext>('resolves to detached if existing attempt completes', (context) =>
-      new Promise<void>((resolve, reject) => {
-        // Force our status and contributors into detached
-        const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-        context.firstContributor.emulateStateChange({
-          current: AblyChannelState.Detached,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError,
-        });
-        status.setStatus({ status: RoomStatus.Detaching });
-        vi.spyOn(context.firstContributor.channel, 'detach');
-
-        const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
-        let completionTriggered = false;
-
-        monitor
-          .detach()
-          .then(() => {
-            expect(completionTriggered).toBeTruthy();
-            expect(status.status).toEqual(RoomStatus.Detached);
-            expect(context.firstContributor.channel.detach).not.toHaveBeenCalled();
-            resolve();
-          })
-          .catch((error: unknown) => {
-            reject(error as Error);
-          });
-
-        completionTriggered = true;
-        status.setStatus({ status: RoomStatus.Detached });
-      }));
-
-    it<TestContext>('fails if the room is in the released state', async (context) => {
-      // Force our status into released
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Released });
-      vi.spyOn(context.firstContributor.channel, 'detach');
-
-      const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
-
-      await expect(monitor.detach()).rejects.toBeErrorInfoWithCode(ErrorCodes.RoomIsReleased);
-      expect(status.status).toEqual(RoomStatus.Released);
-      expect(context.firstContributor.channel.detach).not.toHaveBeenCalled();
-    });
-
-    it<TestContext>('fails if the room is in the releasing state', async (context) => {
-      // Force our status into released
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Releasing });
-      vi.spyOn(context.firstContributor.channel, 'detach');
-
-      const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
-
-      await expect(monitor.detach()).rejects.toBeErrorInfoWithCode(ErrorCodes.RoomIsReleasing);
-      expect(status.status).toEqual(RoomStatus.Releasing);
-      expect(context.firstContributor.channel.detach).not.toHaveBeenCalled();
-    });
-
-    it<TestContext>('goes via the detaching state', async (context) => {
-      // Force our status and contributors into detached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Initialized,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Mock channel detachment results
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      mockChannelDetachSuccess(context.secondContributor.channel);
-      mockChannelDetachSuccess(context.thirdContributor.channel);
-
-      const observedStatuses: RoomStatus[] = [];
-      status.onChange((newStatus) => {
-        observedStatuses.push(newStatus.current);
-      });
-
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-      await monitor.detach();
-
-      // We should have gone through detaching
-      expect(observedStatuses).toEqual([RoomStatus.Detaching, RoomStatus.Detached]);
-    });
-
-    it<TestContext>('detaches channels in sequence', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Mock channel detachment results
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      mockChannelDetachSuccess(context.secondContributor.channel);
-      mockChannelDetachSuccess(context.thirdContributor.channel);
-
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-      await expect(monitor.detach()).resolves.toBeUndefined();
-
-      // We should be in the detached state
-      await waitForRoomLifecycleStatus(status, RoomStatus.Detached);
-
-      // The channel detach methods should have been called
-      expect(context.firstContributor.channel.detach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.detach).toHaveBeenCalled();
-      expect(context.thirdContributor.channel.detach).toHaveBeenCalled();
-    });
-
-    it<TestContext>('detaches all channels but enters failed state if one fails', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Mock channel detachment results
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      mockChannelDetachFailure(context.secondContributor.channel, AblyChannelState.Failed, 1004);
-      mockChannelDetachSuccess(context.thirdContributor.channel);
-
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      await expect(monitor.detach()).rejects.toBeErrorInfo({
-        code: ErrorCodes.PresenceDetachmentFailed,
-        cause: {
-          code: 1004,
-        },
-      });
-
-      // We should be in the failed state
-      await waitForRoomLifecycleStatus(status, RoomStatus.Failed);
-
-      // The channel detach methods should have been called
-      expect(context.firstContributor.channel.detach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.detach).toHaveBeenCalled();
-      expect(context.thirdContributor.channel.detach).toHaveBeenCalled();
-    });
-
-    it<TestContext>('keeps detaching until everything completes', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Mock channel detachment results
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      const secondContributorSpy = mockChannelDetachFailureSucceedAfter(
-        context.secondContributor.channel,
-        AblyChannelState.Attached,
-        1004,
-        5,
-      );
-      mockChannelDetachSuccess(context.thirdContributor.channel);
-
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      await expect(monitor.detach()).resolves.toBeUndefined();
-
-      // We should be in the detached state
-      await waitForRoomLifecycleStatus(status, RoomStatus.Detached);
-
-      // Wait for our second channel to have had a few attempts to detach
-      await vi.waitUntil(() => secondContributorSpy.mock.calls.length > 5, { timeout: 5000, interval: 50 });
-
-      // The channel detach methods should have been called
-      expect(context.firstContributor.channel.detach).toHaveBeenCalled();
-      // 5 + the final success
-      expect(context.secondContributor.channel.detach).toHaveBeenCalledTimes(6);
-      expect(context.thirdContributor.channel.detach).toHaveBeenCalled();
-    });
-
-    it<TestContext>('ignores channel status changes during the detach cycle', async (context) => {
-      vi.useFakeTimers();
-
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // For the first channel, we'll do a detach that only completes after a timer has happened, so that we
-      // can simulate a channel state change during the detach cycle
-      vi.spyOn(context.firstContributor.channel, 'detach').mockImplementation(() => {
-        return new Promise((resolve) => {
-          setTimeout(() => {
-            vi.spyOn(context.firstContributor.channel, 'state', 'get').mockReturnValue(AblyChannelState.Detached);
-            vi.spyOn(context.firstContributor.channel, 'errorReason', 'get').mockReturnValue(baseError);
-            resolve();
-          }, 1000);
-        });
-      });
-
-      // For argument's sake, the second channel will go from suspended to attached when the detach call is made.
-      mockChannelDetachSuccess(context.secondContributor.channel);
-
-      // Observe the statuses that go by
-      const observedStatuses: RoomStatus[] = [];
-      status.onChange((newStatus) => {
-        observedStatuses.push(newStatus.current);
-      });
-
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Start the detach and wait for the first channel detach to be called to ensure the op is in-progress
-      const detachPromise = monitor.detach();
-      await vi.waitFor(() => {
-        expect(context.firstContributor.channel.detach).toHaveBeenCalled();
-      });
-
-      // Simulate a channel state change on the second channel
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Suspended,
-        previous: 'attached',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Wait until the second contributors channel enters the suspended state
-      await new Promise<void>((resolve) => {
-        if (context.secondContributor.channel.state === AblyChannelState.Suspended) {
-          resolve();
-        }
-
-        context.secondContributor.channel.on((change) => {
-          if (change.current === AblyChannelState.Suspended) {
-            resolve();
-          }
-        });
-      });
-
-      // Now we let the first channel complete its detach
-      await vi.advanceTimersToNextTimerAsync();
-
-      // Detach result should resolve
-      await expect(detachPromise).resolves.toBeUndefined();
-
-      // We should be in the detached state now
-      await waitForRoomLifecycleStatus(status, RoomStatus.Detached);
-
-      // The states we should have seen are detaching and detached
-      expect(observedStatuses).toEqual([RoomStatus.Detaching, RoomStatus.Detached]);
-
-      // Now if we try to attach again, we should be able to
-      mockChannelAttachSuccess(context.firstContributor.channel);
-      mockChannelAttachSuccess(context.secondContributor.channel);
-
-      await expect(monitor.attach()).resolves.toBeUndefined();
-
-      // We should be in the attached state now
-      await waitForRoomLifecycleStatus(status, RoomStatus.Attached);
-
-      vi.useRealTimers();
-    });
-  });
-
-  describe('transient state', () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it<TestContext>('handles transient detaches', (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Attached });
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const manager = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
-
-      // Transition the contributor to detached
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Detached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Check that the status is as expected
-      expect(status.status).toEqual(RoomStatus.Attached);
-
-      // Transition the contributor to attached again
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'detached',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Expire any fake timers
-      vi.advanceTimersToNextTimer();
-
-      // Check that the status is as expected
-      expect(status.status).toEqual(RoomStatus.Attached);
-    });
-
-    it<TestContext>('handles transient detaches with multiple contributors', (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError2,
-      });
-      status.setStatus({ status: RoomStatus.Attached });
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const manager = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Transition the first contributor to detached
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Detached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Check that the status is as expected
-      expect(status.status).toEqual(RoomStatus.Attached);
-
-      // Transition the second contributor to detached
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Detached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Check that the status is as expected
-      expect(status.status).toEqual(RoomStatus.Attached);
-
-      // Transition the first contributor to attached again
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'detached',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Check that the status is as expected
-      expect(status.status).toEqual(RoomStatus.Attached);
-
-      // Transition the second contributor to attached again
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'detached',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Check that the status is as expected
-      expect(status.status).toEqual(RoomStatus.Attached);
-
-      // Expire any fake timers
-      vi.advanceTimersToNextTimer();
-
-      // Check that the status is as expected
-      expect(status.status).toEqual(RoomStatus.Attached);
-    });
-
-    // Transient detach is where the channel goes back to attaching as a result of a DETACHED protocol message
-    test<TestContext>('transitions to attaching when transient detach times out', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError2,
-      });
-      status.setStatus({ status: RoomStatus.Attached });
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Transition the contributor to detached
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attaching,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // We should still be in the attached state
-      expect(status.status).toEqual(RoomStatus.Attached);
-
-      // Expire any fake timers
-      vi.advanceTimersToNextTimer();
-
-      // Check that the status is as expected
-      await waitForRoomLifecycleStatus(status, RoomStatus.Attaching);
-      expect(status.error).toEqual(baseError);
-    });
-  });
-
-  describe('non-transient state changes', () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it<TestContext>('transitions to failed if an underlying channel fails', (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError2,
-      });
-      status.setStatus({ status: RoomStatus.Attached });
-
-      // Mock channel detachment results
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      mockChannelDetachSuccess(context.secondContributor.channel);
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Transition contributor two to detached to simulate a transient outage
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Detached,
-        previous: 'attached',
-        resumed: false,
-        reason: baseError2,
-      });
-
-      // Transition the first contributor to failed
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Failed,
-        previous: 'attached',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Check that the status is as expected
-      expect(status.status).toEqual(RoomStatus.Failed);
-      expect(status.error).toEqual(baseError);
-
-      // Only the second contributor should have been detached
-      expect(context.firstContributor.channel.detach).not.toHaveBeenCalled();
-      expect(context.secondContributor.channel.detach).toHaveBeenCalled();
-
-      // Expire any fake timers
-      vi.advanceTimersToNextTimer();
-
-      // The transient timeout timer for the second contributor should have been cleared, so we should still be in the failed state
-      expect(status.status).toEqual(RoomStatus.Failed);
-    });
-
-    it<TestContext>('recovers from an underlying channel entering the suspended state', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError2,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Attached });
-
-      // Mock channel detachment results
-      mockChannelDetachNotCalled(context.firstContributor.channel);
-      mockChannelDetachSuccess(context.secondContributor.channel);
-      mockChannelDetachSuccess(context.thirdContributor.channel);
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Mock channel re-attachment results
-      mockChannelAttachSuccess(context.firstContributor.channel);
-      mockChannelAttachSuccess(context.secondContributor.channel);
-      mockChannelAttachSuccess(context.thirdContributor.channel);
-
-      // Transition the first contributor to suspended
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Suspended,
-        previous: 'attached',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Check that the status is as expected
-      await waitForRoomLifecycleStatus(status, RoomStatus.Suspended);
-
-      // Now transition the first contributor to attached again
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'suspended',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Check that the status is as expected
-      await waitForRoomLifecycleStatus(status, RoomStatus.Attached);
-
-      // The second and third contributors should have been detached
-      expect(context.firstContributor.channel.detach).not.toHaveBeenCalled();
-      expect(context.secondContributor.channel.detach).toHaveBeenCalled();
-      expect(context.thirdContributor.channel.detach).toHaveBeenCalled();
-
-      // All contributors should have been attached
-      expect(context.firstContributor.channel.attach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.attach).toHaveBeenCalled();
-      expect(context.thirdContributor.channel.attach).toHaveBeenCalled();
-    });
-
-    it<TestContext>('recovers from a re-attachment cycle without detaching channels', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError2,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Attached });
-
-      // Mock channel detachment results
-      mockChannelDetachNotCalled(context.firstContributor.channel);
-      mockChannelDetachSuccess(context.secondContributor.channel);
-      mockChannelDetachSuccess(context.thirdContributor.channel);
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Mock channel re-attachment results
-      mockChannelAttachSuccess(context.firstContributor.channel);
-      mockChannelAttachSuccess(context.secondContributor.channel);
-      mockChannelAttachSuccess(context.thirdContributor.channel);
-
-      // Transition the first contributor to attaching
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attaching,
-        previous: 'attached',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Check that the status is as expected
-      await waitForRoomLifecycleStatus(status, RoomStatus.Attaching);
-
-      // Now transition the first contributor to attached again
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'suspended',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Check that the status is as expected
-      await waitForRoomLifecycleStatus(status, RoomStatus.Attached);
-
-      // We shouldn't have detached anything, as we're actively trying to re-attach
-      expect(context.firstContributor.channel.detach).not.toHaveBeenCalled();
-      expect(context.secondContributor.channel.detach).not.toHaveBeenCalled();
-      expect(context.thirdContributor.channel.detach).not.toHaveBeenCalled();
-
-      // We also shouldn't have attached anything, as we're already attached
-      expect(context.firstContributor.channel.attach).not.toHaveBeenCalled();
-      expect(context.secondContributor.channel.attach).not.toHaveBeenCalled();
-      expect(context.thirdContributor.channel.attach).not.toHaveBeenCalled();
-    });
-
-    it<TestContext>('recovers from a suspended channel via retries', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError2,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Attached });
-
-      // Mock channel detachment results
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      mockChannelDetachSuccess(context.secondContributor.channel);
-      mockChannelDetachSuccess(context.thirdContributor.channel);
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Mock channel re-attachment results
-      mockChannelAttachSuccess(context.firstContributor.channel);
-      mockChannelAttachFailureThenSuccess(context.secondContributor.channel, AblyChannelState.Suspended, 1001);
-      mockChannelAttachSuccess(context.thirdContributor.channel);
-
-      // Observations
-      let feature2AttachError: Ably.ErrorInfo | undefined;
-      const observedStatuses: RoomStatus[] = [];
-      status.onChange((newStatus) => {
-        if (newStatus.current === RoomStatus.Suspended) {
-          feature2AttachError = newStatus.error;
-        }
-
-        observedStatuses.push(newStatus.current);
-      });
-
-      // Transition the first contributor to detached
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Suspended,
-        previous: 'attached',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Check that the status is as expected
-      await waitForRoomLifecycleStatus(status, RoomStatus.Suspended);
-
-      // Now transition the first contributor to attached again
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'suspended',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // We should be in attached state
-      await waitForRoomLifecycleStatus(status, RoomStatus.Attached);
-
-      // The first feature got detached when feature 2 failed to attach
-      // The second feature got detached when feature 1 failed
-      // The third feature got detached when feature 1 failed and also when 2 failed to attach
-      expect(context.firstContributor.channel.detach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.detach).toHaveBeenCalled();
-      expect(context.thirdContributor.channel.detach).toHaveBeenCalledTimes(2);
-
-      // Feature 1 would have had attach called after feature 2 failed to attach
-      // Feature 2 would have had attach called after feature 1 failed
-      // Feature 3 would have had attach called after feature 1 failed and also after feature 2 failed to attach
-      expect(context.firstContributor.channel.attach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.attach).toHaveBeenCalledTimes(2);
-      expect(context.thirdContributor.channel.attach).toHaveBeenCalled();
-
-      // We should have seen feature 2's error come through during the attach sequence
-      expect(feature2AttachError).toBeErrorInfo({
-        code: ErrorCodes.PresenceAttachmentFailed,
-        cause: {
-          code: 1001,
-        },
-      });
-
-      // We should have seen a sequence of statuses
-      expect(observedStatuses).toEqual([
-        RoomStatus.Suspended,
-        RoomStatus.Attaching,
-        RoomStatus.Suspended,
-        RoomStatus.Attaching,
-        RoomStatus.Attached,
-      ]);
-    });
-
-    it<TestContext>('does not wind down contributors with shared channel', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError2,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      // We'll give the second contributor the same channel as the third
-      context.secondContributor.channel = context.thirdContributor.channel;
-      status.setStatus({ status: RoomStatus.Attached });
-
-      // Mock channel detachment results
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      mockChannelDetachSuccess(context.secondContributor.channel);
-      mockChannelDetachSuccess(context.thirdContributor.channel);
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Mock channel re-attachment results
-      mockChannelAttachSuccess(context.firstContributor.channel);
-      mockChannelAttachFailureThenSuccess(context.secondContributor.channel, AblyChannelState.Suspended, 1001);
-
-      // Observations
-      let feature2AttachError: Ably.ErrorInfo | undefined;
-      const observedStatuses: RoomStatus[] = [];
-      status.onChange((newStatus) => {
-        if (newStatus.current === RoomStatus.Suspended) {
-          feature2AttachError = newStatus.error;
-        }
-
-        observedStatuses.push(newStatus.current);
-      });
-
-      // Transition the first contributor to detached
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Suspended,
-        previous: 'attached',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Check that the status is as expected
-      await waitForRoomLifecycleStatus(status, RoomStatus.Suspended);
-
-      // Now transition the first contributor to attached again
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'suspended',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // We should be in attached state
-      await waitForRoomLifecycleStatus(status, RoomStatus.Attached);
-
-      // The first feature will have detach called during the second feature failure sequence
-      // The second and third features will have detach called twice (once by each), as they share a channel. This
-      // is as a result of the first feature failing (initial wind down).
-      expect(context.firstContributor.channel.detach).toBeCalledTimes(1);
-      expect(context.secondContributor.channel.detach).toBeCalledTimes(2);
-      expect(context.thirdContributor.channel.detach).toHaveBeenCalledTimes(2);
-
-      // Feature 1 will have attach called twice. First time once it recovers from suspended, second when feature
-      // 2 recovers.
-      // Features 2 and 3 will have attach called 3 times in total. Once during the re-attach and failure sequence
-      // when feature 1 recovers, then twice after feature 2 recovers.
-      expect(context.firstContributor.channel.attach).toHaveBeenCalledTimes(2);
-      expect(context.secondContributor.channel.attach).toHaveBeenCalledTimes(3);
-      expect(context.thirdContributor.channel.attach).toHaveBeenCalledTimes(3);
-
-      // We should have seen feature 1's error come through during the attach sequence as they share a channel
-      expect(feature2AttachError).toBeErrorInfo({
-        code: ErrorCodes.PresenceAttachmentFailed,
-        cause: {
-          code: 1001,
-        },
-      });
-
-      // We should have seen a sequence of statuses
-      expect(observedStatuses).toEqual([
-        RoomStatus.Suspended,
-        RoomStatus.Attaching,
-        RoomStatus.Suspended,
-        RoomStatus.Attaching,
-        RoomStatus.Attached,
-      ]);
-    });
-
-    it<TestContext>('recovers from a suspended channel via many retries', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError2,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Attached });
-
-      // Mock channel detachment results
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      mockChannelDetachSuccess(context.secondContributor.channel);
-      mockChannelDetachSuccess(context.thirdContributor.channel);
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Mock channel re-attachment results
-      mockChannelAttachSuccess(context.firstContributor.channel);
-      mockChannelAttachFailure(context.secondContributor.channel, AblyChannelState.Suspended, 1001);
-      mockChannelAttachSuccess(context.thirdContributor.channel);
-
-      // Observations
-      let feature1AttachError: Ably.ErrorInfo | undefined;
-      let feature2AttachError: Ably.ErrorInfo | undefined;
-      let feature3AttachError: Ably.ErrorInfo | undefined;
-      const observedStatuses: RoomStatus[] = [];
-      status.onChange((newStatus) => {
-        observedStatuses.push(newStatus.current);
-
-        if (newStatus.current === RoomStatus.Suspended && !feature1AttachError) {
-          feature1AttachError = newStatus.error;
+        const handlers = isUpdate
+          ? context.mockChannel._stateChangeHandlers.get('update')
+          : context.mockChannel._stateChangeHandlers.get(stateChange.current);
+        if (!handlers) {
           return;
         }
 
-        if (newStatus.current === RoomStatus.Suspended && !feature2AttachError) {
-          feature2AttachError = newStatus.error;
-          return;
+        for (const handler of handlers) {
+          handler(stateChange);
         }
+      },
+      _stateChangeHandlers: new Map<Ably.ChannelEvent, ((stateChange: Ably.ChannelStateChange) => void)[]>(),
+      _stateChangeHandlersForAll: [],
+      on: vi
+        .fn()
+        .mockImplementation(
+          (event: Ably.ChannelEvent | Ably.ChannelEvent[], handler: (stateChange: Ably.ChannelStateChange) => void) => {
+            if (typeof event === 'string') {
+              event = [event];
+            } else if (typeof event === 'function') {
+              context.mockChannel._stateChangeHandlersForAll.push(
+                event as unknown as (stateChange: Ably.ChannelStateChange) => void,
+              );
+              return;
+            }
 
-        if (newStatus.current === RoomStatus.Suspended && !feature3AttachError) {
-          feature3AttachError = newStatus.error;
-          return;
-        }
-      });
+            for (const e of event) {
+              if (!context.mockChannel._stateChangeHandlers.has(e)) {
+                context.mockChannel._stateChangeHandlers.set(e, []);
+              }
 
-      // Transition the first contributor to suspended
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Suspended,
-        previous: 'attached',
-        resumed: false,
-        reason: baseError,
-      });
+              context.mockChannel._stateChangeHandlers
+                .get(e)
+                ?.push(
+                  Array.isArray(event) ? handler : (event as unknown as (stateChange: Ably.ChannelStateChange) => void),
+                );
+            }
+          },
+        ),
+    };
 
-      // Check that the status is as expected
-      await waitForRoomLifecycleStatus(status, RoomStatus.Suspended);
+    context.channelManager = {
+      get: vi.fn().mockReturnValue(context.mockChannel as Ably.RealtimeChannel),
+      release: vi.fn(),
+    } as unknown as ChannelManager;
 
-      const seenAttaching = new Promise<void>((resolve, reject) => {
-        status.onChangeOnce((newStatus) => {
-          if (newStatus.current === RoomStatus.Attaching) {
-            resolve();
-          }
-
-          if (newStatus.current === RoomStatus.Failed) {
-            reject(new Error('Failed to transition to attaching'));
-          }
-        });
-      });
-
-      // Now transition the first contributor to attached again
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'suspended',
-        resumed: false,
-        reason: baseError,
-      });
-
-      await seenAttaching;
-
-      // We should be in suspended state, because the  second contributor failed to attach
-      await waitForRoomLifecycleStatus(status, RoomStatus.Suspended);
-
-      // Now for arguments sake, the third contributor fails to attach
-      mockChannelAttachFailure(context.thirdContributor.channel, AblyChannelState.Suspended, 1001);
-      mockChannelAttachSuccess(context.secondContributor.channel);
-
-      const seenAttachingAgain = new Promise<void>((resolve, reject) => {
-        status.onChangeOnce((newStatus) => {
-          if (newStatus.current === RoomStatus.Attaching) {
-            resolve();
-          }
-
-          if (newStatus.current === RoomStatus.Failed) {
-            reject(new Error('Failed to transition to attaching'));
-          }
-        });
-      });
-
-      // Now transition the second contributor to attached again
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'suspended',
-        resumed: false,
-        reason: baseError2,
-      });
-
-      await seenAttachingAgain;
-
-      // We should still suspended, because the third contributor failed to attach
-      await waitForRoomLifecycleStatus(status, RoomStatus.Suspended);
-
-      // One last time, the third contributor will succeed
-      mockChannelAttachSuccess(context.thirdContributor.channel);
-
-      // Now transition the third contributor to attached again
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'suspended',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // We should be in attached state
-      await waitForRoomLifecycleStatus(status, RoomStatus.Attached);
-
-      // The first feature got detached when feature 2 failed to attach and when feature 3 failed to attach
-      // The second feature got detached when feature 1 failed to attach and when feature 3 failed to attach
-      // The third feature got detached when feature 1 failed to attach and when feature 2 failed to attach
-      expect(context.firstContributor.channel.detach).toHaveBeenCalledTimes(2);
-      expect(context.secondContributor.channel.detach).toHaveBeenCalledTimes(2);
-      expect(context.thirdContributor.channel.detach).toHaveBeenCalledTimes(2);
-
-      // Feature 1 would have had attach called after feature 2's failure, feature 3's failure, and in the final run
-      // Feature 2 would have had attach called after in its own failure, and feature 3's failure (feature 1's is hidden by a mock reset)
-      // Feature 3 would have had attach called after feature 1 failed and also after feature 2 failed to attach
-      expect(context.firstContributor.channel.attach).toHaveBeenCalledTimes(3);
-      expect(context.secondContributor.channel.attach).toHaveBeenCalledTimes(2);
-      expect(context.thirdContributor.channel.attach).toHaveBeenCalledOnce();
-
-      // Feature 1's error should be the first one we saw
-      expect(feature1AttachError).toBeErrorInfo({
-        code: 500,
-      });
-
-      // We should have seen feature 2's error come through during the attach sequence
-      expect(feature2AttachError).toBeErrorInfo({
-        code: ErrorCodes.PresenceAttachmentFailed,
-        cause: {
-          code: 1001,
-        },
-      });
-
-      // We should have seen feature 3's error come through during the attach sequence
-      expect(feature3AttachError).toBeErrorInfo({
-        code: ErrorCodes.OccupancyAttachmentFailed,
-        cause: {
-          code: 1001,
-        },
-      });
-
-      // We should have seen a sequence of statuses
-      expect(observedStatuses).toEqual([
-        RoomStatus.Suspended,
-        RoomStatus.Attaching,
-        RoomStatus.Suspended,
-        RoomStatus.Attaching,
-        RoomStatus.Suspended,
-        RoomStatus.Attaching,
-        RoomStatus.Attached,
-      ]);
-    });
-
-    it<TestContext>('enters failed if a contributor fails during retry', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError2,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Attached });
-
-      // Mock channel detachment results
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      mockChannelDetachSuccess(context.secondContributor.channel);
-      mockChannelDetachSuccess(context.thirdContributor.channel);
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      // Mock channel re-attachment results
-      mockChannelAttachSuccess(context.firstContributor.channel);
-      mockChannelAttachFailureThenFailed(context.secondContributor.channel, AblyChannelState.Suspended, 1001);
-      mockChannelAttachSuccess(context.thirdContributor.channel);
-
-      // Observations
-      let feature2AttachError: Ably.ErrorInfo | undefined;
-      const observedStatuses: RoomStatus[] = [];
-      status.onChange((newStatus) => {
-        if (newStatus.current === RoomStatus.Suspended) {
-          feature2AttachError = newStatus.error;
-        }
-
-        observedStatuses.push(newStatus.current);
-      });
-
-      // Transition the first contributor to suspended
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Suspended,
-        previous: 'attached',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // Check that the status is as expected
-      await waitForRoomLifecycleStatus(status, RoomStatus.Suspended);
-
-      // Now transition the first contributor to attached again
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'suspended',
-        resumed: false,
-        reason: baseError,
-      });
-
-      // We should be in failed state
-      await waitForRoomLifecycleStatus(status, RoomStatus.Failed);
-
-      // The first feature got detached when feature 2 failed to attach
-      // The second feature got detached when feature 1 failed
-      // The third feature got detached when feature 1 failed and also when 2 failed to attach
-      expect(context.firstContributor.channel.detach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.detach).toHaveBeenCalled();
-      expect(context.thirdContributor.channel.detach).toHaveBeenCalledTimes(3);
-
-      // Feature 1 would have had attach called after feature 2 failed to attach
-      // Feature 2 would have had attach called after feature 1 failed
-      // Feature 3 never got to attach
-      expect(context.firstContributor.channel.attach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.attach).toHaveBeenCalledTimes(2);
-      expect(context.thirdContributor.channel.attach).not.toHaveBeenCalled();
-
-      // We should have seen feature 2's error come through during the attach sequence
-      expect(feature2AttachError).toBeErrorInfo({
-        code: ErrorCodes.PresenceAttachmentFailed,
-        cause: {
-          code: 1001,
-        },
-      });
-
-      // We should have seen a sequence of statuses
-      expect(observedStatuses).toEqual([
-        RoomStatus.Suspended,
-        RoomStatus.Attaching,
-        RoomStatus.Suspended,
-        RoomStatus.Attaching,
-        RoomStatus.Failed,
-      ]);
-
-      // Send contributor 2 into attached
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'failed',
-        resumed: false,
-        reason: baseError2,
-      });
-
-      // We still should be in failed state - we've given up trying
-      await waitForRoomLifecycleStatus(status, RoomStatus.Failed);
-    });
+    context.roomStatus = new DefaultRoomLifecycle('test-room', logger);
+    context.logger = logger;
+    context.roomLifeCycleManager = new RoomLifeCycleManager(
+      'test-room',
+      context.channelManager,
+      context.roomStatus,
+      context.logger,
+    );
   });
 
-  describe('discontinuity handling', () => {
-    describe('via update', () => {
-      it<TestContext>('ignores a discontinuity event if the channel never made it to attached', async (context) => {
-        // Force our status and contributors into initialized
-        const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-        context.firstContributor.emulateStateChange({
-          current: AblyChannelState.Initialized,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError,
-        });
-        status.setStatus({ status: RoomStatus.Initialized });
+  describe('attach', () => {
+    it<TestContext>('should be a no-op if room is already attached', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Attached });
 
-        const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
+      // Act
+      await roomLifeCycleManager.attach();
 
-        // Send the monitor through the attach cycle, but lets fail the attach
-        mockChannelAttachFailure(context.firstContributor.channel, AblyChannelState.Suspended, 1001);
-        mockChannelDetachSuccess(context.firstContributor.channel);
-
-        await expect(monitor.attach()).rejects.toBeErrorInfo({
-          code: ErrorCodes.MessagesAttachmentFailed,
-          cause: { code: 1001 },
-        });
-
-        // Emit an update / discontinuity event on the first contributor (for arguments sake)
-        context.firstContributor.emulateStateChange(
-          {
-            current: AblyChannelState.Attached,
-            previous: AblyChannelState.Initialized,
-            resumed: false,
-            reason: baseError,
-          },
-          true,
-        );
-
-        // Our status should be detached
-        expect(status.status).toEqual(RoomStatus.Suspended);
-
-        // We should not have seen a discontinuity event
-        expect(context.firstContributor.discontinuityDetected).not.toHaveBeenCalled();
-
-        // Now try to attach again
-        mockChannelAttachSuccess(context.firstContributor.channel);
-        await monitor.attach();
-
-        // Our status should be attached
-        expect(status.status).toEqual(RoomStatus.Attached);
-
-        // But we still shouldn't have seen a discontinuity event
-        expect(context.firstContributor.discontinuityDetected).not.toHaveBeenCalled();
-      });
-
-      it<TestContext>('registers a discontinuity event immediately if fully attached and an update event is received', async (context) => {
-        // Force our status and contributors into attached
-        const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-        context.firstContributor.emulateStateChange({
-          current: AblyChannelState.Attached,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError,
-        });
-        context.secondContributor.emulateStateChange({
-          current: AblyChannelState.Attached,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError2,
-        });
-        context.thirdContributor.emulateStateChange({
-          current: AblyChannelState.Attached,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError,
-        });
-        status.setStatus({ status: RoomStatus.Initialized });
-
-        const monitor = new RoomLifecycleManager(
-          status,
-          [context.firstContributor, context.secondContributor, context.thirdContributor],
-          makeTestLogger(),
-          5,
-        );
-
-        // Sent the monitor through the attach cycle
-        mockChannelAttachSuccess(context.firstContributor.channel);
-        mockChannelAttachSuccess(context.secondContributor.channel);
-        mockChannelAttachSuccess(context.thirdContributor.channel);
-
-        await monitor.attach();
-
-        // Emit an update / discontinuity event on the first contributor
-        context.firstContributor.emulateStateChange(
-          {
-            current: AblyChannelState.Attached,
-            previous: AblyChannelState.Attached,
-            resumed: false,
-            reason: baseError,
-          },
-          true,
-        );
-
-        // Our first contributor should have registered a discontinuity event
-        expect(status.status).toEqual(RoomStatus.Attached);
-        expect(context.firstContributor.discontinuityDetected).toBeCalledWith(baseError);
-      });
-
-      it<TestContext>('should prefer the first discontinuity event if multiple are received', async (context) => {
-        vi.useFakeTimers();
-
-        // Force our status and contributors into attached
-        const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-        context.firstContributor.emulateStateChange({
-          current: AblyChannelState.Attached,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError,
-        });
-        context.secondContributor.emulateStateChange({
-          current: AblyChannelState.Attached,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError2,
-        });
-        context.thirdContributor.emulateStateChange({
-          current: AblyChannelState.Attached,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError,
-        });
-        status.setStatus({ status: RoomStatus.Initialized });
-
-        const monitor = new RoomLifecycleManager(
-          status,
-          [context.firstContributor, context.secondContributor, context.thirdContributor],
-          makeTestLogger(),
-          5,
-        );
-
-        // Send the monitor through the attach cycle
-
-        mockChannelAttachSuccess(context.firstContributor.channel);
-        mockChannelAttachSuccess(context.secondContributor.channel);
-        mockChannelAttachSuccess(context.thirdContributor.channel);
-
-        await monitor.attach();
-
-        // Send the monitor through the detach cycle - the first contributor wont detach until a promise resolves
-        vi.spyOn(context.firstContributor.channel, 'detach').mockImplementation(() => {
-          return new Promise((resolve) => {
-            setTimeout(() => {
-              vi.spyOn(context.firstContributor.channel, 'state', 'get').mockReturnValue(AblyChannelState.Detached);
-              vi.spyOn(context.firstContributor.channel, 'errorReason', 'get').mockReturnValue(baseError);
-              resolve();
-            }, 1000);
-          });
-        });
-        mockChannelDetachSuccess(context.secondContributor.channel);
-        mockChannelDetachSuccess(context.thirdContributor.channel);
-
-        void monitor.detach();
-
-        // Wait for the first contributor to have detach called
-        await vi.waitFor(() => {
-          expect(context.firstContributor.channel.detach).toHaveBeenCalled();
-        });
-
-        // Emit an update / discontinuity event on the first contributor - naturally this wouldn't happen
-        // during this phase, but its a good way to emulate
-        const error1 = new Ably.ErrorInfo('first', 1, 1);
-        context.firstContributor.emulateStateChange(
-          {
-            current: AblyChannelState.Attached,
-            previous: AblyChannelState.Attached,
-            resumed: false,
-            reason: error1,
-          },
-          true,
-        );
-
-        // Now do another
-        context.firstContributor.emulateStateChange(
-          {
-            current: AblyChannelState.Attached,
-            previous: AblyChannelState.Attached,
-            resumed: false,
-            reason: baseError,
-          },
-          true,
-        );
-
-        // Advance timers so the channel goes ahead and detaches.
-        vi.advanceTimersByTime(1000);
-
-        // We shouldn't have registered a discontinuity event yet
-        await vi.waitFor(() => {
-          expect(status.status).toEqual(RoomStatus.Detached);
-        });
-        expect(context.firstContributor.discontinuityDetected).not.toHaveBeenCalled();
-
-        // Now re-attach the room
-        await monitor.attach();
-
-        // Our first contributor should have registered a discontinuity event now
-        expect(status.status).toEqual(RoomStatus.Attached);
-        expect(context.firstContributor.discontinuityDetected).toBeCalledWith(error1);
-      });
+      // Assert
+      expect(mockChannel.attach).not.toHaveBeenCalled();
     });
 
-    describe('via attach event', () => {
-      it<TestContext>('does not register a discontinuity event on initial attach', async (context) => {
-        const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-        context.firstContributor.emulateStateChange({
-          current: AblyChannelState.Initialized,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError,
-        });
-        status.setStatus({ status: RoomStatus.Initialized });
+    it<TestContext>('should throw error if room is released', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Released });
 
-        const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
+      // Act & Assert
+      await expect(roomLifeCycleManager.attach()).rejects.toBeErrorInfo({
+        message: 'cannot attach room, room is released',
+        code: ErrorCodes.RoomIsReleased,
+        statusCode: 400,
+      });
+      expect(mockChannel.attach).not.toHaveBeenCalled();
+    });
 
-        // Send the monitor through the attach cycle
-        mockChannelAttachSuccess(context.firstContributor.channel);
+    it<TestContext>('should throw error if room is releasing', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Releasing });
 
-        await monitor.attach();
+      // Act & Assert
+      await expect(roomLifeCycleManager.attach()).rejects.toBeErrorInfo({
+        message: 'cannot attach room, room is currently releasing',
+        code: ErrorCodes.RoomIsReleasing,
+        statusCode: 400,
+      });
+      expect(mockChannel.attach).not.toHaveBeenCalled();
+    });
 
-        // We shouldn't have registered a discontinuity event
-        expect(status.status).toEqual(RoomStatus.Attached);
-        expect(context.firstContributor.discontinuityDetected).not.toHaveBeenCalled();
+    it<TestContext>('should successfully attach and update status', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Initialized });
+
+      // Act
+      await roomLifeCycleManager.attach();
+
+      // Assert
+      expect(mockChannel.attach).toHaveBeenCalledTimes(1);
+      expect(roomStatus.status).toBe(RoomStatus.Attached);
+    });
+
+    it<TestContext>('should handle Ably errors during attach', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+    }) => {
+      // Arrange
+      const ablyError = new Ably.ErrorInfo('attach failed', 12345, 400);
+      vi.spyOn(mockChannel, 'attach').mockRejectedValue(ablyError);
+      vi.spyOn(mockChannel, 'state', 'get').mockReturnValue('failed');
+
+      // Act & Assert
+      await expect(roomLifeCycleManager.attach()).rejects.toBeErrorInfo({
+        message: 'failed to attach room: attach failed',
+        code: 12345,
+        statusCode: 400,
+        cause: ablyError as ErrorInfoCompareType,
       });
 
-      it<TestContext>('registers a discontinuity immediately post-attach if one of the attach events was a failed resume', async (context) => {
-        // Force our status and contributors into initialized
-        const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-        context.firstContributor.emulateStateChange({
-          current: AblyChannelState.Initialized,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError,
-        });
-        context.secondContributor.emulateStateChange({
-          current: AblyChannelState.Initialized,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError2,
-        });
-        context.thirdContributor.emulateStateChange({
-          current: AblyChannelState.Initialized,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError,
-        });
-        status.setStatus({ status: RoomStatus.Initialized });
-
-        const monitor = new RoomLifecycleManager(
-          status,
-          [context.firstContributor, context.secondContributor, context.thirdContributor],
-          makeTestLogger(),
-          5,
-        );
-
-        // Send the monitor through the attach cycle
-        mockChannelAttachSuccess(context.firstContributor.channel);
-        mockChannelAttachSuccess(context.secondContributor.channel);
-        mockChannelAttachSuccess(context.thirdContributor.channel);
-
-        await monitor.attach();
-
-        // Send the monitor through the detach cycle
-        mockChannelDetachSuccess(context.firstContributor.channel);
-        mockChannelDetachSuccess(context.secondContributor.channel);
-        mockChannelDetachSuccess(context.thirdContributor.channel);
-
-        await monitor.detach();
-
-        // There should be no discontinuity event yet
-        expect(status.status).toEqual(RoomStatus.Detached);
-        expect(context.firstContributor.discontinuityDetected).not.toHaveBeenCalled();
-
-        // Now do a re-attach, but make the first channel fail to resume
-        mockChannelAttachSuccessWithResumeFailure(context.firstContributor.channel);
-
-        // Now re-attach the room
-        await monitor.attach();
-
-        // Our first contributor should have registered a discontinuity event now
-        expect(status.status).toEqual(RoomStatus.Attached);
-        expect(context.firstContributor.discontinuityDetected).toBeCalledWith(baseError);
-      });
-
-      it<TestContext>('prefers the first discontinuity event if multiple are received', async (context) => {
-        // Force our status and contributors into initialized
-        const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-        context.firstContributor.emulateStateChange({
-          current: AblyChannelState.Initialized,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError,
-        });
-        context.secondContributor.emulateStateChange({
-          current: AblyChannelState.Initialized,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError2,
-        });
-        context.thirdContributor.emulateStateChange({
-          current: AblyChannelState.Initialized,
-          previous: 'initialized',
-          resumed: false,
-          reason: baseError,
-        });
-        status.setStatus({ status: RoomStatus.Initialized });
-
-        const monitor = new RoomLifecycleManager(
-          status,
-          [context.firstContributor, context.secondContributor, context.thirdContributor],
-          makeTestLogger(),
-          5,
-        );
-
-        // Send the monitor through the attach cycle
-        mockChannelAttachSuccess(context.firstContributor.channel);
-        mockChannelAttachSuccess(context.secondContributor.channel);
-        mockChannelAttachSuccess(context.thirdContributor.channel);
-
-        await monitor.attach();
-
-        // Send the monitor through the detach cycle
-        mockChannelDetachSuccess(context.firstContributor.channel);
-        mockChannelDetachSuccess(context.secondContributor.channel);
-        mockChannelDetachSuccess(context.thirdContributor.channel);
-
-        await monitor.detach();
-
-        // There should be no discontinuity event yet
-        expect(status.status).toEqual(RoomStatus.Detached);
-        expect(context.firstContributor.discontinuityDetected).not.toHaveBeenCalled();
-
-        // Now we attach again, but fail the second channel so we get a detach event
-        const firstError = new Ably.ErrorInfo('first', 1, 1);
-        mockChannelAttachSuccessWithResumeFailure(context.firstContributor.channel, firstError);
-        mockChannelAttachFailure(context.secondContributor.channel, AblyChannelState.Suspended, 1001);
-        mockChannelAttachSuccess(context.thirdContributor.channel);
-
-        // Now re-attach the room, it should reject with the error
-        await expect(monitor.attach()).rejects.toBeErrorInfo({
-          code: ErrorCodes.PresenceAttachmentFailed,
-          cause: {
-            code: 1001,
-          },
-        });
-
-        // We should be suspended
-        expect(status.status).toEqual(RoomStatus.Suspended);
-
-        // And still no discontinuity event
-        expect(context.firstContributor.discontinuityDetected).not.toHaveBeenCalled();
-
-        // Now we attach in full with a second resume fail
-        const secondError = new Ably.ErrorInfo('second', 2, 2);
-        mockChannelAttachSuccessWithResumeFailure(context.firstContributor.channel, secondError);
-        mockChannelAttachSuccess(context.secondContributor.channel);
-        mockChannelAttachSuccess(context.thirdContributor.channel);
-
-        // Now we'll transition channel 2 back into attached to complete the attach
-        context.secondContributor.emulateStateChange({
-          current: AblyChannelState.Attached,
-          previous: AblyChannelState.Initialized,
-          resumed: false,
-          reason: baseError2,
-        });
-
-        // We should be attached
-        await waitForRoomLifecycleStatus(status, RoomStatus.Attached);
-
-        // Our first contributor should have registered a discontinuity event now
-        expect(status.status).toEqual(RoomStatus.Attached);
-        expect(context.firstContributor.discontinuityDetected).toBeCalledWith(firstError);
+      expect(roomStatus.status).toBe(RoomStatus.Failed);
+      expect(roomStatus.error).toBeErrorInfo({
+        message: 'failed to attach room: attach failed',
+        code: 12345,
+        statusCode: 400,
+        cause: ablyError as ErrorInfoCompareType,
       });
     });
   });
 
-  describe('release lifecycle', () => {
-    it<TestContext>('resolves immediately if the room is already released', async (context) => {
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      status.setStatus({ status: RoomStatus.Released });
+  describe('detach', () => {
+    it<TestContext>('should be a no-op if room is already detached', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Detached });
 
-      const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
+      // Act
+      await roomLifeCycleManager.detach();
 
-      await expect(monitor.release()).resolves.toBeUndefined();
+      // Assert
+      expect(mockChannel.detach).not.toHaveBeenCalled();
     });
 
-    it<TestContext>('resolves immediately and transitions to released if the room is detached', async (context) => {
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Detached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
+    it<TestContext>('should throw error if room is in failed state', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Failed });
+
+      // Act & Assert
+      await expect(roomLifeCycleManager.detach()).rejects.toBeErrorInfo({
+        message: 'cannot detach room, room is in failed state',
+        code: ErrorCodes.RoomInFailedState,
+        statusCode: 400,
       });
-      status.setStatus({ status: RoomStatus.Detached });
-
-      const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
-
-      await expect(monitor.release()).resolves.toBeUndefined();
-
-      await waitForRoomLifecycleStatus(status, RoomStatus.Released);
+      expect(mockChannel.detach).not.toHaveBeenCalled();
     });
 
-    it<TestContext>('resolves immediately and transitions to released if the room is initialized', async (context) => {
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Detached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
+    it<TestContext>('should throw error if room is released', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Released });
+
+      // Act & Assert
+      await expect(roomLifeCycleManager.detach()).rejects.toBeErrorInfo({
+        message: 'cannot detach room, room is released',
+        code: ErrorCodes.RoomIsReleased,
+        statusCode: 400,
       });
-      status.setStatus({ status: RoomStatus.Initialized });
-
-      const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
-
-      await expect(monitor.release()).resolves.toBeUndefined();
-
-      await waitForRoomLifecycleStatus(status, RoomStatus.Released);
+      expect(mockChannel.detach).not.toHaveBeenCalled();
     });
 
-    it<TestContext>('resolves to released if existing attempt completes', (context) =>
-      new Promise<void>((resolve, reject) => {
-        vi.useFakeTimers();
+    it<TestContext>('should throw error if room is releasing', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Releasing });
 
-        // Force our status and contributors into detached
-        const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-        context.firstContributor.emulateStateChange({
-          current: AblyChannelState.Attached,
-          previous: 'initialized',
+      // Act & Assert
+      await expect(roomLifeCycleManager.detach()).rejects.toBeErrorInfo({
+        message: 'cannot detach room, room is currently releasing',
+        code: ErrorCodes.RoomIsReleasing,
+        statusCode: 400,
+      });
+      expect(mockChannel.detach).not.toHaveBeenCalled();
+    });
+
+    it<TestContext>('should successfully detach and update status', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Attached });
+      mockChannel.detach = vi.fn().mockImplementation(() => Promise.resolve(null));
+
+      // Act
+      await roomLifeCycleManager.detach();
+
+      // Assert
+      expect(mockChannel.detach).toHaveBeenCalledTimes(1);
+      expect(roomStatus.status).toBe(RoomStatus.Detached);
+    });
+
+    it<TestContext>('should handle Ably errors during detach', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+    }) => {
+      // Arrange
+      const ablyError = new Ably.ErrorInfo('detach failed', 12345, 400);
+      mockChannel.detach = vi.fn().mockRejectedValue(ablyError);
+      vi.spyOn(mockChannel, 'state', 'get').mockReturnValue('failed');
+
+      // Act & Assert
+      await expect(roomLifeCycleManager.detach()).rejects.toBeErrorInfo({
+        message: 'failed to detach room: detach failed',
+        code: 12345,
+        statusCode: 400,
+        cause: ablyError as ErrorInfoCompareType,
+      });
+      expect(roomStatus.status).toBe(RoomStatus.Failed);
+      expect(roomStatus.error).toBeErrorInfo({
+        message: 'failed to detach room: detach failed',
+        code: 12345,
+        statusCode: 400,
+        cause: ablyError as ErrorInfoCompareType,
+      });
+    });
+  });
+
+  describe('release', () => {
+    it<TestContext>('should be a no-op if room is already released', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+      channelManager,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Released });
+
+      // Act
+      await roomLifeCycleManager.release();
+
+      // Assert
+      expect(mockChannel.detach).not.toHaveBeenCalled();
+      expect(channelManager.release).not.toHaveBeenCalled();
+      expect(roomStatus.status).toBe(RoomStatus.Released);
+    });
+
+    it<TestContext>('should immediately release if room is initialized', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+      channelManager,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Initialized });
+
+      // Act
+      await roomLifeCycleManager.release();
+
+      // Assert
+      expect(mockChannel.detach).not.toHaveBeenCalled();
+      expect(channelManager.release).toHaveBeenCalledTimes(1);
+      expect(roomStatus.status).toBe(RoomStatus.Released);
+    });
+
+    it<TestContext>('should immediately release if room is detached', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+      channelManager,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Detached });
+
+      // Act
+      await roomLifeCycleManager.release();
+
+      // Assert
+      expect(mockChannel.detach).not.toHaveBeenCalled();
+      expect(channelManager.release).toHaveBeenCalledTimes(1);
+      expect(roomStatus.status).toBe(RoomStatus.Released);
+    });
+
+    it<TestContext>('should skip detach if channel is in failed state', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+      channelManager,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Attached });
+      vi.spyOn(mockChannel, 'state', 'get').mockReturnValue('failed');
+
+      // Act
+      await roomLifeCycleManager.release();
+
+      // Assert
+      expect(mockChannel.detach).not.toHaveBeenCalled();
+      expect(channelManager.release).toHaveBeenCalledTimes(1);
+      expect(roomStatus.status).toBe(RoomStatus.Released);
+    });
+
+    it<TestContext>('should successfully release after detaching', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+      channelManager,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Attached });
+      mockChannel.detach = vi.fn().mockImplementation(() => Promise.resolve(null));
+
+      // Act
+      await roomLifeCycleManager.release();
+
+      // Assert
+      expect(mockChannel.detach).toHaveBeenCalledTimes(1);
+      expect(channelManager.release).toHaveBeenCalledTimes(1);
+      expect(roomStatus.status).toBe(RoomStatus.Released);
+    });
+
+    it<TestContext>('should retry detach multiple times before succeeding', async ({
+      roomLifeCycleManager,
+      mockChannel,
+      roomStatus,
+      channelManager,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Attached });
+      const ablyError = new Ably.ErrorInfo('detach failed', 12345, 400);
+
+      // Mock detach to fail twice then succeed
+      mockChannel.detach = vi
+        .fn()
+        .mockRejectedValueOnce(ablyError)
+        .mockRejectedValueOnce(ablyError)
+        .mockResolvedValueOnce(null);
+
+      // Act
+      await roomLifeCycleManager.release();
+
+      // Assert
+      expect(mockChannel.detach).toHaveBeenCalledTimes(3);
+      expect(channelManager.release).toHaveBeenCalledTimes(1);
+      expect(roomStatus.status).toBe(RoomStatus.Released);
+    });
+  });
+
+  describe('channel state monitoring', () => {
+    it<TestContext>('should update room status when channel state changes and no operation is in progress', ({
+      mockChannel,
+      roomStatus,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Attached });
+
+      // Act - simulate channel state change to suspended
+      mockChannel.invokeStateChange({
+        current: 'suspended',
+        previous: 'attached',
+        reason: new Ably.ErrorInfo('Connection lost', 80003, 500),
+        resumed: false,
+      });
+
+      // Assert
+      expect(roomStatus.status).toBe(RoomStatus.Suspended);
+      expect(roomStatus.error).toBeDefined();
+      expect(roomStatus.error?.code).toBe(80003);
+    });
+
+    it<TestContext>('should ignore channel state changes when attach operation is in progress', ({
+      mockChannel,
+      roomStatus,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Attaching });
+
+      // Act - simulate channel state change to suspended
+      mockChannel.invokeStateChange({
+        current: 'suspended',
+        previous: 'attaching',
+        reason: new Ably.ErrorInfo('Connection lost', 80003, 500),
+        resumed: false,
+      });
+
+      // Assert
+      expect(roomStatus.status).toBe(RoomStatus.Attaching);
+      expect(roomStatus.error).toBeUndefined();
+    });
+
+    it<TestContext>('should ignore channel state changes when detach operation is in progress', ({
+      mockChannel,
+      roomStatus,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Detaching });
+
+      // Act - simulate channel state change to suspended
+      mockChannel.invokeStateChange({
+        current: 'suspended',
+        previous: 'detaching',
+        reason: new Ably.ErrorInfo('Connection lost', 80003, 500),
+        resumed: false,
+      });
+
+      // Assert
+      expect(roomStatus.status).toBe(RoomStatus.Detaching);
+      expect(roomStatus.error).toBeUndefined();
+    });
+
+    it<TestContext>('should ignore channel state changes when release operation is in progress', ({
+      mockChannel,
+      roomStatus,
+    }) => {
+      // Arrange
+      roomStatus.setStatus({ status: RoomStatus.Releasing });
+
+      // Act - simulate channel state change to suspended
+      mockChannel.invokeStateChange({
+        current: 'suspended',
+        previous: 'attached',
+        reason: new Ably.ErrorInfo('Connection lost', 80003, 500),
+        resumed: false,
+      });
+
+      // Assert
+      expect(roomStatus.status).toBe(RoomStatus.Releasing);
+      expect(roomStatus.error).toBeUndefined();
+    });
+
+    describe.each([
+      ['initialized', RoomStatus.Initialized],
+      ['attaching', RoomStatus.Attaching],
+      ['attached', RoomStatus.Attached],
+      ['detaching', RoomStatus.Detaching],
+      ['detached', RoomStatus.Detached],
+      ['suspended', RoomStatus.Suspended],
+      ['failed', RoomStatus.Failed],
+    ])('should handle channel state %s', (state: string, expectedStatus: RoomStatus) => {
+      it<TestContext>('performs channel update', (context) => {
+        // Arrange
+        context.roomStatus.setStatus({ status: RoomStatus.Attached });
+
+        // Act
+        context.mockChannel.invokeStateChange({
+          current: state as Ably.ChannelState,
+          previous: 'attached',
+          reason: undefined,
           resumed: false,
-          reason: baseError,
         });
-        status.setStatus({ status: RoomStatus.Releasing });
-        vi.spyOn(context.firstContributor.channel, 'detach');
 
-        const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
-        let completionTriggered = false;
+        // Assert
+        expect(context.roomStatus.status).toBe(expectedStatus);
+      });
+    });
+  });
 
-        // Make it so that the first contributor only detaches when a timer expires
-        vi.spyOn(context.firstContributor.channel, 'detach').mockImplementation(
-          () =>
-            new Promise((resolve) => {
-              setTimeout(() => {
-                resolve();
-              }, 100);
-            }),
-        );
+  describe('discontinuity monitoring', () => {
+    it<TestContext>('should not emit discontinuity on first attach attached', ({
+      mockChannel,
+      roomLifeCycleManager,
+    }) => {
+      const handler = vi.fn();
+      roomLifeCycleManager.onDiscontinuity(handler);
 
-        // Release the room
-        void monitor.release();
-
-        monitor
-          .release()
-          .then(() => {
-            expect(completionTriggered).toBeTruthy();
-            expect(status.status).toEqual(RoomStatus.Released);
-            expect(context.firstContributor.channel.detach).toHaveBeenCalledOnce();
-            resolve();
-          })
-          .catch((error: unknown) => {
-            reject(error as Error);
-          });
-
-        // Expire the fake timer to trigger the completion
-        completionTriggered = true;
-        vi.advanceTimersToNextTimer();
-
-        vi.useRealTimers();
-      }));
-
-    it<TestContext>('transitions via releasing', async (context) => {
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
+      // First attach
+      mockChannel.invokeStateChange({
+        current: 'attached',
+        previous: 'attaching',
         resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Attached });
-
-      const monitor = new RoomLifecycleManager(status, [context.firstContributor], makeTestLogger(), 5);
-
-      const observedStatuses: RoomStatus[] = [];
-      status.onChange((newStatus) => {
-        observedStatuses.push(newStatus.current);
       });
 
-      await monitor.release();
-
-      expect(observedStatuses).toEqual([RoomStatus.Releasing, RoomStatus.Released]);
+      expect(handler).not.toHaveBeenCalled();
     });
 
-    it<TestContext>('detaches all contributors during release', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
+    it<TestContext>('should not emit discontinuity when resumed is true attached', ({
+      mockChannel,
+      roomLifeCycleManager,
+    }) => {
+      const handler = vi.fn();
+      roomLifeCycleManager.onDiscontinuity(handler);
+
+      // First attach
+      mockChannel.invokeStateChange({
+        current: 'attached',
+        previous: 'attaching',
         resumed: false,
-        reason: baseError,
       });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError2,
+
+      // Second attach with resumed=true
+      mockChannel.invokeStateChange({
+        current: 'attached',
+        previous: 'attaching',
+        resumed: true,
       });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Attached });
 
-      // Mock channel detachment results
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      mockChannelDetachSuccess(context.secondContributor.channel);
-      mockChannelDetachSuccess(context.thirdContributor.channel);
-
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      await expect(monitor.release()).resolves.toBeUndefined();
-
-      expect(context.firstContributor.channel.detach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.detach).toHaveBeenCalled();
-      expect(context.thirdContributor.channel.detach).toHaveBeenCalled();
-
-      expect(status.status).toEqual(RoomStatus.Released);
+      expect(handler).not.toHaveBeenCalled();
     });
 
-    it<TestContext>('allows channels detaching into failed', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError2,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Attached });
+    it<TestContext>('should emit discontinuity when not first attach and resumed is false attached', ({
+      mockChannel,
+      roomLifeCycleManager,
+    }) => {
+      const handler = vi.fn();
+      roomLifeCycleManager.onDiscontinuity(handler);
 
-      // Mock channel detachment results
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      mockChannelDetachFailure(context.secondContributor.channel, AblyChannelState.Failed, 1001);
-      mockChannelDetachSuccess(context.thirdContributor.channel);
+      // First attach
+      roomLifeCycleManager.testForceFirstAttach(false);
 
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
+      // Second attach with resumed=false
+      const reason = new Ably.ErrorInfo('test error', 12345, 503);
+      mockChannel.invokeStateChange({
+        current: 'attached',
+        previous: 'attaching',
+        resumed: false,
+        reason,
+      });
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.toBeErrorInfo({
+          message: 'discontinuity detected',
+          code: ErrorCodes.RoomDiscontinuity,
+          statusCode: 503,
+          cause: reason as ErrorInfoCompareType,
+        }),
       );
-
-      await expect(monitor.release()).resolves.toBeUndefined();
-
-      expect(context.firstContributor.channel.detach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.detach).toHaveBeenCalled();
-      expect(context.thirdContributor.channel.detach).toHaveBeenCalled();
-
-      expect(status.status).toEqual(RoomStatus.Released);
     });
 
-    it<TestContext>('allows channels detaching into suspended', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
+    it<TestContext>('should not emit discontinuity after explicit detach attached event', async ({
+      mockChannel,
+      roomLifeCycleManager,
+    }) => {
+      const handler = vi.fn();
+      roomLifeCycleManager.onDiscontinuity(handler);
+
+      // First attach
+      mockChannel.invokeStateChange({
+        current: 'attached',
+        previous: 'attaching',
         resumed: false,
-        reason: baseError,
       });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
+
+      // Explicit detach
+      (mockChannel.detach as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      await roomLifeCycleManager.detach();
+
+      // Re-attach
+      mockChannel.invokeStateChange({
+        current: 'attached',
+        previous: 'attaching',
         resumed: false,
-        reason: baseError2,
       });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Attached });
 
-      // Mock channel detachment results
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      vi.spyOn(context.secondContributor.channel, 'detach')
-        .mockImplementationOnce(() => {
-          vi.spyOn(context.secondContributor.channel, 'state', 'get').mockReturnValue(AblyChannelState.Suspended);
-          return Promise.reject(new Ably.ErrorInfo('failed', 1001, 1001));
-        })
-        .mockImplementationOnce(() => {
-          vi.spyOn(context.secondContributor.channel, 'state', 'get').mockReturnValue(AblyChannelState.Detached);
-          return Promise.resolve();
-        });
-      mockChannelDetachSuccess(context.thirdContributor.channel);
-
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
-      );
-
-      await expect(monitor.release()).resolves.toBeUndefined();
-
-      expect(context.firstContributor.channel.detach).toHaveBeenCalledOnce();
-      expect(context.secondContributor.channel.detach).toHaveBeenCalledTimes(2);
-      expect(context.thirdContributor.channel.detach).toHaveBeenCalledOnce();
-
-      expect(status.status).toEqual(RoomStatus.Released);
+      expect(handler).not.toHaveBeenCalled();
     });
 
-    it<TestContext>('continues to run the detach cycle until a resolution is reached', async (context) => {
-      // Force our status and contributors into attached
-      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
-      context.firstContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      context.secondContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError2,
-      });
-      context.thirdContributor.emulateStateChange({
-        current: AblyChannelState.Attached,
-        previous: 'initialized',
-        resumed: false,
-        reason: baseError,
-      });
-      status.setStatus({ status: RoomStatus.Attached });
+    it<TestContext>('should allow handler to be removed', ({ mockChannel, roomLifeCycleManager }) => {
+      const handler = vi.fn();
+      const subscription = roomLifeCycleManager.onDiscontinuity(handler);
 
-      // Mock channel detachment results
-      mockChannelDetachSuccess(context.firstContributor.channel);
-      mockChannelDetachFailureSucceedAfter(context.secondContributor.channel, AblyChannelState.Attached, 1001, 5);
-      mockChannelDetachSuccess(context.thirdContributor.channel);
+      // First attach
+      mockChannel.invokeStateChange({
+        current: 'attached',
+        previous: 'attaching',
+        resumed: false,
+      });
 
-      const monitor = new RoomLifecycleManager(
-        status,
-        [context.firstContributor, context.secondContributor, context.thirdContributor],
-        makeTestLogger(),
-        5,
+      // Remove handler
+      subscription.off();
+
+      // Second attach with resumed=false
+      mockChannel.invokeStateChange({
+        current: 'attached',
+        previous: 'attaching',
+        resumed: false,
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it<TestContext>('should not emit discontinuity on first attach update', ({ mockChannel, roomLifeCycleManager }) => {
+      const handler = vi.fn();
+      roomLifeCycleManager.onDiscontinuity(handler);
+
+      // First attach
+      mockChannel.invokeStateChange({
+        current: 'attached',
+        previous: 'attaching',
+        resumed: false,
+      });
+
+      // Update event
+      mockChannel.invokeStateChange(
+        {
+          current: 'attached',
+          previous: 'attached',
+          resumed: false,
+        },
+        true,
       );
 
-      await expect(monitor.release()).resolves.toBeUndefined();
+      expect(handler).not.toHaveBeenCalled();
+    });
 
-      expect(context.firstContributor.channel.detach).toHaveBeenCalled();
-      expect(context.secondContributor.channel.detach).toHaveBeenCalledTimes(6);
-      expect(context.thirdContributor.channel.detach).toHaveBeenCalled();
+    it<TestContext>('should not emit discontinuity when resumed is true update', ({
+      mockChannel,
+      roomLifeCycleManager,
+    }) => {
+      const handler = vi.fn();
+      roomLifeCycleManager.onDiscontinuity(handler);
 
-      expect(status.status).toEqual(RoomStatus.Released);
+      // First attach
+      mockChannel.invokeStateChange({
+        current: 'attached',
+        previous: 'attaching',
+        resumed: false,
+      });
+
+      // Update event with resumed=true
+      mockChannel.invokeStateChange(
+        {
+          current: 'attached',
+          previous: 'attached',
+          resumed: true,
+        },
+        true,
+      );
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it<TestContext>('should not emit discontinuity when not double attached', ({
+      mockChannel,
+      roomLifeCycleManager,
+    }) => {
+      const handler = vi.fn();
+      roomLifeCycleManager.onDiscontinuity(handler);
+
+      // First attach
+      mockChannel.invokeStateChange({
+        current: 'attached',
+        previous: 'attaching',
+        resumed: false,
+      });
+
+      // Update event with resumed=true
+      mockChannel.invokeStateChange(
+        {
+          current: 'attached',
+          previous: 'attaching',
+          resumed: false,
+        },
+        true,
+      );
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it<TestContext>('should emit discontinuity when not first attach and resumed is false update', ({
+      mockChannel,
+      roomLifeCycleManager,
+    }) => {
+      const handler = vi.fn();
+      roomLifeCycleManager.onDiscontinuity(handler);
+
+      // First attach
+      roomLifeCycleManager.testForceFirstAttach(false);
+
+      // Update event with resumed=false
+      const reason = new Ably.ErrorInfo('test error', 12345, 503);
+      mockChannel.invokeStateChange(
+        {
+          current: 'attached',
+          previous: 'attached',
+          resumed: false,
+          reason,
+        },
+        true,
+      );
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.toBeErrorInfo({
+          message: 'discontinuity detected',
+          code: ErrorCodes.RoomDiscontinuity,
+          statusCode: 503,
+          cause: reason as ErrorInfoCompareType,
+        }),
+      );
+    });
+
+    it<TestContext>('should not emit discontinuity after explicit detach update event', async ({
+      mockChannel,
+      roomLifeCycleManager,
+    }) => {
+      const handler = vi.fn();
+      roomLifeCycleManager.onDiscontinuity(handler);
+
+      // First attach
+      mockChannel.invokeStateChange({
+        current: 'attached',
+        previous: 'attaching',
+        resumed: false,
+      });
+
+      // Explicit detach
+      (mockChannel.detach as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      await roomLifeCycleManager.detach();
+
+      // Re-attach
+      mockChannel.invokeStateChange({
+        current: 'attached',
+        previous: 'attaching',
+        resumed: false,
+      });
+
+      // Update event
+      mockChannel.invokeStateChange(
+        {
+          current: 'attached',
+          previous: 'attached',
+          resumed: false,
+        },
+        true,
+      );
+
+      expect(handler).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/core/room-lifecycle-manager.test.ts
+++ b/test/core/room-lifecycle-manager.test.ts
@@ -4,13 +4,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChannelManager } from '../../src/core/channel-manager.js';
 import { ErrorCodes } from '../../src/core/errors.js';
 import { Logger } from '../../src/core/logger.js';
-import { RoomLifeCycleManager } from '../../src/core/room-lifecycle-manager.js';
+import { RoomLifecycleManager } from '../../src/core/room-lifecycle-manager.js';
 import { DefaultRoomLifecycle, InternalRoomLifecycle, RoomStatus } from '../../src/core/room-status.js';
 import { ErrorInfoCompareType } from '../helper/expectations.js';
 import { makeTestLogger } from '../helper/logger.js';
 
 interface TestContext {
-  roomLifeCycleManager: RoomLifeCycleManager;
+  roomLifeCycleManager: RoomLifecycleManager;
   channelManager: ChannelManager;
   roomStatus: InternalRoomLifecycle;
   logger: Logger;
@@ -26,7 +26,7 @@ interface TestContext {
 
 vi.mock('ably');
 
-describe('RoomLifeCycleManager', () => {
+describe('RoomLifecycleManager', () => {
   beforeEach<TestContext>((context) => {
     const logger = makeTestLogger();
 
@@ -87,7 +87,7 @@ describe('RoomLifeCycleManager', () => {
 
     context.roomStatus = new DefaultRoomLifecycle('test-room', logger);
     context.logger = logger;
-    context.roomLifeCycleManager = new RoomLifeCycleManager(
+    context.roomLifeCycleManager = new RoomLifecycleManager(
       'test-room',
       context.channelManager,
       context.roomStatus,

--- a/test/core/room-lifecycle-manager.test.ts
+++ b/test/core/room-lifecycle-manager.test.ts
@@ -649,7 +649,7 @@ describe('RoomLifeCycleManager', () => {
       roomLifeCycleManager.onDiscontinuity(handler);
 
       // First attach
-      roomLifeCycleManager.testForceFirstAttach(false);
+      roomLifeCycleManager.testForceHasAttachedOnce(true);
 
       // Second attach with resumed=false
       const reason = new Ably.ErrorInfo('test error', 12345, 503);
@@ -808,7 +808,7 @@ describe('RoomLifeCycleManager', () => {
       roomLifeCycleManager.onDiscontinuity(handler);
 
       // First attach
-      roomLifeCycleManager.testForceFirstAttach(false);
+      roomLifeCycleManager.testForceHasAttachedOnce(true);
 
       // Update event with resumed=false
       const reason = new Ably.ErrorInfo('test error', 12345, 503);

--- a/test/core/room-options.test.ts
+++ b/test/core/room-options.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeRoomOptions, RoomOptions } from '../../src/core/room-options.ts';
+
+describe('normalizeRoomOptions', () => {
+  it('should return default options when no options provided', () => {
+    const result = normalizeRoomOptions(undefined, false);
+
+    expect(result).toEqual({
+      typing: {
+        heartbeatThrottleMs: 10000,
+      },
+      occupancy: {
+        enableInboundOccupancy: false,
+      },
+      presence: {
+        receivePresenceEvents: true,
+      },
+      isReactClient: false,
+    });
+  });
+
+  it('should properly set isReactClient flag', () => {
+    const result = normalizeRoomOptions(undefined, true);
+    expect(result.isReactClient).toBe(true);
+  });
+
+  it('should merge provided typing options with defaults', () => {
+    const options: RoomOptions = {
+      typing: {
+        heartbeatThrottleMs: 5000,
+      },
+    };
+
+    const result = normalizeRoomOptions(options, false);
+
+    expect(result.typing).toEqual({
+      heartbeatThrottleMs: 5000,
+    });
+    expect(result.presence).toEqual({
+      receivePresenceEvents: true,
+    });
+  });
+
+  it('should merge provided occupancy options with defaults', () => {
+    const options: RoomOptions = {
+      occupancy: {
+        enableInboundOccupancy: true,
+      },
+    };
+
+    const result = normalizeRoomOptions(options, false);
+
+    expect(result.occupancy).toEqual({
+      enableInboundOccupancy: true,
+    });
+  });
+
+  it('should merge provided presence options with defaults', () => {
+    const options: RoomOptions = {
+      presence: {
+        receivePresenceEvents: false,
+      },
+    };
+
+    const result = normalizeRoomOptions(options, false);
+
+    expect(result.presence).toEqual({
+      receivePresenceEvents: false,
+    });
+  });
+
+  it('should handle partial options without affecting other defaults', () => {
+    const options: RoomOptions = {
+      typing: {
+        heartbeatThrottleMs: 3000,
+      },
+      presence: {
+        receivePresenceEvents: false,
+      },
+    };
+
+    const result = normalizeRoomOptions(options, false);
+
+    expect(result).toEqual({
+      typing: {
+        heartbeatThrottleMs: 3000,
+      },
+      occupancy: {
+        enableInboundOccupancy: false, // Default preserved
+      },
+      presence: {
+        receivePresenceEvents: false,
+      },
+      isReactClient: false,
+    });
+  });
+});

--- a/test/core/room-reactions.test.ts
+++ b/test/core/room-reactions.test.ts
@@ -291,6 +291,9 @@ describe('Reactions', () => {
       new Promise<void>((done, reject) => {
         const { room } = context;
 
+        // Add spy to check the published message
+        const publishSpy = vi.spyOn(room.channel, 'publish');
+
         room.reactions.subscribe((reaction) => {
           try {
             expect(reaction).toEqual(
@@ -301,6 +304,19 @@ describe('Reactions', () => {
                 type: 'love',
               }),
             );
+
+            // Verify the complete published message structure
+            expect(publishSpy).toHaveBeenCalledWith({
+              name: 'roomReaction',
+              data: {
+                type: 'love',
+                metadata: {},
+              },
+              extras: {
+                ephemeral: true,
+                headers: {},
+              },
+            });
           } catch (error: unknown) {
             reject(error as Error);
           }

--- a/test/core/room-reactions.test.ts
+++ b/test/core/room-reactions.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { ChatApi } from '../../src/core/chat-api.ts';
 import { Reaction } from '../../src/core/reaction.ts';
 import { Room } from '../../src/core/room.ts';
-import { DefaultRoomReactions } from '../../src/core/room-reactions.ts';
 import { channelEventEmitter } from '../helper/channel.ts';
 import { makeTestLogger } from '../helper/logger.ts';
 import { makeRandomRoom } from '../helper/room.ts';
@@ -33,7 +32,7 @@ describe('Reactions', () => {
     };
 
     context.room = makeRandomRoom({ chatApi: context.chatApi, realtime: context.realtime });
-    const channel = context.room.reactions.channel;
+    const channel = context.room.channel;
     context.emulateBackendPublish = channelEventEmitter(channel);
 
     vi.spyOn(channel, 'publish').mockImplementation((message: Ably.Message) => {
@@ -204,29 +203,6 @@ describe('Reactions', () => {
     expect(received).toEqual(['like', 'like', 'love']);
   });
 
-  it<TestContext>('should only unsubscribe the correct subscription for discontinuities', (context) => {
-    const { room } = context;
-
-    const received: string[] = [];
-    const listener = (error?: Ably.ErrorInfo) => {
-      received.push(error?.message ?? 'no error');
-    };
-
-    const subscription1 = room.reactions.onDiscontinuity(listener);
-    const subscription2 = room.reactions.onDiscontinuity(listener);
-
-    (room.reactions as DefaultRoomReactions).discontinuityDetected(new Ably.ErrorInfo('error1', 0, 0));
-    expect(received).toEqual(['error1', 'error1']);
-
-    subscription1.off();
-    (room.reactions as DefaultRoomReactions).discontinuityDetected(new Ably.ErrorInfo('error2', 0, 0));
-    expect(received).toEqual(['error1', 'error1', 'error2']);
-
-    subscription2.off();
-    (room.reactions as DefaultRoomReactions).discontinuityDetected(new Ably.ErrorInfo('error3', 0, 0));
-    expect(received).toEqual(['error1', 'error1', 'error2']);
-  });
-
   it<TestContext>('should be able to unsubscribe all reactions', (context) => {
     const publishTimestamp = Date.now();
     const { room } = context;
@@ -371,13 +347,5 @@ describe('Reactions', () => {
           headers: { action: 'strike back', number: 1980 },
         });
       }));
-  });
-
-  it<TestContext>('has an attachment error code', (context) => {
-    expect((context.room.reactions as DefaultRoomReactions).attachmentErrorCode).toBe(102003);
-  });
-
-  it<TestContext>('has a detachment error code', (context) => {
-    expect((context.room.reactions as DefaultRoomReactions).detachmentErrorCode).toBe(102052);
   });
 });

--- a/test/core/room.integration.test.ts
+++ b/test/core/room.integration.test.ts
@@ -24,19 +24,19 @@ describe('Room', () => {
     expect(room.status).toEqual(RoomStatus.Attached);
 
     // If we check the underlying channels, they should be attached too
-    const messagesChannel = room.messages.channel;
+    const messagesChannel = room.channel;
     expect(messagesChannel.state).toEqual('attached');
 
-    const reactionsChannel = room.reactions.channel;
+    const reactionsChannel = room.channel;
     expect(reactionsChannel.state).toEqual('attached');
 
-    const typingChannel = room.typing.channel;
+    const typingChannel = room.channel;
     expect(typingChannel.state).toEqual('attached');
 
-    const presenceChannel = room.presence.channel;
+    const presenceChannel = room.channel;
     expect(presenceChannel.state).toEqual('attached');
 
-    const occupancyChannel = room.occupancy.channel;
+    const occupancyChannel = room.channel;
     expect(occupancyChannel.state).toEqual('attached');
   });
 
@@ -48,19 +48,19 @@ describe('Room', () => {
     expect(room.status).toEqual(RoomStatus.Detached);
 
     // If we check the underlying channels, they should be detached too
-    const messagesChannel = room.messages.channel;
+    const messagesChannel = room.channel;
     expect(messagesChannel.state).toEqual('detached');
 
-    const reactionsChannel = room.reactions.channel;
+    const reactionsChannel = room.channel;
     expect(reactionsChannel.state).toEqual('detached');
 
-    const typingChannel = room.typing.channel;
+    const typingChannel = room.channel;
     expect(typingChannel.state).toEqual('detached');
 
-    const presenceChannel = room.presence.channel;
+    const presenceChannel = room.channel;
     expect(presenceChannel.state).toEqual('detached');
 
-    const occupancyChannel = room.occupancy.channel;
+    const occupancyChannel = room.channel;
     expect(occupancyChannel.state).toEqual('detached');
   });
 

--- a/test/core/room.test.ts
+++ b/test/core/room.test.ts
@@ -2,18 +2,15 @@ import * as Ably from 'ably';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatApi } from '../../src/core/chat-api.ts';
+import { RoomEvents } from '../../src/core/events.ts';
 import { randomId } from '../../src/core/id.ts';
 import { DefaultRoom, Room } from '../../src/core/room.ts';
-import { RoomLifecycleManager } from '../../src/core/room-lifecycle-manager.ts';
-import { AllFeaturesEnabled, normalizeRoomOptions, RoomOptions } from '../../src/core/room-options.ts';
+import { RoomLifeCycleEvents } from '../../src/core/room-lifecycle-manager.ts';
+import { normalizeRoomOptions, RoomOptions } from '../../src/core/room-options.ts';
 import { RoomStatus } from '../../src/core/room-status.ts';
 import { DefaultTyping } from '../../src/core/typing.ts';
-import {
-  CHANNEL_OPTIONS_AGENT_STRING,
-  CHANNEL_OPTIONS_AGENT_STRING_REACT,
-  DEFAULT_CHANNEL_OPTIONS,
-  DEFAULT_CHANNEL_OPTIONS_REACT,
-} from '../../src/core/version.ts';
+import EventEmitter from '../../src/core/utils/event-emitter.ts';
+import { CHANNEL_OPTIONS_AGENT_STRING, CHANNEL_OPTIONS_AGENT_STRING_REACT } from '../../src/core/version.ts';
 import { randomRoomId } from '../helper/identifier.ts';
 import { makeTestLogger } from '../helper/logger.ts';
 import { ablyRealtimeClient } from '../helper/realtime-client.ts';
@@ -23,7 +20,7 @@ vi.mock('ably');
 
 interface TestContext {
   realtime: Ably.Realtime;
-  getRoom: (options: RoomOptions, useReact?: boolean) => Room;
+  getRoom: (options?: RoomOptions, useReact?: boolean) => Room;
 }
 
 describe('Room', () => {
@@ -31,7 +28,7 @@ describe('Room', () => {
     context.realtime = ablyRealtimeClient();
     const logger = makeTestLogger();
     const chatApi = new ChatApi(context.realtime, logger);
-    context.getRoom = (options: RoomOptions, useReact?: boolean) =>
+    context.getRoom = (options?: RoomOptions, useReact?: boolean) =>
       new DefaultRoom(
         randomRoomId(),
         randomId(),
@@ -40,31 +37,6 @@ describe('Room', () => {
         chatApi,
         logger,
       );
-  });
-
-  describe.each([
-    ['presence', (room: Room) => room.presence],
-    ['occupancy', (room: Room) => room.occupancy],
-    ['typing', (room: Room) => room.typing],
-    ['reactions', (room: Room) => room.reactions],
-  ])('feature not configured', (description: string, featureLoader: (room: Room) => unknown) => {
-    it<TestContext>(`should throw error if trying to access ${description} without being enabled`, (context) => {
-      const room = context.getRoom({});
-      expect(() => featureLoader(room)).toThrowErrorInfoWithCode(40000);
-    });
-  });
-
-  describe.each([
-    ['messages', {}, (room: Room) => room.messages],
-    ['presence', { presence: AllFeaturesEnabled.presence }, (room: Room) => room.presence],
-    ['occupancy', { occupancy: AllFeaturesEnabled.occupancy }, (room: Room) => room.occupancy],
-    ['typing', { typing: AllFeaturesEnabled.typing }, (room: Room) => room.typing],
-    ['reactions', { reactions: AllFeaturesEnabled.reactions }, (room: Room) => room.reactions],
-  ])('feature configured', (description: string, options: RoomOptions, featureLoader: (room: Room) => unknown) => {
-    it<TestContext>(`should not throw an error when trying to access ${description} whilst enabled`, (context) => {
-      const room = context.getRoom(options);
-      featureLoader(room);
-    });
   });
 
   describe.each([
@@ -102,49 +74,34 @@ describe('Room', () => {
   });
 
   describe.each([
-    ['vanilla JS', false, CHANNEL_OPTIONS_AGENT_STRING, DEFAULT_CHANNEL_OPTIONS],
-    ['react', true, CHANNEL_OPTIONS_AGENT_STRING_REACT, DEFAULT_CHANNEL_OPTIONS_REACT],
-  ])(
-    'should apply channel options %s',
-    (description: string, setReact: boolean, agentString: string, defaultOptions: unknown) => {
-      it<TestContext>('applies the correct options', (context) => {
-        vi.spyOn(context.realtime.channels, 'get');
-        const room = context.getRoom(AllFeaturesEnabled, setReact) as DefaultRoom;
+    ['vanilla JS', false, CHANNEL_OPTIONS_AGENT_STRING],
+    ['react', true, CHANNEL_OPTIONS_AGENT_STRING_REACT],
+  ])('should apply channel options %s', (description: string, setReact: boolean, agentString: string) => {
+    it<TestContext>('applies the correct options', (context) => {
+      vi.spyOn(context.realtime.channels, 'get');
+      const room = context.getRoom(
+        {
+          occupancy: {
+            enableInboundOccupancy: true,
+          },
+        },
+        setReact,
+      ) as DefaultRoom;
 
-        // Check that the shared channel for messages, occupancy and presence was called with the correct options
-        const expectedMessagesChannelOptions = {
-          params: { occupancy: 'metrics', agent: agentString },
-          modes: ['PUBLISH', 'SUBSCRIBE', 'PRESENCE', 'PRESENCE_SUBSCRIBE'],
-          attachOnSubscribe: false,
-        };
+      // Check that the shared channel for messages, occupancy and presence was called with the correct options
+      const expectedChannelOptions = {
+        params: { occupancy: 'metrics', agent: agentString },
+        attachOnSubscribe: false,
+      };
 
-        expect(context.realtime.channels.get).toHaveBeenCalledTimes(5);
-        expect(context.realtime.channels.get).toHaveBeenNthCalledWith(
-          1,
-          room.messages.channel.name,
-          expectedMessagesChannelOptions,
-        );
-        expect(context.realtime.channels.get).toHaveBeenNthCalledWith(
-          2,
-          room.messages.channel.name,
-          expectedMessagesChannelOptions,
-        );
-        expect(context.realtime.channels.get).toHaveBeenNthCalledWith(
-          5,
-          room.messages.channel.name,
-          expectedMessagesChannelOptions,
-        );
-
-        // Check that the reactions and typing channels were called with the default options
-        expect(context.realtime.channels.get).toHaveBeenNthCalledWith(3, room.typing.channel.name, defaultOptions);
-        expect(context.realtime.channels.get).toHaveBeenNthCalledWith(4, room.reactions.channel.name, defaultOptions);
-      });
-    },
-  );
+      expect(context.realtime.channels.get).toHaveBeenCalledOnce();
+      expect(context.realtime.channels.get).toHaveBeenNthCalledWith(1, room.channel.name, expectedChannelOptions);
+    });
+  });
 
   describe('room status', () => {
     it<TestContext>('should have a room status and error', async (context) => {
-      const room = context.getRoom(AllFeaturesEnabled);
+      const room = context.getRoom();
       expect(room.status).toBe(RoomStatus.Initialized);
 
       // Wait for the room to be initialized
@@ -165,7 +122,7 @@ describe('Room', () => {
     });
 
     it<TestContext>('should allow subscriptions to status changes', async (context) => {
-      const room = context.getRoom(AllFeaturesEnabled);
+      const room = context.getRoom();
 
       const statuses: RoomStatus[] = [];
       const errors: Ably.ErrorInfo[] = [];
@@ -200,7 +157,7 @@ describe('Room', () => {
     });
 
     it<TestContext>('should allow all subscriptions to be removed', async (context) => {
-      const room = context.getRoom(AllFeaturesEnabled);
+      const room = context.getRoom();
 
       const statuses: RoomStatus[] = [];
       const errors: Ably.ErrorInfo[] = [];
@@ -247,8 +204,8 @@ describe('Room', () => {
 
   describe('room release', () => {
     it<TestContext>('should release the room', async (context) => {
-      const room = context.getRoom(AllFeaturesEnabled) as DefaultRoom;
-      const lifecycleManager = (room as unknown as { _lifecycleManager: RoomLifecycleManager })._lifecycleManager;
+      const room = context.getRoom() as DefaultRoom;
+      const lifecycleManager = room.lifecycleManager;
 
       // Setup spies on the realtime client and the room lifecycle manager
       vi.spyOn(context.realtime.channels, 'release');
@@ -260,28 +217,16 @@ describe('Room', () => {
       // The room lifecycle manager should have been released
       expect(lifecycleManager.release).toHaveBeenCalledTimes(1);
 
-      // Every underlying feature channel should have been released
-      expect(context.realtime.channels.release).toHaveBeenCalledTimes(5);
+      // The underlying channel should have been released
+      expect(context.realtime.channels.release).toHaveBeenCalledTimes(1);
 
-      const messagesChannel = room.messages.channel;
+      const messagesChannel = room.channel;
       expect(context.realtime.channels.release).toHaveBeenCalledWith(messagesChannel.name);
-
-      const presenceChannel = room.presence.channel;
-      expect(context.realtime.channels.release).toHaveBeenCalledWith(presenceChannel.name);
-
-      const typingChannel = room.typing.channel;
-      expect(context.realtime.channels.release).toHaveBeenCalledWith(typingChannel.name);
-
-      const reactionsChannel = room.reactions.channel;
-      expect(context.realtime.channels.release).toHaveBeenCalledWith(reactionsChannel.name);
-
-      const occupancyChannel = room.occupancy.channel;
-      expect(context.realtime.channels.release).toHaveBeenCalledWith(occupancyChannel.name);
     });
 
     it<TestContext>('should only release with enabled features', async (context) => {
-      const room = context.getRoom({ typing: AllFeaturesEnabled.typing }) as DefaultRoom;
-      const lifecycleManager = (room as unknown as { _lifecycleManager: RoomLifecycleManager })._lifecycleManager;
+      const room = context.getRoom() as DefaultRoom;
+      const lifecycleManager = room.lifecycleManager;
 
       // Setup spies on the realtime client and the room lifecycle manager
       vi.spyOn(context.realtime.channels, 'release');
@@ -293,19 +238,16 @@ describe('Room', () => {
       // The room lifecycle manager should have been released
       expect(lifecycleManager.release).toHaveBeenCalledTimes(1);
 
-      // Every underlying feature channel should have been released
-      expect(context.realtime.channels.release).toHaveBeenCalledTimes(2);
+      // The underlying channel should have been released
+      expect(context.realtime.channels.release).toHaveBeenCalledOnce();
 
-      const messagesChannel = room.messages.channel;
+      const messagesChannel = room.channel;
       expect(context.realtime.channels.release).toHaveBeenCalledWith(messagesChannel.name);
-
-      const typingChannel = room.typing.channel;
-      expect(context.realtime.channels.release).toHaveBeenCalledWith(typingChannel.name);
     });
 
     it<TestContext>('releasing multiple times is idempotent', async (context) => {
-      const room = context.getRoom(AllFeaturesEnabled) as DefaultRoom;
-      const lifecycleManager = (room as unknown as { _lifecycleManager: RoomLifecycleManager })._lifecycleManager;
+      const room = context.getRoom() as DefaultRoom;
+      const lifecycleManager = room.lifecycleManager;
 
       // Setup spies on the realtime client and the room lifecycle manager
       vi.spyOn(context.realtime.channels, 'release');
@@ -318,20 +260,80 @@ describe('Room', () => {
       await room.release();
       await room.release();
 
-      // Every underlying feature channel should have been released
-      expect(context.realtime.channels.release).toHaveBeenCalledTimes(5);
+      // Channel should have been released only once
+      expect(context.realtime.channels.release).toHaveBeenCalledTimes(1);
 
       // The room lifecycle manager should have been released only once
       expect(lifecycleManager.release).toHaveBeenCalledTimes(1);
     });
   });
 
-  it<TestContext>('can be released immediately without unhandled rejections', async (context) => {
-    const room = context.getRoom(AllFeaturesEnabled);
+  describe('discontinuity handling', () => {
+    it<TestContext>('should allow subscriptions to discontinuity events', (context) => {
+      const room = context.getRoom() as DefaultRoom;
 
-    // Release the room
-    // Note that an unhandled rejection will not cause the test to fail, but it will cause the process to exit
-    // with a non-zero exit code.
-    await (room as DefaultRoom).release();
+      const discontinuityErrors: Ably.ErrorInfo[] = [];
+      const { off } = room.onDiscontinuity((error) => {
+        discontinuityErrors.push(error);
+      });
+
+      // Simulate a discontinuity event
+      const error = new Ably.ErrorInfo('test discontinuity', 50000, 500);
+      const eventEmitter = (room.lifecycleManager as unknown as { _eventEmitter: EventEmitter<RoomLifeCycleEvents> })
+        ._eventEmitter;
+      eventEmitter.emit(RoomEvents.Discontinuity, new Ably.ErrorInfo('discontinuity detected', 80003, 500, error));
+
+      expect(discontinuityErrors).toEqual([new Ably.ErrorInfo('discontinuity detected', 80003, 500, error)]);
+
+      // Remove the listener
+      off();
+
+      // Simulate another discontinuity event
+      eventEmitter.emit(RoomEvents.Discontinuity, new Ably.ErrorInfo('discontinuity detected', 80003, 500, error));
+
+      // Change should not be recorded since we removed the listener
+      expect(discontinuityErrors).toEqual([new Ably.ErrorInfo('discontinuity detected', 80003, 500, error)]);
+    });
+
+    it<TestContext>('should only unsubscribe the correct subscription for discontinuities', (context) => {
+      const room = context.getRoom() as DefaultRoom;
+
+      const received: string[] = [];
+      const listener = (error?: Ably.ErrorInfo) => {
+        received.push(error?.message ?? 'no error');
+      };
+
+      const subscription1 = room.onDiscontinuity(listener);
+      const subscription2 = room.onDiscontinuity(listener);
+
+      (room.lifecycleManager as unknown as { _eventEmitter: EventEmitter<RoomLifeCycleEvents> })._eventEmitter.emit(
+        RoomEvents.Discontinuity,
+        new Ably.ErrorInfo('error1', 0, 0),
+      );
+      expect(received).toEqual(['error1', 'error1']);
+
+      subscription1.off();
+      (room.lifecycleManager as unknown as { _eventEmitter: EventEmitter<RoomLifeCycleEvents> })._eventEmitter.emit(
+        RoomEvents.Discontinuity,
+        new Ably.ErrorInfo('error2', 0, 0),
+      );
+      expect(received).toEqual(['error1', 'error1', 'error2']);
+
+      subscription2.off();
+      (room.lifecycleManager as unknown as { _eventEmitter: EventEmitter<RoomLifeCycleEvents> })._eventEmitter.emit(
+        RoomEvents.Discontinuity,
+        new Ably.ErrorInfo('error3', 0, 0),
+      );
+      expect(received).toEqual(['error1', 'error1', 'error2']);
+    });
+
+    it<TestContext>('can be released immediately without unhandled rejections', async (context) => {
+      const room = context.getRoom();
+
+      // Release the room
+      // Note that an unhandled rejection will not cause the test to fail, but it will cause the process to exit
+      // with a non-zero exit code.
+      await (room as DefaultRoom).release();
+    });
   });
 });

--- a/test/core/rooms.integration.test.ts
+++ b/test/core/rooms.integration.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 
 import { LogLevel } from '../../src/core/logger.ts';
 import { RoomStatus } from '../../src/core/room-status.ts';
-import { AllFeaturesEnabled } from '../../src/index.ts';
 import { newChatClient } from '../helper/chat.ts';
 import { waitForRoomStatus } from '../helper/room.ts';
 
@@ -48,21 +47,18 @@ describe('Rooms', () => {
     const chat = newChatClient();
     const room1 = await chat.rooms.get('test', {
       typing: { heartbeatThrottleMs: 5000 },
-      presence: AllFeaturesEnabled.presence,
     });
     await room1.attach();
     await chat.rooms.release('test');
 
     const room2 = await chat.rooms.get('test', {
       typing: { heartbeatThrottleMs: 5000 },
-      presence: AllFeaturesEnabled.presence,
     });
     await room2.attach();
     await chat.rooms.release('test');
 
     await chat.rooms.get('test', {
       typing: { heartbeatThrottleMs: 5000 },
-      presence: AllFeaturesEnabled.presence,
     });
     await chat.rooms.release('test');
   });
@@ -77,7 +73,7 @@ describe('Rooms', () => {
     // Make sure our room is attached
     await room.attach();
 
-    const channelFailable = room.messages.channel as Ably.RealtimeChannel & {
+    const channelFailable = room.channel as Ably.RealtimeChannel & {
       notifyState(state: 'failed'): void;
     };
     channelFailable.notifyState('failed');

--- a/test/core/rooms.test.ts
+++ b/test/core/rooms.test.ts
@@ -2,7 +2,6 @@ import * as Ably from 'ably';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { normalizeClientOptions } from '../../src/core/config.ts';
-import { AllFeaturesEnabled, RoomOptions } from '../../src/core/room-options.ts';
 import { DefaultRooms, Rooms } from '../../src/core/rooms.ts';
 import { ErrorCodes } from '../../src/index.ts';
 import { randomRoomId } from '../helper/identifier.ts';
@@ -26,8 +25,8 @@ describe('rooms', () => {
   describe('room get', () => {
     it<TestContext>('throws error if room with same ID but different options already exists', async (context) => {
       const roomId = randomRoomId();
-      const room1 = context.rooms.get(roomId, AllFeaturesEnabled);
-      const room2 = context.rooms.get(roomId, { reactions: {} });
+      const room1 = context.rooms.get(roomId);
+      const room2 = context.rooms.get(roomId, { typing: {} });
       await expect(room1).resolves.toBeDefined();
       await expect(room2).rejects.toBeErrorInfo({
         statusCode: 400,
@@ -38,15 +37,14 @@ describe('rooms', () => {
 
     it<TestContext>('returns a fresh room instance if room does not exist', async (context) => {
       const roomId = randomRoomId();
-      const roomOptions: RoomOptions = AllFeaturesEnabled;
-      const room = context.rooms.get(roomId, roomOptions);
+      const room = context.rooms.get(roomId);
       await expect(room).resolves.toBeDefined();
     });
 
     it<TestContext>('returns the same room instance if room already exists', async (context) => {
       const roomId = randomRoomId();
-      const room1 = await context.rooms.get(roomId, AllFeaturesEnabled);
-      const room2 = await context.rooms.get(roomId, AllFeaturesEnabled);
+      const room1 = await context.rooms.get(roomId);
+      const room2 = await context.rooms.get(roomId);
       expect(room1).toBe(room2);
     });
   });
@@ -54,24 +52,24 @@ describe('rooms', () => {
   describe('room get-release lifecycle', () => {
     it<TestContext>('should return a the same room if rooms.get called twice', async (context) => {
       const roomId = randomRoomId();
-      const room1 = await context.rooms.get(roomId, AllFeaturesEnabled);
-      const room2 = await context.rooms.get(roomId, AllFeaturesEnabled);
+      const room1 = await context.rooms.get(roomId);
+      const room2 = await context.rooms.get(roomId);
       expect(room1).toBe(room2);
     });
 
     it<TestContext>('should return a fresh room in room.get if previous one is currently releasing', (context) => {
       const roomId = randomRoomId();
-      const room1 = context.rooms.get(roomId, AllFeaturesEnabled);
+      const room1 = context.rooms.get(roomId);
       void context.rooms.release(roomId);
-      const room2 = context.rooms.get(roomId, AllFeaturesEnabled);
+      const room2 = context.rooms.get(roomId);
       expect(room1).not.toBe(room2);
     });
 
     it<TestContext>('releasing a room should abort any get operations', async (context) => {
       const roomId = randomRoomId();
-      const room1 = context.rooms.get(roomId, AllFeaturesEnabled);
+      const room1 = context.rooms.get(roomId);
       const releasePromise1 = context.rooms.release(roomId);
-      const room2 = context.rooms.get(roomId, AllFeaturesEnabled);
+      const room2 = context.rooms.get(roomId);
       const releasedPromise2 = context.rooms.release(roomId);
 
       await expect(releasePromise1).resolves.toBeUndefined();
@@ -86,15 +84,15 @@ describe('rooms', () => {
 
     it<TestContext>('releasing a room should abort any get operations from previous get', async (context) => {
       const roomId = randomRoomId();
-      const room1 = context.rooms.get(roomId, AllFeaturesEnabled);
+      const room1 = context.rooms.get(roomId);
       const releasePromise1 = context.rooms.release(roomId);
-      const room2 = context.rooms.get(roomId, AllFeaturesEnabled);
+      const room2 = context.rooms.get(roomId);
       const releasedPromise2 = context.rooms.release(roomId);
-      const room3 = context.rooms.get(roomId, AllFeaturesEnabled);
-      const room4 = context.rooms.get(roomId, AllFeaturesEnabled);
+      const room3 = context.rooms.get(roomId);
+      const room4 = context.rooms.get(roomId);
       const releasePromise3 = context.rooms.release(roomId);
       const releasePromise4 = context.rooms.release(roomId);
-      const finalRoom = context.rooms.get(roomId, AllFeaturesEnabled);
+      const finalRoom = context.rooms.get(roomId);
 
       await expect(room1).resolves.toBeDefined();
       await expect(releasePromise1).resolves.toBeUndefined();
@@ -125,11 +123,11 @@ describe('rooms', () => {
 
     it<TestContext>('multiple gets on a releasing room return the same room instance', async (context) => {
       const roomId = randomRoomId();
-      const room1 = context.rooms.get(roomId, AllFeaturesEnabled);
+      const room1 = context.rooms.get(roomId);
       const releasePromise1 = context.rooms.release(roomId);
-      const room2 = context.rooms.get(roomId, AllFeaturesEnabled);
-      const room3 = context.rooms.get(roomId, AllFeaturesEnabled);
-      const room4 = context.rooms.get(roomId, AllFeaturesEnabled);
+      const room2 = context.rooms.get(roomId);
+      const room3 = context.rooms.get(roomId);
+      const room4 = context.rooms.get(roomId);
 
       await expect(room1).resolves.toBeDefined();
       await expect(releasePromise1).resolves.toBeUndefined();

--- a/test/helper/expectations.ts
+++ b/test/helper/expectations.ts
@@ -36,7 +36,7 @@ interface CheckResponseType {
   actual: unknown;
 }
 
-const toBeErrorInfo = (received: unknown, expected: ErrorInfoCompareType): CheckResponseType => {
+export const toBeErrorInfo = (received: unknown, expected: ErrorInfoCompareType): CheckResponseType => {
   if (!(received instanceof Ably.ErrorInfo)) {
     return {
       pass: false,

--- a/test/helper/room.ts
+++ b/test/helper/room.ts
@@ -6,7 +6,7 @@ import { ChatApi } from '../../src/core/chat-api.ts';
 import { ErrorCodes } from '../../src/core/errors.ts';
 import { randomId } from '../../src/core/id.ts';
 import { DefaultRoom, Room } from '../../src/core/room.ts';
-import { AllFeaturesEnabled, normalizeRoomOptions, RoomOptions } from '../../src/core/room-options.ts';
+import { normalizeRoomOptions, RoomOptions } from '../../src/core/room-options.ts';
 import { RoomLifecycle, RoomStatus } from '../../src/core/room-status.ts';
 import { randomRoomId } from './identifier.ts';
 import { makeTestLogger } from './logger.ts';
@@ -27,24 +27,24 @@ export const waitForRoomError = async (status: RoomLifecycle, expected: ErrorCod
 };
 
 // Gets a random room with default options from the chat client
-export const getRandomRoom = async (chat: ChatClient): Promise<Room> =>
-  chat.rooms.get(randomRoomId(), AllFeaturesEnabled);
+export const getRandomRoom = async (chat: ChatClient, options?: RoomOptions): Promise<Room> =>
+  chat.rooms.get(randomRoomId(), options);
 
 // Makes a room with the given (or default) options, as a standalone room aside from the chat client
 // Should be used in unit tests where the dependencies are mocked.
-export const makeRandomRoom = (params: {
+export const makeRandomRoom = (params?: {
   realtime?: Ably.Realtime;
   chatApi?: ChatApi;
   options?: RoomOptions;
 }): Room => {
   const logger = makeTestLogger();
-  const realtime = params.realtime ?? ablyRealtimeClient();
-  const chatApi = params.chatApi ?? new ChatApi(realtime, logger);
+  const realtime = params?.realtime ?? ablyRealtimeClient();
+  const chatApi = params?.chatApi ?? new ChatApi(realtime, logger);
 
   return new DefaultRoom(
     randomRoomId(),
     randomId(),
-    normalizeRoomOptions(params.options ?? AllFeaturesEnabled, false),
+    normalizeRoomOptions(params?.options, false),
     realtime,
     chatApi,
     logger,

--- a/test/react/helper/use-eventual-room.test.tsx
+++ b/test/react/helper/use-eventual-room.test.tsx
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Logger } from '../../../src/core/logger.ts';
 import { Room } from '../../../src/core/room.ts';
-import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { useEventualRoom, useEventualRoomProperty } from '../../../src/react/helper/use-eventual-room.ts';
 import { makeTestLogger } from '../../helper/logger.ts';
 import { makeRandomRoom } from '../../helper/room.ts';
@@ -30,7 +29,7 @@ const updateMockRoom = (newRoom: Room) => {
 describe('eventual rooms', () => {
   beforeEach(() => {
     mockLogger = makeTestLogger();
-    updateMockRoom(makeRandomRoom({ options: AllFeaturesEnabled }));
+    updateMockRoom(makeRandomRoom());
   });
 
   afterEach(() => {
@@ -62,7 +61,7 @@ describe('eventual rooms', () => {
       });
 
       // Now update the room and re-render
-      const newRoom = makeRandomRoom({ options: AllFeaturesEnabled });
+      const newRoom = makeRandomRoom();
       updateMockRoom(newRoom);
 
       rerender();
@@ -99,7 +98,7 @@ describe('eventual rooms', () => {
       });
 
       // Now update the room and re-render
-      const newRoom = makeRandomRoom({ options: AllFeaturesEnabled });
+      const newRoom = makeRandomRoom();
       updateMockRoom(newRoom);
 
       rerender();

--- a/test/react/helper/use-room-context.test.tsx
+++ b/test/react/helper/use-room-context.test.tsx
@@ -1,7 +1,6 @@
 import { cleanup, render } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { useRoomContext } from '../../../src/react/helper/use-room-context.ts';
 import { ChatRoomProvider } from '../../../src/react/index.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
@@ -39,16 +38,13 @@ describe('useRoom', () => {
       const context = useRoomContext('foo');
       expect(context).toBeDefined();
       expect(context.roomId).toBe('foo');
-      expect(context.options).toBe(AllFeaturesEnabled);
+      expect(context.options).toBeUndefined();
       return null;
     };
 
     const TestProvider = () => (
       <ChatClientProvider client={chatClient}>
-        <ChatRoomProvider
-          id="foo"
-          options={AllFeaturesEnabled}
-        >
+        <ChatRoomProvider id="foo">
           <TestUseRoom />
         </ChatRoomProvider>
       </ChatClientProvider>

--- a/test/react/helper/use-room-status.test.tsx
+++ b/test/react/helper/use-room-status.test.tsx
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Logger } from '../../../src/core/logger.ts';
 import { Room } from '../../../src/core/room.ts';
-import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { InternalRoomLifecycle, RoomStatus, RoomStatusChange } from '../../../src/core/room-status.ts';
 import { useRoomStatus } from '../../../src/react/helper/use-room-status.ts';
 import { makeTestLogger } from '../../helper/logger.ts';
@@ -33,7 +32,7 @@ const updateMockRoom = (newRoom: Room) => {
 describe('useRoomStatus', () => {
   beforeEach(() => {
     mockLogger = makeTestLogger();
-    updateMockRoom(makeRandomRoom({ options: AllFeaturesEnabled }));
+    updateMockRoom(makeRandomRoom());
   });
 
   afterEach(() => {

--- a/test/react/hooks/use-messages.integration.test.tsx
+++ b/test/react/hooks/use-messages.integration.test.tsx
@@ -6,7 +6,6 @@ import { ChatClient } from '../../../src/core/chat.ts';
 import { ChatMessageActions, MessageEvents } from '../../../src/core/events.ts';
 import { Message } from '../../../src/core/message.ts';
 import { MessageListener } from '../../../src/core/messages.ts';
-import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { RoomStatus } from '../../../src/core/room-status.ts';
 import { useMessages } from '../../../src/react/hooks/use-messages.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
@@ -27,7 +26,7 @@ describe('useMessages', () => {
 
     // create a second room and attach it, so we can listen for messages
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
+    const roomTwo = await chatClientTwo.rooms.get(roomId);
     await roomTwo.attach();
 
     // start listening for messages
@@ -48,10 +47,7 @@ describe('useMessages', () => {
 
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
-        <ChatRoomProvider
-          id={roomId}
-          options={AllFeaturesEnabled}
-        >
+        <ChatRoomProvider id={roomId}>
           <TestComponent />
         </ChatRoomProvider>
       </ChatClientProvider>
@@ -71,7 +67,7 @@ describe('useMessages', () => {
 
     // create a second room and attach it, so we can listen for deletions
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
+    const roomTwo = await chatClientTwo.rooms.get(roomId);
     await roomTwo.attach();
 
     // start listening for deletions
@@ -101,10 +97,7 @@ describe('useMessages', () => {
 
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
-        <ChatRoomProvider
-          id={roomId}
-          options={AllFeaturesEnabled}
-        >
+        <ChatRoomProvider id={roomId}>
           <TestComponent />
         </ChatRoomProvider>
       </ChatClientProvider>
@@ -125,7 +118,7 @@ describe('useMessages', () => {
 
     // create a second room and attach it, so we can listen for updates
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
+    const roomTwo = await chatClientTwo.rooms.get(roomId);
     await roomTwo.attach();
 
     // start listening for updates
@@ -162,10 +155,7 @@ describe('useMessages', () => {
 
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
-        <ChatRoomProvider
-          id={roomId}
-          options={AllFeaturesEnabled}
-        >
+        <ChatRoomProvider id={roomId}>
           <TestComponent />
         </ChatRoomProvider>
       </ChatClientProvider>
@@ -193,7 +183,7 @@ describe('useMessages', () => {
 
     // create a second room so we can send messages from it
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
+    const roomTwo = await chatClientTwo.rooms.get(roomId);
 
     // start listening for messages
     const messagesRoomOne: Message[] = [];
@@ -214,10 +204,7 @@ describe('useMessages', () => {
 
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
-        <ChatRoomProvider
-          id={roomId}
-          options={AllFeaturesEnabled}
-        >
+        <ChatRoomProvider id={roomId}>
           <TestComponent />
         </ChatRoomProvider>
       </ChatClientProvider>
@@ -248,7 +235,7 @@ describe('useMessages', () => {
 
     // create a second room instance so we can send messages from it
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
+    const roomTwo = await chatClientTwo.rooms.get(roomId);
     await roomTwo.attach();
 
     // send a few messages before the first room has subscribed
@@ -272,10 +259,7 @@ describe('useMessages', () => {
 
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
-        <ChatRoomProvider
-          id={roomId}
-          options={AllFeaturesEnabled}
-        >
+        <ChatRoomProvider id={roomId}>
           <TestComponent />
         </ChatRoomProvider>
       </ChatClientProvider>
@@ -312,7 +296,7 @@ describe('useMessages', () => {
 
     // create a second room instance so we can send messages from it
     const roomId = randomRoomId();
-    const room = await chatClient.rooms.get(roomId, AllFeaturesEnabled);
+    const room = await chatClient.rooms.get(roomId);
     await room.attach();
 
     let lastSeenMessageText: string | undefined;
@@ -347,10 +331,7 @@ describe('useMessages', () => {
 
     const TestProvider = ({ defineListener }: { defineListener: boolean }) => (
       <ChatClientProvider client={chatClient}>
-        <ChatRoomProvider
-          id={roomId}
-          options={AllFeaturesEnabled}
-        >
+        <ChatRoomProvider id={roomId}>
           <TestComponent defineListener={defineListener} />
         </ChatRoomProvider>
       </ChatClientProvider>
@@ -449,7 +430,7 @@ describe('useMessages', () => {
 
     // create a second room instance so we can send messages from it
     const roomId = randomRoomId();
-    const room = await chatClient.rooms.get(roomId, AllFeaturesEnabled);
+    const room = await chatClient.rooms.get(roomId);
     await room.attach();
 
     let lastSeenMessageText: string | undefined;
@@ -484,10 +465,7 @@ describe('useMessages', () => {
 
     const TestProvider = ({ listener }: { listener: MessageListener }) => (
       <ChatClientProvider client={chatClient}>
-        <ChatRoomProvider
-          id={roomId}
-          options={AllFeaturesEnabled}
-        >
+        <ChatRoomProvider id={roomId}>
           <TestComponent listener={listener} />
         </ChatRoomProvider>
       </ChatClientProvider>

--- a/test/react/hooks/use-messages.test.tsx
+++ b/test/react/hooks/use-messages.test.tsx
@@ -213,7 +213,7 @@ describe('useMessages', () => {
     // change the mock room instance
     updateMockRoom(makeRandomRoom({}));
 
-    // re-render to trigger the useEffect
+    // re-render to trigger the useEffectYou
     rerender();
 
     // check that the messages instance is updated
@@ -224,10 +224,10 @@ describe('useMessages', () => {
     const mockOff = vi.fn();
     const mockDiscontinuityListener = vi.fn();
 
-    // spy on the onDiscontinuity method of the messages instance
+    // spy on the onDiscontinuity method of the room instance
     let discontinuityListener: DiscontinuityListener | undefined;
-    vi.spyOn(mockRoom.messages, 'onDiscontinuity').mockImplementation((listener) => {
-      discontinuityListener = listener;
+    vi.spyOn(mockRoom, 'onDiscontinuity').mockImplementation((error) => {
+      discontinuityListener = error;
       return { off: mockOff };
     });
 

--- a/test/react/hooks/use-occupancy.integration.test.tsx
+++ b/test/react/hooks/use-occupancy.integration.test.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { OccupancyEvent, OccupancyListener } from '../../../src/core/occupancy.ts';
-import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { useOccupancy } from '../../../src/react/hooks/use-occupancy.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
@@ -25,8 +24,8 @@ describe('useOccupancy', () => {
 
     // create two more rooms and attach to contribute towards occupancy metrics
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
-    const roomThree = await chatClientThree.rooms.get(roomId, AllFeaturesEnabled);
+    const roomTwo = await chatClientTwo.rooms.get(roomId);
+    const roomThree = await chatClientThree.rooms.get(roomId);
     await roomTwo.attach();
     await roomThree.attach();
 
@@ -52,7 +51,11 @@ describe('useOccupancy', () => {
       <ChatClientProvider client={chatClient}>
         <ChatRoomProvider
           id={roomId}
-          options={AllFeaturesEnabled}
+          options={{
+            occupancy: {
+              enableInboundOccupancy: true,
+            },
+          }}
         >
           <TestComponent listener={(occupancyEvent) => occupancyEvents.push(occupancyEvent)} />
         </ChatRoomProvider>

--- a/test/react/hooks/use-presence-listener.integration.test.tsx
+++ b/test/react/hooks/use-presence-listener.integration.test.tsx
@@ -3,7 +3,6 @@ import React, { useEffect } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { PresenceEvent, PresenceListener, PresenceMember } from '../../../src/core/presence.ts';
-import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { RoomStatus } from '../../../src/core/room-status.ts';
 import { usePresenceListener } from '../../../src/react/hooks/use-presence-listener.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
@@ -24,7 +23,7 @@ describe('usePresenceListener', () => {
 
     // create a second room and attach it, so we can send presence events with it
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
+    const roomTwo = await chatClientTwo.rooms.get(roomId);
     await roomTwo.attach();
 
     // store the current presence member state
@@ -48,10 +47,7 @@ describe('usePresenceListener', () => {
 
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
-        <ChatRoomProvider
-          id={roomId}
-          options={AllFeaturesEnabled}
-        >
+        <ChatRoomProvider id={roomId}>
           <TestComponent
             listener={(event: PresenceEvent) => {
               presenceEventsReceived.push(event);

--- a/test/react/hooks/use-presence-listener.test.tsx
+++ b/test/react/hooks/use-presence-listener.test.tsx
@@ -55,7 +55,7 @@ const updateMockRoom = (newRoom: Room) => {
 describe('usePresenceListener', () => {
   beforeEach(() => {
     // create a new mock room before each test
-    updateMockRoom(makeRandomRoom({ options: { presence: { subscribe: true } } }));
+    updateMockRoom(makeRandomRoom());
     mockLogger = makeTestLogger();
     mockCurrentRoomStatus = RoomStatus.Attached;
     mockCurrentConnectionStatus = ConnectionStatus.Connected;
@@ -127,7 +127,7 @@ describe('usePresenceListener', () => {
     expect(result.current.presence).toBe(mockRoom.presence);
 
     // change the mock room instance
-    updateMockRoom(makeRandomRoom({ options: { presence: { subscribe: true } } }));
+    updateMockRoom(makeRandomRoom());
 
     // re-render to trigger the useEffect
     rerender();
@@ -269,7 +269,7 @@ describe('usePresenceListener', () => {
 
     // spy on the onDiscontinuity method of the room presence instance
     let discontinuityListener: DiscontinuityListener | undefined;
-    vi.spyOn(mockRoom.presence, 'onDiscontinuity').mockImplementation((listener) => {
+    vi.spyOn(mockRoom, 'onDiscontinuity').mockImplementation((listener) => {
       discontinuityListener = listener;
       return { off: mockOff };
     });

--- a/test/react/hooks/use-presence.integration.test.tsx
+++ b/test/react/hooks/use-presence.integration.test.tsx
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { PresenceEvents } from '../../../src/core/events.ts';
 import { PresenceData, PresenceEvent } from '../../../src/core/presence.ts';
-import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { usePresence } from '../../../src/react/hooks/use-presence.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
@@ -50,7 +49,7 @@ describe('usePresence', () => {
 
     // create a second room and attach it, so we can listen for presence events
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
+    const roomTwo = await chatClientTwo.rooms.get(roomId);
     await roomTwo.attach();
 
     // start listening for presence events on room two
@@ -82,12 +81,7 @@ describe('usePresence', () => {
     };
     const Providers = ({ children }: React.PropsWithChildren) => (
       <ChatClientProvider client={chatClientOne}>
-        <ChatRoomProvider
-          id={roomId}
-          options={AllFeaturesEnabled}
-        >
-          {children}
-        </ChatRoomProvider>
+        <ChatRoomProvider id={roomId}>{children}</ChatRoomProvider>
       </ChatClientProvider>
     );
 

--- a/test/react/hooks/use-presence.test.tsx
+++ b/test/react/hooks/use-presence.test.tsx
@@ -54,16 +54,7 @@ describe('usePresence', () => {
     mockLogger = makeTestLogger();
     mockCurrentConnectionStatus = ConnectionStatus.Connected;
     mockCurrentRoomStatus = RoomStatus.Attached;
-    updateMockRoom(
-      makeRandomRoom({
-        options: {
-          presence: {
-            enter: true,
-            subscribe: true,
-          },
-        },
-      }),
-    );
+    updateMockRoom(makeRandomRoom());
   });
 
   afterEach(() => {
@@ -106,16 +97,7 @@ describe('usePresence', () => {
     expect(result.current.isPresent).toBe(true);
 
     // change the mock room instance
-    updateMockRoom(
-      makeRandomRoom({
-        options: {
-          presence: {
-            enter: true,
-            subscribe: true,
-          },
-        },
-      }),
-    );
+    updateMockRoom(makeRandomRoom());
 
     vi.spyOn(mockRoom.presence, 'enter');
 
@@ -239,7 +221,7 @@ describe('usePresence', () => {
 
     // spy on the onDiscontinuity method of the presence instance
     let discontinuityListener: DiscontinuityListener | undefined;
-    vi.spyOn(mockRoom.presence, 'onDiscontinuity').mockImplementation((listener: DiscontinuityListener) => {
+    vi.spyOn(mockRoom, 'onDiscontinuity').mockImplementation((listener: DiscontinuityListener) => {
       discontinuityListener = listener;
       return { off: mockOff };
     });

--- a/test/react/hooks/use-room-reactions.integration.test.tsx
+++ b/test/react/hooks/use-room-reactions.integration.test.tsx
@@ -3,7 +3,6 @@ import React, { useEffect } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { Reaction } from '../../../src/core/reaction.ts';
-import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { RoomReactionListener } from '../../../src/core/room-reactions.ts';
 import { RoomStatus } from '../../../src/core/room-status.ts';
 import { useRoomReactions } from '../../../src/react/hooks/use-room-reactions.ts';
@@ -25,7 +24,7 @@ describe('useRoomReactions', () => {
 
     // create a second room and attach it, so we can receive reactions
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
+    const roomTwo = await chatClientTwo.rooms.get(roomId);
     await roomTwo.attach();
 
     // store the received reactions
@@ -52,10 +51,7 @@ describe('useRoomReactions', () => {
     // create the test providers and render it, sending a reaction
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
-        <ChatRoomProvider
-          id={roomId}
-          options={AllFeaturesEnabled}
-        >
+        <ChatRoomProvider id={roomId}>
           <TestComponent />
         </ChatRoomProvider>
       </ChatClientProvider>
@@ -76,7 +72,7 @@ describe('useRoomReactions', () => {
 
     // create a second room and attach it, so we can send a reaction
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
+    const roomTwo = await chatClientTwo.rooms.get(roomId);
     await roomTwo.attach();
 
     // store the received reactions
@@ -96,10 +92,7 @@ describe('useRoomReactions', () => {
     // create the test providers and render it
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
-        <ChatRoomProvider
-          id={roomId}
-          options={AllFeaturesEnabled}
-        >
+        <ChatRoomProvider id={roomId}>
           <TestComponent listener={(reaction) => reactions.push(reaction)} />
         </ChatRoomProvider>
       </ChatClientProvider>

--- a/test/react/hooks/use-room-reactions.test.tsx
+++ b/test/react/hooks/use-room-reactions.test.tsx
@@ -48,7 +48,7 @@ describe('useRoomReactions', () => {
     // create a new mock room before each test
     vi.resetAllMocks();
     mockLogger = makeTestLogger();
-    updateMockRoom(makeRandomRoom({ options: { reactions: {} } }));
+    updateMockRoom(makeRandomRoom());
   });
 
   afterEach(() => {
@@ -138,7 +138,7 @@ describe('useRoomReactions', () => {
     await waitForEventualHookValue(result, mockRoom.reactions, (value) => value.reactions);
 
     // change the mock room instance
-    updateMockRoom(makeRandomRoom({ options: { reactions: {} } }));
+    updateMockRoom(makeRandomRoom());
     mockLogger.debug('rerendering with new room instance');
 
     // re-render to trigger the useEffect
@@ -154,7 +154,7 @@ describe('useRoomReactions', () => {
 
     // spy on the onDiscontinuity method of the room reactions instance
     let discontinuityListener: DiscontinuityListener | undefined;
-    vi.spyOn(mockRoom.reactions, 'onDiscontinuity').mockImplementation((listener: DiscontinuityListener) => {
+    vi.spyOn(mockRoom, 'onDiscontinuity').mockImplementation((listener: DiscontinuityListener) => {
       discontinuityListener = listener;
       return { off: mockOff };
     });

--- a/test/react/hooks/use-room.test.tsx
+++ b/test/react/hooks/use-room.test.tsx
@@ -3,7 +3,6 @@ import * as Ably from 'ably';
 import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { RoomStatus, RoomStatusListener } from '../../../src/core/room-status.ts';
 import { ChatRoomProvider, useRoom, UseRoomResponse } from '../../../src/react/index.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
@@ -53,7 +52,6 @@ describe('useRoom', () => {
           id={roomId}
           attach={false}
           release={false}
-          options={AllFeaturesEnabled}
         >
           <TestComponent
             callback={(response) => {
@@ -82,7 +80,6 @@ describe('useRoom', () => {
           id={roomId}
           attach={false}
           release={false}
-          options={AllFeaturesEnabled}
         >
           <TestComponent
             callback={(response) => {
@@ -111,7 +108,7 @@ describe('useRoom', () => {
     let called1 = 0;
     let called2 = 0;
     const roomId = randomRoomId();
-    const room = await chatClient.rooms.get(roomId, AllFeaturesEnabled);
+    const room = await chatClient.rooms.get(roomId);
 
     vi.spyOn(room, 'attach').mockImplementation(() => Promise.resolve());
     vi.spyOn(room, 'detach').mockImplementation(() => Promise.resolve());
@@ -123,7 +120,6 @@ describe('useRoom', () => {
           id={roomId}
           attach={false}
           release={false}
-          options={AllFeaturesEnabled}
         >
           <TestComponent
             callback={() => {
@@ -138,7 +134,6 @@ describe('useRoom', () => {
           id={roomId}
           attach={true}
           release={true}
-          options={AllFeaturesEnabled}
         >
           <TestComponent
             callback={() => {
@@ -243,7 +238,7 @@ describe('useRoom', () => {
   it('should correctly set room status callback', async () => {
     const chatClient = newChatClient();
     const roomId = randomRoomId();
-    const room = await chatClient.rooms.get(roomId, AllFeaturesEnabled);
+    const room = await chatClient.rooms.get(roomId);
 
     let listeners: RoomStatusListener[] = [];
 
@@ -266,12 +261,7 @@ describe('useRoom', () => {
     const WithClient = ({ children }: { children: React.ReactNode }) => {
       return (
         <ChatClientProvider client={chatClient}>
-          <ChatRoomProvider
-            id={roomId}
-            options={AllFeaturesEnabled}
-          >
-            {children}
-          </ChatRoomProvider>
+          <ChatRoomProvider id={roomId}>{children}</ChatRoomProvider>
         </ChatClientProvider>
       );
     };
@@ -300,7 +290,7 @@ describe('useRoom', () => {
   it('should correctly set room status and error state variables', async () => {
     const chatClient = newChatClient();
     const roomId = randomRoomId();
-    const room = await chatClient.rooms.get(roomId, AllFeaturesEnabled);
+    const room = await chatClient.rooms.get(roomId);
 
     let listeners: RoomStatusListener[] = [];
 
@@ -316,12 +306,7 @@ describe('useRoom', () => {
     const WithClient = ({ children }: { children: React.ReactNode }) => {
       return (
         <ChatClientProvider client={chatClient}>
-          <ChatRoomProvider
-            id={roomId}
-            options={AllFeaturesEnabled}
-          >
-            {children}
-          </ChatRoomProvider>
+          <ChatRoomProvider id={roomId}>{children}</ChatRoomProvider>
         </ChatClientProvider>
       );
     };

--- a/test/react/hooks/use-typing.integration.test.tsx
+++ b/test/react/hooks/use-typing.integration.test.tsx
@@ -3,7 +3,6 @@ import React, { useEffect } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { TypingEvent } from '../../../src/core/events.ts';
-import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { RoomStatus } from '../../../src/core/room-status.ts';
 import { TypingListener } from '../../../src/core/typing.ts';
 import { useTyping } from '../../../src/react/hooks/use-typing.ts';
@@ -25,7 +24,7 @@ describe('useTyping', () => {
 
     // create a second room and attach it, so we can listen for typing events
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
+    const roomTwo = await chatClientTwo.rooms.get(roomId);
     await roomTwo.attach();
 
     // start listening for typing events on room two
@@ -49,10 +48,7 @@ describe('useTyping', () => {
 
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
-        <ChatRoomProvider
-          id={roomId}
-          options={AllFeaturesEnabled}
-        >
+        <ChatRoomProvider id={roomId}>
           <TestComponent />
         </ChatRoomProvider>
       </ChatClientProvider>
@@ -72,7 +68,7 @@ describe('useTyping', () => {
 
     // create a second room and attach it, so we can send typing events
     const roomId = randomRoomId();
-    const roomTwo = await chatClientTwo.rooms.get(roomId, AllFeaturesEnabled);
+    const roomTwo = await chatClientTwo.rooms.get(roomId);
     await roomTwo.attach();
 
     // store the received typing events for room one
@@ -93,10 +89,7 @@ describe('useTyping', () => {
 
     const TestProvider = () => (
       <ChatClientProvider client={chatClientOne}>
-        <ChatRoomProvider
-          id={roomId}
-          options={AllFeaturesEnabled}
-        >
+        <ChatRoomProvider id={roomId}>
           <TestComponent
             listener={(typingEvent) => {
               typingEventsRoomOne.push(typingEvent);

--- a/test/react/hooks/use-typing.test.tsx
+++ b/test/react/hooks/use-typing.test.tsx
@@ -233,7 +233,7 @@ describe('useTyping', () => {
 
     // spy on the onDiscontinuity method of the typing instance
     let discontinuityListener: DiscontinuityListener | undefined;
-    vi.spyOn(mockRoom.typing, 'onDiscontinuity').mockImplementation((listener: DiscontinuityListener) => {
+    vi.spyOn(mockRoom, 'onDiscontinuity').mockImplementation((listener: DiscontinuityListener) => {
       discontinuityListener = listener;
       return { off: mockOff };
     });

--- a/test/react/providers/chat-room-provider.integration.test.tsx
+++ b/test/react/providers/chat-room-provider.integration.test.tsx
@@ -1,7 +1,6 @@
 import { cleanup, configure, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { AllFeaturesEnabled } from '../../../src/core/room-options.ts';
 import { RoomStatus } from '../../../src/core/room-status.ts';
 import { ChatClientProvider } from '../../../src/react/providers/chat-client-provider.tsx';
 import { ChatRoomProvider } from '../../../src/react/providers/chat-room-provider.tsx';
@@ -31,7 +30,6 @@ describe('ChatRoomProvider', () => {
         <ChatClientProvider client={chatClient}>
           <ChatRoomProvider
             id={roomId}
-            options={{ reactions: AllFeaturesEnabled.reactions }}
             attach={true}
             release={false}
           >
@@ -42,7 +40,7 @@ describe('ChatRoomProvider', () => {
     };
     render(<TestProvider />);
 
-    const room = await chatClient.rooms.get(roomId, { reactions: AllFeaturesEnabled.reactions });
+    const room = await chatClient.rooms.get(roomId);
     await vi.waitFor(
       () => {
         expect(room.status).toBe(RoomStatus.Attached);


### PR DESCRIPTION
### Context

[CHA-867]

### Description

This PR contains the reference implementation for the single-channel migration, in a nutshell.

- Moved all features to use a single channel, `<roomID>::$chat`.
- All API calls now use "v3" of the HTTP API.
- Room Reactions now use the `ephemeral` flag on messages.
- Refactor of `RoomOptions`
  - These are now entirely optional, with defaults provided.
  - Presence of an object in the options no longer controls the "on-ness" of features. All features are on by default. Features that incur an additional cost for the users have separate flags that disable that part of the feature, i.e. occupancy and presence.
- Discontinuity handling now moved up to the Room level.
- Removed feature-level channel access, now at Room level.
- Re-implementation of the Room Lifecycle Manager to greatly simplify how it runs to use just one channel.
- Removed "transient detachment" handling. 

### Checklist

* [ ] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [ ] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

Please test the entire SDK thoroughly.


[CHA-867]: https://ably.atlassian.net/browse/CHA-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ