### PR TITLE
Make DefaultMessage clase use object-based constructor

### DIFF
--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -129,19 +129,13 @@ export class ChatApi {
     const mapToDefaultMessage = (message: Message): DefaultMessage => {
       const metadata = message.metadata as MessageMetadata | undefined;
       const headers = message.headers as MessageHeaders | undefined;
-      return new DefaultMessage(
-        message.serial,
-        message.clientId,
-        message.roomId,
-        message.text,
-        metadata ?? {},
-        headers ?? {},
-        message.action,
-        message.version,
-        (message.createdAt as Date | undefined) ? new Date(message.createdAt) : new Date(message.timestamp),
-        new Date(message.timestamp),
-        message.operation,
-      );
+      return new DefaultMessage({
+        ...message,
+        metadata: metadata ?? {},
+        headers: headers ?? {},
+        createdAt: (message.createdAt as Date | undefined) ? new Date(message.createdAt) : new Date(message.timestamp),
+        timestamp: new Date(message.timestamp),
+      });
     };
 
     const paginatedResult: PaginatedResult<Message> = {} as PaginatedResult<Message>;

--- a/src/core/message-parser.ts
+++ b/src/core/message-parser.ts
@@ -72,17 +72,17 @@ export function parseMessage(roomId: string | undefined, inboundMessage: Ably.In
     }
   }
 
-  return new DefaultMessage(
-    message.serial,
-    message.clientId,
-    roomId,
-    message.data.text,
-    message.data.metadata ?? {},
-    message.extras.headers ?? {},
-    message.action as ChatMessageActions,
-    message.version,
-    new Date(message.createdAt),
-    new Date(message.timestamp),
-    message.operation as Operation,
-  );
+  return new DefaultMessage({
+    serial: message.serial,
+    clientId: message.clientId,
+    roomId: roomId,
+    text: message.data.text,
+    metadata: message.data.metadata ?? {},
+    headers: message.extras.headers ?? {},
+    action: message.action as ChatMessageActions,
+    version: message.version,
+    createdAt: new Date(message.createdAt),
+    timestamp: new Date(message.timestamp),
+    operation: message.operation as Operation,
+  });
 }

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -261,24 +261,65 @@ export interface MessageCopyParams {
 }
 
 /**
+ * Parameters for creating a new DefaultMessage instance.
+ */
+export interface DefaultMessageParams {
+  serial: string;
+  clientId: string;
+  roomId: string;
+  text: string;
+  metadata: MessageMetadata;
+  headers: MessageHeaders;
+  action: ChatMessageActions;
+  version: string;
+  createdAt: Date;
+  timestamp: Date;
+  operation?: Operation;
+}
+
+/**
  * An implementation of the Message interface for chat messages.
  *
  * Allows for comparison of messages based on their serials.
  */
 export class DefaultMessage implements Message {
-  constructor(
-    public readonly serial: string,
-    public readonly clientId: string,
-    public readonly roomId: string,
-    public readonly text: string,
-    public readonly metadata: MessageMetadata,
-    public readonly headers: MessageHeaders,
-    public readonly action: ChatMessageActions,
-    public readonly version: string,
-    public readonly createdAt: Date,
-    public readonly timestamp: Date,
-    public readonly operation?: Operation,
-  ) {
+  public readonly serial: string;
+  public readonly clientId: string;
+  public readonly roomId: string;
+  public readonly text: string;
+  public readonly metadata: MessageMetadata;
+  public readonly headers: MessageHeaders;
+  public readonly action: ChatMessageActions;
+  public readonly version: string;
+  public readonly createdAt: Date;
+  public readonly timestamp: Date;
+  public readonly operation?: Operation;
+
+  constructor({
+    serial,
+    clientId,
+    roomId,
+    text,
+    metadata,
+    headers,
+    action,
+    version,
+    createdAt,
+    timestamp,
+    operation,
+  }: DefaultMessageParams) {
+    this.serial = serial;
+    this.clientId = clientId;
+    this.roomId = roomId;
+    this.text = text;
+    this.metadata = metadata;
+    this.headers = headers;
+    this.action = action;
+    this.version = version;
+    this.createdAt = createdAt;
+    this.timestamp = timestamp;
+    this.operation = operation;
+
     // The object is frozen after constructing to enforce readonly at runtime too
     Object.freeze(this);
   }
@@ -365,18 +406,18 @@ export class DefaultMessage implements Message {
 
   // Clone a message, optionally replace the given fields
   private static _clone(source: Message, replace?: Partial<Message>): DefaultMessage {
-    return new DefaultMessage(
-      replace?.serial ?? source.serial,
-      replace?.clientId ?? source.clientId,
-      replace?.roomId ?? source.roomId,
-      replace?.text ?? source.text,
-      replace?.metadata ?? structuredClone(source.metadata),
-      replace?.headers ?? structuredClone(source.headers),
-      replace?.action ?? source.action,
-      replace?.version ?? source.version,
-      replace?.createdAt ?? source.createdAt,
-      replace?.timestamp ?? source.timestamp,
-      replace?.operation ?? structuredClone(source.operation),
-    );
+    return new DefaultMessage({
+      serial: replace?.serial ?? source.serial,
+      clientId: replace?.clientId ?? source.clientId,
+      roomId: replace?.roomId ?? source.roomId,
+      text: replace?.text ?? source.text,
+      metadata: replace?.metadata ?? structuredClone(source.metadata),
+      headers: replace?.headers ?? structuredClone(source.headers),
+      action: replace?.action ?? source.action,
+      version: replace?.version ?? source.version,
+      createdAt: replace?.createdAt ?? source.createdAt,
+      timestamp: replace?.timestamp ?? source.timestamp,
+      operation: replace?.operation ?? structuredClone(source.operation),
+    });
   }
 }

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -468,18 +468,18 @@ export class DefaultMessages
     const { text, metadata, headers } = params;
 
     const response = await this._chatApi.sendMessage(this._roomId, { text, headers, metadata });
-    return new DefaultMessage(
-      response.serial,
-      this._clientId,
-      this._roomId,
-      text,
-      metadata ?? {},
-      headers ?? {},
-      ChatMessageActions.MessageCreate,
-      response.serial,
-      new Date(response.createdAt),
-      new Date(response.createdAt), // timestamp is the same as createdAt for new messages
-    );
+    return new DefaultMessage({
+      serial: response.serial,
+      clientId: this._clientId,
+      roomId: this._roomId,
+      text: text,
+      metadata: metadata ?? {},
+      headers: headers ?? {},
+      action: ChatMessageActions.MessageCreate,
+      version: response.serial,
+      createdAt: new Date(response.createdAt),
+      timestamp: new Date(response.createdAt), // timestamp is the same as createdAt for new messages
+    });
   }
 
   async update(message: Message, details?: OperationDetails): Promise<Message> {
@@ -494,23 +494,23 @@ export class DefaultMessages
       ...details,
     });
 
