### PR TITLE
Add unique listeners so unsubscribe() and stop extending EventEmitter

### DIFF
--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -16,7 +16,7 @@ import { Logger } from './logger.js';
 import { ContributesToRoomLifecycle } from './room-lifecycle-manager.js';
 import { TypingOptions } from './room-options.js';
 import { Subscription } from './subscription.js';
-import EventEmitter from './utils/event-emitter.js';
+import EventEmitter, { wrap } from './utils/event-emitter.js';
 
 const PRESENCE_GET_RETRY_INTERVAL_MS = 1500; // base retry interval, we double it each time
 const PRESENCE_GET_RETRY_MAX_INTERVAL_MS = 30000; // max retry interval
@@ -219,12 +219,13 @@ export class DefaultTyping
    */
   subscribe(listener: TypingListener): Subscription {
     this._logger.trace(`DefaultTyping.subscribe();`);
-    this.on(listener);
+    const wrapped = wrap(listener);
+    this.on(wrapped);
 
     return {
       unsubscribe: () => {
         this._logger.trace('DefaultTyping.unsubscribe();');
-        this.off(listener);
+        this.off(wrapped);
       },
     };
   }
@@ -317,11 +318,12 @@ export class DefaultTyping
 
   onDiscontinuity(listener: DiscontinuityListener): OnDiscontinuitySubscriptionResponse {
     this._logger.trace(`DefaultTyping.onDiscontinuity();`);
-    this._discontinuityEmitter.on(listener);
+    const wrapped = wrap(listener);
+    this._discontinuityEmitter.on(wrapped);
 
     return {
       off: () => {
-        this._discontinuityEmitter.off(listener);
+        this._discontinuityEmitter.off(wrapped);
       },
     };
   }

--- a/src/core/utils/event-emitter.ts
+++ b/src/core/utils/event-emitter.ts
@@ -60,3 +60,12 @@ const InternalEventEmitter: new <EventsMap>() => InterfaceEventEmitter<EventsMap
 class EventEmitter<EventsMap> extends InternalEventEmitter<EventsMap> {}
 
 export default EventEmitter;
+
+/**
+ * Creates a wrapper function that forwards all arguments to the provided function.
+ * @param fn The function to wrap
+ * @returns A new function with the same signature as the input function
+ */
+export const wrap = <Args extends unknown[], Return>(fn: (...args: Args) => Return): ((...args: Args) => Return) => {
+  return (...args: Args) => fn(...args);
+};

--- a/test/core/presence.test.ts
+++ b/test/core/presence.test.ts
@@ -2,8 +2,9 @@ import * as Ably from 'ably';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatApi } from '../../src/core/chat-api.ts';
-import { DefaultPresence } from '../../src/core/presence.ts';
+import { DefaultPresence, PresenceData, PresenceEvent } from '../../src/core/presence.ts';
 import { Room } from '../../src/core/room.ts';
+import { PresenceEvents } from '../../src/index.ts';
 import { makeTestLogger } from '../helper/logger.ts';
 import { makeRandomRoom } from '../helper/room.ts';
 
@@ -38,5 +39,75 @@ describe('Presence', () => {
       message: 'could not subscribe listener: invalid arguments',
       code: 40000,
     });
