### PR TITLE
Fix: Encode `fromSerial`

### DIFF
--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -103,6 +103,10 @@ export class ChatApi {
 
     // convert the params into internal format
     const apiParams: ApiGetMessagesQueryParams = { ...params };
+    // encode the serial if it is provided
+    if (params.fromSerial) {
+      apiParams.fromSerial = encodeURIComponent(params.fromSerial);
+    }
     if (params.orderBy) {
       switch (params.orderBy) {
         case OrderBy.NewestFirst: {


### PR DESCRIPTION
### Context

* Ensure we are encoding the `fromSerial` parameter when it is provided in get requests.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [ ] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

* Explain how to test the changes in this PR.
* Provide specific steps or commands to execute.