-    const updatedMessage: Message = new DefaultMessage(
-      message.serial,
-      message.clientId,
-      this._roomId,
-      message.text,
-      message.metadata,
-      message.headers,
-      ChatMessageActions.MessageUpdate,
-      response.version,
-      new Date(message.createdAt),
-      new Date(response.timestamp),
-      {
+    const updatedMessage: Message = new DefaultMessage({
+      serial: message.serial,
+      clientId: message.clientId,
+      roomId: this._roomId,
+      text: message.text,
+      metadata: message.metadata,
+      headers: message.headers,
+      action: ChatMessageActions.MessageUpdate,
+      version: response.version,
+      createdAt: new Date(message.createdAt),
+      timestamp: new Date(response.timestamp),
+      operation: {
         clientId: this._clientId,
         description: details?.description,
         metadata: details?.metadata,
       },
-    );
+    });
 
     this._logger.debug('Messages.update(); message update successfully', { message });
     return updatedMessage;
@@ -524,23 +524,23 @@ export class DefaultMessages
 
     const response = await this._chatApi.deleteMessage(this._roomId, message.serial, params);
 
-    const deletedMessage: Message = new DefaultMessage(
-      message.serial,
-      message.clientId,
-      this._roomId,
-      message.text,
-      message.metadata,
-      message.headers,
-      ChatMessageActions.MessageDelete,
-      response.version,
-      new Date(message.createdAt),
-      new Date(response.timestamp),
-      {
+    const deletedMessage: Message = new DefaultMessage({
+      serial: message.serial,
+      clientId: message.clientId,
+      roomId: this._roomId,
+      text: message.text,
+      metadata: message.metadata,
+      headers: message.headers,
+      action: ChatMessageActions.MessageDelete,
+      version: response.version,
+      createdAt: new Date(message.createdAt),
+      timestamp: new Date(response.timestamp),
+      operation: {
         clientId: this._clientId,
         description: params?.description,
         metadata: params?.metadata,
       },
-    );
+    });
 
     this._logger.debug('Messages.delete(); message deleted successfully', { deletedMessage });
     return deletedMessage;

--- a/test/core/message.test.ts
+++ b/test/core/message.test.ts
@@ -8,30 +8,31 @@ describe('ChatMessage', () => {
     const firstSerial = '01672531200000-123@abcdefghij';
     const secondSerial = '01672531200000-123@abcdefghij';
 
-    const firstMessage = new DefaultMessage(
-      firstSerial,
-      'clientId',
-      'roomId',
-      'hello there',
-      {},
-      {},
-      ChatMessageActions.MessageCreate,
-      firstSerial,
-      new Date(1672531200000),
-      new Date(1672531200000),
-    );
-    const secondMessage = new DefaultMessage(
-      secondSerial,
-      'clientId',
-      'roomId',
-      'hello there',
-      {},
-      {},
-      ChatMessageActions.MessageCreate,
-      secondSerial,
-      new Date(1672531200000),
-      new Date(1672531200000),
-    );
+    const firstMessage = new DefaultMessage({
+      serial: firstSerial,
+      clientId: 'clientId',
+      roomId: 'roomId',
+      text: 'hello there',
+      metadata: {},
+      headers: {},
+      action: ChatMessageActions.MessageCreate,
+      version: firstSerial,
+      createdAt: new Date(1672531200000),
+      timestamp: new Date(1672531200000),
+    });
+
+    const secondMessage = new DefaultMessage({
+      serial: secondSerial,
+      clientId: 'clientId',
+      roomId: 'roomId',
+      text: 'hello there',
+      metadata: {},
+      headers: {},
+      action: ChatMessageActions.MessageCreate,
+      version: secondSerial,
+      createdAt: new Date(1672531200000),
+      timestamp: new Date(1672531200000),
+    });
 
     expect(firstMessage.equal(secondMessage)).toBe(true);
   });
@@ -40,30 +41,31 @@ describe('ChatMessage', () => {
     const firstSerial = '01672531200000-123@abcdefghij';
     const secondSerial = '01672531200000-124@abcdefghij';
 
-    const firstMessage = new DefaultMessage(
-      firstSerial,
-      'clientId',
-      'roomId',
-      'hello there',
-      {},
-      {},
-      ChatMessageActions.MessageCreate,
-      firstSerial,
-      new Date(1672531200000),
-      new Date(1672531200000),
-    );
-    const secondMessage = new DefaultMessage(
-      secondSerial,
-      'clientId',
-      'roomId',
-      'hello there',
-      {},
-      {},
-      ChatMessageActions.MessageCreate,
-      secondSerial,
-      new Date(1672531200000),
-      new Date(1672531200000),
-    );
+    const firstMessage = new DefaultMessage({
+      serial: firstSerial,
+      clientId: 'clientId',
+      roomId: 'roomId',
+      text: 'hello there',
+      metadata: {},
+      headers: {},
+      action: ChatMessageActions.MessageCreate,
+      version: firstSerial,
+      createdAt: new Date(1672531200000),
+      timestamp: new Date(1672531200000),
+    });
+
+    const secondMessage = new DefaultMessage({
+      serial: secondSerial,
+      clientId: 'clientId',
+      roomId: 'roomId',
+      text: 'hello there',
+      metadata: {},
+      headers: {},
+      action: ChatMessageActions.MessageCreate,
+      version: secondSerial,
+      createdAt: new Date(1672531200000),
+      timestamp: new Date(1672531200000),
+    });
 
     expect(firstMessage.equal(secondMessage)).toBe(false);
   });
@@ -72,30 +74,31 @@ describe('ChatMessage', () => {
     const firstSerial = '01672531200000-123@abcdefghij';
     const secondSerial = '01672531200000-123@abcdefghij';
 
-    const firstMessage = new DefaultMessage(
-      firstSerial,
-      'clientId',
-      'roomId',
-      'hello there',
-      {},
-      {},
-      ChatMessageActions.MessageCreate,
-      firstSerial,
-      new Date(1672531200000),
-      new Date(1672531200000),
-    );
-    const secondMessage = new DefaultMessage(
-      secondSerial,
-      'clientId',
-      'roomId',
-      'hello there',
-      {},
-      {},
-      ChatMessageActions.MessageCreate,
-      secondSerial,
-      new Date(1672531200000),
-      new Date(1672531200000),
-    );
+    const firstMessage = new DefaultMessage({
+      serial: firstSerial,
+      clientId: 'clientId',
+      roomId: 'roomId',
+      text: 'hello there',
+      metadata: {},
+      headers: {},
+      action: ChatMessageActions.MessageCreate,
+      version: firstSerial,
+      createdAt: new Date(1672531200000),
+      timestamp: new Date(1672531200000),
+    });
+
+    const secondMessage = new DefaultMessage({
+      serial: secondSerial,
+      clientId: 'clientId',
+      roomId: 'roomId',
+      text: 'hello there',
+      metadata: {},
+      headers: {},
+      action: ChatMessageActions.MessageCreate,
+      version: secondSerial,
+      createdAt: new Date(1672531200000),
+      timestamp: new Date(1672531200000),
+    });
 
     expect(firstMessage.isSameAs(secondMessage)).toBe(true);
   });
@@ -104,30 +107,31 @@ describe('ChatMessage', () => {
     const firstSerial = '01672531200000-123@abcdefghij';
     const secondSerial = '01672531200000-124@abcdefghij';
 
-    const firstMessage = new DefaultMessage(
-      firstSerial,
-      'clientId',
-      'roomId',
-      'hello there',
-      {},
-      {},
-      ChatMessageActions.MessageCreate,
-      firstSerial,
-      new Date(1672531200000),
-      new Date(1672531200000),
-    );
-    const secondMessage = new DefaultMessage(
-      secondSerial,
-      'clientId',
-      'roomId',
-      'hello there',
-      {},
-      {},
-      ChatMessageActions.MessageCreate,
-      secondSerial,
-      new Date(1672531200000),
-      new Date(1672531200000),
-    );
+    const firstMessage = new DefaultMessage({
+      serial: firstSerial,
+      clientId: 'clientId',
+      roomId: 'roomId',
+      text: 'hello there',
+      metadata: {},
+      headers: {},
+      action: ChatMessageActions.MessageCreate,
+      version: firstSerial,
+      createdAt: new Date(1672531200000),
+      timestamp: new Date(1672531200000),
+    });
+
+    const secondMessage = new DefaultMessage({
+      serial: secondSerial,
+      clientId: 'clientId',
+      roomId: 'roomId',
+      text: 'hello there',
+      metadata: {},
+      headers: {},
+      action: ChatMessageActions.MessageCreate,
+      version: secondSerial,
+      createdAt: new Date(1672531200000),
+      timestamp: new Date(1672531200000),
+    });
 
     expect(firstMessage.isSameAs(secondMessage)).toBe(false);
   });
@@ -136,30 +140,31 @@ describe('ChatMessage', () => {
     const firstSerial = '01672531200000-123@abcdefghij';
     const secondSerial = '01672531200000-124@abcdefghij';
 
-    const firstMessage = new DefaultMessage(
-      firstSerial,
-      'clientId',
-      'roomId',
-      'hello there',
-      {},
-      {},
-      ChatMessageActions.MessageCreate,
-      firstSerial,
-      new Date(1672531200000),
-      new Date(1672531200000),
-    );
-    const secondMessage = new DefaultMessage(
-      secondSerial,
-      'clientId',
-      'roomId',
-      'hello there',
-      {},
-      {},
-      ChatMessageActions.MessageCreate,
-      secondSerial,
-      new Date(1672531200000),
-      new Date(1672531200000),
-    );
+    const firstMessage = new DefaultMessage({
+      serial: firstSerial,
+      clientId: 'clientId',
+      roomId: 'roomId',
+      text: 'hello there',
+      metadata: {},
+      headers: {},
+      action: ChatMessageActions.MessageCreate,
+      version: firstSerial,
+      createdAt: new Date(1672531200000),
+      timestamp: new Date(1672531200000),
+    });
+
+    const secondMessage = new DefaultMessage({
+      serial: secondSerial,
+      clientId: 'clientId',
+      roomId: 'roomId',
+      text: 'hello there',
+      metadata: {},
+      headers: {},
+      action: ChatMessageActions.MessageCreate,
+      version: secondSerial,
+      createdAt: new Date(1672531200000),
+      timestamp: new Date(1672531200000),
+    });
 
     expect(firstMessage.before(secondMessage)).toBe(true);
   });
@@ -168,30 +173,31 @@ describe('ChatMessage', () => {
     const firstSerial = '01672531200000-124@abcdefghij';
     const secondSerial = '01672531200000-123@abcdefghij';
 
-    const firstMessage = new DefaultMessage(
-      firstSerial,
-      'clientId',
-      'roomId',
-      'hello there',
-      {},
-      {},
-      ChatMessageActions.MessageCreate,
-      firstSerial,
-      new Date(1672531200000),
-      new Date(1672531200000),
-    );
-    const secondMessage = new DefaultMessage(
-      secondSerial,
-      'clientId',
-      'roomId',
-      'hello there',
-      {},
-      {},
-      ChatMessageActions.MessageCreate,
-      secondSerial,
-      new Date(1672531200000),
-      new Date(1672531200000),
-    );
+    const firstMessage = new DefaultMessage({
+      serial: firstSerial,
+      clientId: 'clientId',
+      roomId: 'roomId',
+      text: 'hello there',
+      metadata: {},
+      headers: {},
+      action: ChatMessageActions.MessageCreate,
+      version: firstSerial,
+      createdAt: new Date(1672531200000),
+      timestamp: new Date(1672531200000),
+    });
+
+    const secondMessage = new DefaultMessage({
+      serial: secondSerial,
+      clientId: 'clientId',
+      roomId: 'roomId',
+      text: 'hello there',
+      metadata: {},
+      headers: {},
+      action: ChatMessageActions.MessageCreate,
+      version: secondSerial,
+      createdAt: new Date(1672531200000),
+      timestamp: new Date(1672531200000),
+    });
 
     expect(firstMessage.after(secondMessage)).toBe(true);
   });
@@ -199,40 +205,40 @@ describe('ChatMessage', () => {
   describe('message versions', () => {
     it('is deleted', () => {
       const firstSerial = '01672531200000-124@abcdefghij:0';
-      const firstMessage = new DefaultMessage(
-        firstSerial,
-        'clientId',
-        'roomId',
-        'hello there',
-        {},
-        {},
-        ChatMessageActions.MessageDelete,
-        '01672531300000-123@abcdefghij:0',
-        new Date(1672531200000),
-        new Date(1672531300000),
-        {
+      const firstMessage = new DefaultMessage({
+        serial: firstSerial,
+        clientId: 'clientId',
+        roomId: 'roomId',
+        text: 'hello there',
+        metadata: {},
+        headers: {},
+        action: ChatMessageActions.MessageDelete,
+        version: '01672531300000-123@abcdefghij:0',
+        createdAt: new Date(1672531200000),
+        timestamp: new Date(1672531300000),
+        operation: {
           clientId: 'clientId2',
         },
-      );
+      });
       expect(firstMessage.isDeleted).toBe(true);
       expect(firstMessage.deletedBy).toBe('clientId2');
     });
 
     it('is updated', () => {
       const firstSerial = '01672531200000-124@abcdefghij';
-      const firstMessage = new DefaultMessage(
-        firstSerial,
-        'clientId',
-        'roomId',
-        'hello there',
-        {},
-        {},
-        ChatMessageActions.MessageUpdate,
-        '01672531200000-123@abcdefghij:0',
-        new Date(1672531200000),
-        new Date(1672531300000),
-        { clientId: 'clientId2' },
-      );
+      const firstMessage = new DefaultMessage({
+        serial: firstSerial,
+        clientId: 'clientId',
+        roomId: 'roomId',
+        text: 'hello there',
+        metadata: {},
+        headers: {},
+        action: ChatMessageActions.MessageUpdate,
+        version: '01672531200000-123@abcdefghij:0',
+        createdAt: new Date(1672531200000),
+        timestamp: new Date(1672531300000),
+        operation: { clientId: 'clientId2' },
+      });
       expect(firstMessage.isUpdated).toBe(true);
       expect(firstMessage.updatedBy).toBe('clientId2');
     });
@@ -244,30 +250,31 @@ describe('ChatMessage', () => {
       const firstVersion = '01672531200000-123@abcdefghij:0';
       const secondVersion = '01672531200000-123@abcdefghij:0';
 
-      const firstMessage = new DefaultMessage(
-        firstSerial,
-        'clientId',
-        'roomId',
-        'hello there',
-        {},
-        {},
-        ChatMessageActions.MessageUpdate,
-        firstVersion,
-        new Date(1672531200000),
-        new Date(1672531200000),
-      );
-      const secondMessage = new DefaultMessage(
-        secondSerial,
-        'clientId',
-        'roomId',
-        'hello there',
-        {},
-        {},
-        ChatMessageActions.MessageUpdate,
-        secondVersion,
-        new Date(1672531200000),
-        new Date(1672531200000),
-      );
+      const firstMessage = new DefaultMessage({
+        serial: firstSerial,
+        clientId: 'clientId',
+        roomId: 'roomId',
+        text: 'hello there',
+        metadata: {},
+        headers: {},
+        action: ChatMessageActions.MessageUpdate,
+        version: firstVersion,
+        createdAt: new Date(1672531200000),
+        timestamp: new Date(1672531200000),
+      });
+
+      const secondMessage = new DefaultMessage({
+        serial: secondSerial,
+        clientId: 'clientId',
+        roomId: 'roomId',
+        text: 'hello there',
+        metadata: {},
+        headers: {},
+        action: ChatMessageActions.MessageUpdate,
+        version: secondVersion,
+        createdAt: new Date(1672531200000),
+        timestamp: new Date(1672531200000),
+      });
 
       expect(firstMessage.isSameVersionAs(secondMessage)).toBe(false);
       expect(firstMessage.isOlderVersionOf(secondMessage)).toBe(false);
@@ -322,65 +329,66 @@ describe('ChatMessage', () => {
     ])('compare message versions', (name, { firstVersion, secondVersion, expected }) => {
       it(name, () => {
         const messageSerial = '01672531200000-123@abcdefghij';
-        const firstMessage = new DefaultMessage(
-          messageSerial,
-          'clientId',
-          'roomId',
-          'hello there',
-          {},
-          {},
-          ChatMessageActions.MessageUpdate,
-          firstVersion,
-          new Date(1672531200000),
-          new Date(1672531200001),
-        );
-        const secondMessage = new DefaultMessage(
-          messageSerial,
-          'clientId',
-          'roomId',
-          'hello there',
-          {},
-          {},
-          ChatMessageActions.MessageUpdate,
-          secondVersion,
-          new Date(1672531200000),
-          new Date(1672531200001),
-        );
+        const firstMessage = new DefaultMessage({
+          serial: messageSerial,
+          clientId: 'clientId',
+          roomId: 'roomId',
+          text: 'hello there',
+          metadata: {},
+          headers: {},
+          action: ChatMessageActions.MessageUpdate,
+          version: firstVersion,
+          createdAt: new Date(1672531200000),
+          timestamp: new Date(1672531200001),
+        });
+
+        const secondMessage = new DefaultMessage({
+          serial: messageSerial,
+          clientId: 'clientId',
+          roomId: 'roomId',
+          text: 'hello there',
+          metadata: {},
+          headers: {},
+          action: ChatMessageActions.MessageUpdate,
+          version: secondVersion,
+          createdAt: new Date(1672531200000),
+          timestamp: new Date(1672531200001),
+        });
         expected(firstMessage, secondMessage);
       });
     });
   });
 
   describe('apply events with with()', () => {
-    const message = new DefaultMessage(
-      '01672531200000-123@abcdefghij',
-      'yoda',
-      'rebel-alliance-general',
-      'hello there',
-      {},
-      {},
-      ChatMessageActions.MessageCreate,
-      '01672531200100-123@abcdefghij',
-      new Date(1672531200000),
-      new Date(1672531200000),
-      undefined,
-    );
+    const message = new DefaultMessage({
+      serial: '01672531200000-123@abcdefghij',
+      clientId: 'yoda',
+      roomId: 'rebel-alliance-general',
+      text: 'hello there',
+      metadata: {},
+      headers: {},
+      action: ChatMessageActions.MessageCreate,
+      version: '01672531200100-123@abcdefghij',
+      createdAt: new Date(1672531200000),
+      timestamp: new Date(1672531200000),
+      operation: undefined,
+    });
 
     it('should throw an error if different messages', () => {
       const serial = '01672531200000-123@abcdefgxyz';
-      const eventMessage = new DefaultMessage(
-        serial,
-        'yoda',
-        'rebel-alliance-general',
-        'hello there',
-        {},
-        {},
-        ChatMessageActions.MessageUpdate,
-        '01672531200500-123@abcdefghij',
-        new Date(1672531200000),
-        new Date(1672531200500),
-        { clientId: 'luke' },
-      );
+      const eventMessage = new DefaultMessage({
+        serial: serial,
+        clientId: 'yoda',
+        roomId: 'rebel-alliance-general',
+        text: 'hello there',
+        metadata: {},
+        headers: {},
+        action: ChatMessageActions.MessageUpdate,
+        version: '01672531200500-123@abcdefghij',
+        createdAt: new Date(1672531200000),
+        timestamp: new Date(1672531200500),
+        operation: { clientId: 'luke' },
+      });
 
       const event: MessageEvent = {
         type: MessageEvents.Updated,
@@ -395,19 +403,19 @@ describe('ChatMessage', () => {
     });
 
     it('should throw an error for create events messages', () => {
-      const eventMessage = new DefaultMessage(
-        message.serial,
-        'yoda',
-        'rebel-alliance-general',
-        'hello there',
-        {},
-        {},
-        ChatMessageActions.MessageCreate,
-        '01672531200500-123@abcdefghij',
-        new Date(1672531200000),
-        new Date(1672531200500),
-        { clientId: 'luke' },
-      );
+      const eventMessage = new DefaultMessage({
+        serial: message.serial,
+        clientId: 'yoda',
+        roomId: 'rebel-alliance-general',
+        text: 'hello there',
+        metadata: {},
+        headers: {},
+        action: ChatMessageActions.MessageCreate,
+        version: '01672531200500-123@abcdefghij',
+        createdAt: new Date(1672531200000),
+        timestamp: new Date(1672531200500),
+        operation: { clientId: 'luke' },
+      });
 
       const event: MessageEvent = {
         type: MessageEvents.Created,
@@ -422,19 +430,19 @@ describe('ChatMessage', () => {
     });
 
     it('should correctly apply an UPDATE', () => {
-      const eventMessage = new DefaultMessage(
-        message.serial,
-        'yoda',
-        'rebel-alliance-general',
-        'hi!',
-        {},
-        {},
-        ChatMessageActions.MessageUpdate,
-        '01672531209999-123@abcdefghij',
-        new Date(1672531200000),
-        new Date(1672531209999),
-        { clientId: 'luke' },
-      );
+      const eventMessage = new DefaultMessage({
+        serial: message.serial,
+        clientId: 'yoda',
+        roomId: 'rebel-alliance-general',
+        text: 'hi!',
+        metadata: {},
+        headers: {},
+        action: ChatMessageActions.MessageUpdate,
+        version: '01672531209999-123@abcdefghij',
+        createdAt: new Date(1672531200000),
+        timestamp: new Date(1672531209999),
+        operation: { clientId: 'luke' },
+      });
 
       const event: MessageEvent = {
         type: MessageEvents.Updated,
@@ -447,19 +455,19 @@ describe('ChatMessage', () => {
     });
 
     it('should correctly apply a DELETE', () => {
-      const eventMessage = new DefaultMessage(
-        message.serial,
-        'yoda',
-        'rebel-alliance-general',
-        'hola',
-        {},
-        {},
-        ChatMessageActions.MessageDelete,
-        '01672531209999-123@abcdefghij',
-        new Date(1672531200000),
-        new Date(1672531209999),
-        { clientId: 'luke' },
-      );
+      const eventMessage = new DefaultMessage({
+        serial: message.serial,
+        clientId: 'yoda',
+        roomId: 'rebel-alliance-general',
+        text: 'hola',
+        metadata: {},
+        headers: {},
+        action: ChatMessageActions.MessageDelete,
+        version: '01672531209999-123@abcdefghij',
+        createdAt: new Date(1672531200000),
+        timestamp: new Date(1672531209999),
+        operation: { clientId: 'luke' },
+      });
 
       const event: MessageEvent = {
         type: MessageEvents.Updated,
@@ -472,19 +480,19 @@ describe('ChatMessage', () => {
     });
 
     it('should ignore outdated versions', () => {
-      const eventMessage = new DefaultMessage(
-        message.serial,
-        'yoda',
-        'rebel-alliance-general',
-        'old one',
-        {},
-        {},
-        ChatMessageActions.MessageUpdate,
-        '01672531200000-123@abcdefghij',
-        new Date(1672531200000),
-        new Date(1672531209999),
-        { clientId: 'luke' },
-      );
+      const eventMessage = new DefaultMessage({
+        serial: message.serial,
+        clientId: 'yoda',
+        roomId: 'rebel-alliance-general',
+        text: 'old one',
+        metadata: {},
+        headers: {},
+        action: ChatMessageActions.MessageUpdate,
+        version: '01672531200000-123@abcdefghij',
+        createdAt: new Date(1672531200000),
+        timestamp: new Date(1672531209999),
+        operation: { clientId: 'luke' },
+      });
 
       const event: MessageEvent = {
         type: MessageEvents.Updated,
@@ -496,19 +504,19 @@ describe('ChatMessage', () => {
     });
 
     it('should ignore equal versions', () => {
-      const eventMessage = new DefaultMessage(
-        message.serial,
-        'yoda',
-        'rebel-alliance-general',
-        'old one',
-        {},
-        {},
-        ChatMessageActions.MessageUpdate,
-        message.version,
-        new Date(1672531200000),
-        new Date(1672531209999),
-        { clientId: 'luke' },
-      );
+      const eventMessage = new DefaultMessage({
+        serial: message.serial,
+        clientId: 'yoda',
+        roomId: 'rebel-alliance-general',
+        text: 'old one',
+        metadata: {},
+        headers: {},
+        action: ChatMessageActions.MessageUpdate,
+        version: message.version,
+        createdAt: new Date(1672531200000),
+        timestamp: new Date(1672531209999),
+        operation: { clientId: 'luke' },
+      });
 
       const event: MessageEvent = {
         type: MessageEvents.Updated,
@@ -522,18 +530,18 @@ describe('ChatMessage', () => {
 
   describe('message copy', () => {
     it('copies a message with updated fields', () => {
-      const originalMessage = new DefaultMessage(
-        '01672531200000-123@abcdefghij',
-        'clientId',
-        'roomId',
-        'original text',
-        { key: 'value' },
-        { headerKey: 'headerValue' },
-        ChatMessageActions.MessageCreate,
-        'version1',
-        new Date(1672531200000),
-        new Date(1672531200000),
-      );
+      const originalMessage = new DefaultMessage({
+        serial: '01672531200000-123@abcdefghij',
+        clientId: 'clientId',
+        roomId: 'roomId',
+        text: 'original text',
+        metadata: { key: 'value' },
+        headers: { headerKey: 'headerValue' },
+        action: ChatMessageActions.MessageCreate,
+        version: 'version1',
+        createdAt: new Date(1672531200000),
+        timestamp: new Date(1672531200000),
+      });
 
       const copiedMessage = originalMessage.copy({
         text: 'updated text',
@@ -553,18 +561,18 @@ describe('ChatMessage', () => {
     });
 
     it('copies a message without changes when no parameters are provided', () => {
-      const originalMessage = new DefaultMessage(
-        '01672531200000-123@abcdefghij',
-        'clientId',
-        'roomId',
-        'original text',
-        { key: 'value' },
-        { headerKey: 'headerValue' },
-        ChatMessageActions.MessageCreate,
-        'version1',
-        new Date(1672531200000),
-        new Date(1672531200000),
-      );
+      const originalMessage = new DefaultMessage({
+        serial: '01672531200000-123@abcdefghij',
+        clientId: 'clientId',
+        roomId: 'roomId',
+        text: 'original text',
+        metadata: { key: 'value' },
+        headers: { headerKey: 'headerValue' },
+        action: ChatMessageActions.MessageCreate,
+        version: 'version1',
+        createdAt: new Date(1672531200000),
+        timestamp: new Date(1672531200000),
+      });
 
       const copiedMessage = originalMessage.copy();
 
@@ -581,18 +589,25 @@ describe('ChatMessage', () => {
     });
 
     it('ensures deep copy of metadata and headers', () => {
-      const originalMessage = new DefaultMessage(
-        '01672531200000-123@abcdefghij',
-        'clientId',
-        'roomId',
-        'original text',
-        { key: 'value', nested: { key: 'nestedValue' } },
-        { headerKey: 'headerValue' },
-        ChatMessageActions.MessageCreate,
-        'version1',
-        new Date(1672531200000),
-        new Date(1672531200000),
-      );
+      const originalMessage = new DefaultMessage({
+        serial: '01672531200000-123@abcdefghij',
+        clientId: 'clientId',
+        roomId: 'roomId',
+        text: 'original text',
+        metadata: {
+          key: 'value',
+          nested: {
+            key: 'nestedValue',
+          },
+        },
+        headers: {
+          headerKey: 'headerValue',
+        },
+        action: ChatMessageActions.MessageCreate,
+        version: 'version1',
+        createdAt: new Date(1672531200000),
+        timestamp: new Date(1672531200000),
+      });
 
       const copiedMessage = originalMessage.copy();
 
@@ -611,18 +626,23 @@ describe('ChatMessage', () => {
     });
 
     it('ensures deep replacement of metadata and headers', () => {
-      const originalMessage = new DefaultMessage(
-        '01672531200000-123@abcdefghij',
-        'clientId',
-        'roomId',
-        'original text',
-        { key: 'value', nested: { key: 'nestedValue' } },
-        { headerKey: 'headerValue' },
-        ChatMessageActions.MessageCreate,
-        'version1',
-        new Date(1672531200000),
-        new Date(1672531200000),
-      );
+      const originalMessage = new DefaultMessage({
+        serial: '01672531200000-123@abcdefghij',
+        clientId: 'clientId',
+        roomId: 'roomId',
+        text: 'original text',
+        metadata: {
+          key: 'value',
+          nested: {
+            key: 'nestedValue',
+          },
+        },
+        headers: { headerKey: 'headerValue' },
+        action: ChatMessageActions.MessageCreate,
+        version: 'version1',
+        createdAt: new Date(1672531200000),
+        timestamp: new Date(1672531200000),
+      });
 
       const copiedMessage = originalMessage.copy({
         metadata: { key: 'newValue', nested: { key: 'newNestedValue' } },

--- a/test/react/hooks/use-messages.test.tsx
+++ b/test/react/hooks/use-messages.test.tsx
@@ -173,18 +173,18 @@ describe('useMessages', () => {
 
     const deleteSpy = vi.spyOn(mockRoom.messages, 'delete').mockResolvedValue({} as unknown as Message);
 
-    const message = new DefaultMessage(
-      '01719948956834-000@108TeGZDQBderu97202638',
-      'client-1',
-      'some-room',
-      'I have the high ground now',
-      {},
-      {},
-      ChatMessageActions.MessageCreate,
-      '01719948956834-000@108TeGZDQBderu97202638',
-      new Date(1719948956834),
-      new Date(1719948956834),
-    );
+    const message = new DefaultMessage({
+      serial: '01719948956834-000@108TeGZDQBderu97202638',
+      clientId: 'client-1',
+      roomId: 'some-room',
+      text: 'I have the high ground now',
+      metadata: {},
+      headers: {},
+      action: ChatMessageActions.MessageCreate,
+      version: '01719948956834-000@108TeGZDQBderu97202638',
+      createdAt: new Date(1719948956834),
+      timestamp: new Date(1719948956834),
+    });
     // call both methods and ensure they call the underlying messages methods
     await act(async () => {
       await result.current.send({ text: 'test message' });


### PR DESCRIPTION
### Context

* DefaultMessage constructor was growing in size and becoming a bit unwieldy, to make it easier to read and maintain, I've refactored it to use an object-based constructor.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

* Explain how to test the changes in this PR.
* Provide specific steps or commands to execute.