### PR TITLE
demo: add log level configuration for chat client

### DIFF
--- a/demo/.env.example
+++ b/demo/.env.example
@@ -4,5 +4,8 @@ VITE_ABLY_CHAT_API_KEY=
 # Your environment, set to 'production' by default.
 VITE_ABLY_CHAT_ENV=
 
+# Log level for the chat client, defaults to 'info'
+VITE_ABLY_CHAT_LOG_LEVEL=info
+
 # Optional if you're using a custom domain for Ably
 #VITE_ABLY_HOST=my-personal-domain.ably-realtime.com

--- a/demo/src/main.tsx
+++ b/demo/src/main.tsx
@@ -57,9 +57,30 @@ const getRealtimeOptions = () => {
   return realtimeOptions;
 };
 
+const getLogLevel = () => {
+  const envLogLevel = import.meta?.env?.VITE_ABLY_CHAT_LOG_LEVEL?.toLowerCase();
+  switch (envLogLevel) {
+    case 'silent':
+      return LogLevel.Silent;
+    case 'error':
+      return LogLevel.Error;
+    case 'warn':
+      return LogLevel.Warn;
+    case 'info':
+      return LogLevel.Info;
+    case 'debug':
+      return LogLevel.Debug;
+    case 'trace':
+      return LogLevel.Trace;
+    default:
+      console.log(`Unknown log level: ${envLogLevel}, defaulting to 'info'`);
+      return LogLevel.Info;
+  }
+};
+
 const realtimeClient = new Ably.Realtime(getRealtimeOptions());
 
-const chatClient = new ChatClient(realtimeClient, { logLevel: LogLevel.Info });
+const chatClient = new ChatClient(realtimeClient, { logLevel: getLogLevel() });
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>


### PR DESCRIPTION
### Context

N/A

### Description

- Introduced VITE_ABLY_CHAT_LOG_LEVEL in the .env.example file to allow customization of the chat client's log level.
- Saves us having to change checked-in code if we want to use a different level when running the demo.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A