+  });
+
+  it<TestContext>('should only unsubscribe the correct subscription', (context) => {
+    const { room } = context;
+    const received: PresenceEvent[] = [];
+
+    const emulatePresenceEvent = (clientId: string, action: PresenceEvents, data?: PresenceData) => {
+      const presenceMessage: Ably.PresenceMessage = {
+        action,
+        clientId,
+        timestamp: Date.now(),
+        data: data ? { userCustomData: data } : undefined,
+        connectionId: 'connection-id',
+        encoding: '',
+        id: 'message-id',
+        extras: null,
+      };
+
+      // Call the subscribeToEvents handler directly
+      (room.presence as DefaultPresence).subscribeToEvents(presenceMessage);
+    };
+
+    const listener = (event: PresenceEvent) => {
+      received.push(event);
+    };
+
+    // Subscribe the same listener twice
+    const subscription1 = room.presence.subscribe(listener);
+    const subscription2 = room.presence.subscribe(listener);
+
+    // Both subscriptions should trigger the listener
+    emulatePresenceEvent('user1', PresenceEvents.Enter, { foo: 'bar' });
+    expect(received).toHaveLength(2);
+
+    // Unsubscribe first subscription
+    subscription1.unsubscribe();
+
+    // One subscription should still trigger the listener
+    emulatePresenceEvent('user2', PresenceEvents.Enter, { baz: 'qux' });
+    expect(received).toHaveLength(3);
+
+    // Unsubscribe second subscription
+    subscription2.unsubscribe();
+
+    // No subscriptions should trigger the listener
+    emulatePresenceEvent('user3', PresenceEvents.Enter, { test: 'data' });
+    expect(received).toHaveLength(3);
+  });
+
+  it<TestContext>('should only unsubscribe the correct subscription for discontinuities', (context) => {
+    const { room } = context;
+
+    const received: string[] = [];
+    const listener = (error?: Ably.ErrorInfo) => {
+      received.push(error?.message ?? 'no error');
+    };
+
+    const subscription1 = room.presence.onDiscontinuity(listener);
+    const subscription2 = room.presence.onDiscontinuity(listener);
+
+    (room.presence as DefaultPresence).discontinuityDetected(new Ably.ErrorInfo('error1', 0, 0));
+    expect(received).toEqual(['error1', 'error1']);
+
+    subscription1.off();
+    (room.presence as DefaultPresence).discontinuityDetected(new Ably.ErrorInfo('error2', 0, 0));
+    expect(received).toEqual(['error1', 'error1', 'error2']);
+
+    subscription2.off();
+    (room.presence as DefaultPresence).discontinuityDetected(new Ably.ErrorInfo('error3', 0, 0));
+    expect(received).toEqual(['error1', 'error1', 'error2']);
   });
 });

--- a/test/core/room-status.test.ts
+++ b/test/core/room-status.test.ts
@@ -53,4 +53,29 @@ describe('room status', () => {
       status.setStatus({ status: RoomStatus.Attached, error: baseError });
       done();
     }));
+
+  it('subscriptions are unique even if listeners are identical', () =>
+    new Promise<void>((done, reject) => {
+      const status = new DefaultRoomLifecycle('roomId', makeTestLogger());
+
+      let eventCount = 0;
+      const listener = () => {
+        eventCount++;
+        if (eventCount > 3) {
+          reject(new Error('too many events received (' + eventCount.toString() + ')'));
+        }
+      };
+
+      const s1 = status.onChange(listener);
+      const s2 = status.onChange(listener);
+      status.setStatus({ status: RoomStatus.Attached, error: baseError });
+      expect(eventCount).toEqual(2);
+      s1.off();
+      status.setStatus({ status: RoomStatus.Attached, error: baseError });
+      expect(eventCount).toEqual(3);
+      s2.off();
+      status.setStatus({ status: RoomStatus.Attached, error: baseError });
+      expect(eventCount).toEqual(3);
+      done();
+    }));
 });

--- a/test/react/helper/use-room-status.test.tsx
+++ b/test/react/helper/use-room-status.test.tsx
@@ -120,7 +120,9 @@ describe('useRoomStatus', () => {
     });
 
     // At this point we should have two listeners on the room status
-    expect((mockRoom as unknown as { _lifecycle: { listeners(): unknown[] } })._lifecycle.listeners()).toHaveLength(2);
+    expect(
+      (mockRoom as unknown as { _lifecycle: { _emitter: { listeners(): unknown[] } } })._lifecycle._emitter.listeners(),
+    ).toHaveLength(2);
 
     // Check the event
     expect(receivedEvents[0]?.current).toBe(RoomStatus.Failed);
@@ -146,6 +148,8 @@ describe('useRoomStatus', () => {
 
     // After unmount we should have no listeners
     unmount();
-    expect((mockRoom as unknown as { _lifecycle: { listeners(): unknown[] } })._lifecycle.listeners()).toBeNull();
+    expect(
+      (mockRoom as unknown as { _lifecycle: { _emitter: { listeners(): unknown[] } } })._lifecycle._emitter.listeners(),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
Stop extending EventEmitter so we get a cleaner public API (in JS).

Wrap all listeners into a unique reference function to make sure that subscribing the same function twice and unsubscribing one subscription will only unsubscribes that one subscription and not both.

### Context

* [CHA-856]
* [CHA-506]

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

[CHA-856]: https://ably.atlassian.net/browse/CHA-856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CHA-506]: https://ably.atlassian.net/browse/CHA-506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