### PR TITLE
Docs: Update README Chat install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ The Chat SDK can be installed either from NPM, or included directly from Ably's 
 
 ```sh
 npm install ably @ably/chat
+npm install react
 ```
+NOTE: React dependency is currently required even if you are not using Chat React components.
+This is a known issue and will be removed in a future release.
 
 ### CDN
 
@@ -92,8 +95,8 @@ import * as Ably from "ably";
 import {
   ChatClient,
   ConnectionStatusChange,
+  AllFeaturesEnabled,
   MessageEvent,
-  RoomOptionsDefaults,
   RoomStatusChange,
 } from "@ably/chat";
 
@@ -115,8 +118,8 @@ async function getStartedWithChat() {
 
   // Get a room to join, subscribe to messages and then attach to the room
   const room = await chatClient.rooms.get(
-    "readme-getting-started",
-    RoomOptionsDefaults
+    "readme-getting-started", 
+     AllFeaturesEnabled
   );
   const { off: unsubscribeRoomStatus } = room.onStatusChange(
     (change: RoomStatusChange) => {
@@ -302,7 +305,7 @@ own key from the Ably dashboard.
 
 ```tsx
 import * as Ably from 'ably';
-import { ChatClient, ChatClientProvider, ChatRoomProvider, RoomOptionsDefaults } from '@ably/chat';
+import { ChatClient, ChatClientProvider, ChatRoomProvider, AllFeaturesEnabled } from '@ably/chat';
 import { Messages } from './Messages';
 
 // Initialize an Ably Realtime client, which we'll use to power the chat client
@@ -323,7 +326,7 @@ const chatClient = new ChatClient(ablyClient, {});
 function App() {
   return (
     <ChatClientProvider client={chatClient}>
-      <ChatRoomProvider id="readme-getting-started" options={RoomOptionsDefaults}>
+      <ChatRoomProvider id="readme-getting-started" options={AllFeaturesEnabled}>
         <div>
           <Messages />
         </div>


### PR DESCRIPTION
### Context

* Currently, chat will only work correctly if React is installed as a dependency, this is due to be fixed soon. The issue is our getting started guide doesn't mention this, so users would likely get stuck when trying to run the getting started example.

### Description

* Added `npm install react` to the guides installation section - also mentioned this will be fixed in an upcoming version.
* Corrected the room options param name, it is now exported as `AllFeaturesEnabled` instead of `RoomOptionsDefaults`.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

* Create a new ts project and follow the getting started guide.
