### PR TITLE
refactor: logging contexts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "copilot:from-cursor": "(cd .github && npx tsx ./copilot-from-cursor.ts)",
     "lint": "eslint . && npm run cspell",
     "lint:fix": "eslint --fix .; (npm run format > /dev/null)",
-    "format": "prettier --write src test __mocks__ demo/src",
+    "format": "prettier --list-different --write src test __mocks__ demo/src",
     "format:check": "prettier --check src test __mocks__ demo/src",
     "test": "vitest run",
     "test:chat": "vitest run --project chat",

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -555,9 +555,7 @@ export class DefaultMessages implements Messages, HandlesDiscontinuity, Contribu
 
     // Add a handler for unhandled rejections incase the room is released before the subscription point is resolved
     resolvedSubscriptionStart.catch(() => {
-      this._logger.debug('Messages.subscribe(); subscription point was not resolved before the room was released', {
-        roomId: this._roomId,
-      });
+      this._logger.debug('Messages.subscribe(); subscription point was not resolved before the room was released');
     });
 
     this._listenerSubscriptionPoints.set(wrapped, resolvedSubscriptionStart);

--- a/src/core/room-status.ts
+++ b/src/core/room-status.ts
@@ -163,16 +163,15 @@ export class DefaultRoomLifecycle implements InternalRoomLifecycle {
   private readonly _internalEmitter = new EventEmitter<RoomStatusEventsMap>();
   private readonly _roomId: string;
   private readonly _emitter = new EventEmitter<RoomStatusEventsMap>();
+
   /**
-   * Constructs a new `DefaultStatus` instance.
-   * @param roomId - The unique identifier for the room.
-   * @param logger The logger to use.
+   * Constructs a new DefaultRoomLifecycle instance.
+   * @param roomId The unique identifier of the room.
+   * @param logger An instance of the Logger.
    */
   constructor(roomId: string, logger: Logger) {
     this._roomId = roomId;
     this._logger = logger;
-    this._status = RoomStatus.Initialized;
-    this._error = undefined;
   }
 
   /**
@@ -223,7 +222,7 @@ export class DefaultRoomLifecycle implements InternalRoomLifecycle {
 
     this._status = change.current;
     this._error = change.error;
-    this._logger.info(`room status changed`, { ...change, roomId: this._roomId });
+    this._logger.info(`room status changed`, { ...change });
     this._internalEmitter.emit(change.current, change);
     this._emitter.emit(change.current, change);
   }

--- a/src/react/helper/room-promise.ts
+++ b/src/react/helper/room-promise.ts
@@ -64,7 +64,7 @@ class DefaultRoomPromise implements RoomPromise {
     this._logger = logger;
 
     this.mount(room).catch(() => {
-      this._logger.trace('DefaultRoomPromise(); mount error', { roomId: this._roomId });
+      this._logger.trace('DefaultRoomPromise(); mount error');
     });
   }
 
@@ -76,17 +76,17 @@ class DefaultRoomPromise implements RoomPromise {
    * @returns A promise that we simply resolve when it's done.
    */
   async mount(promise: Promise<Room>): Promise<void> {
-    this._logger.debug('DefaultRoomPromise(); mount', { roomId: this._roomId });
+    this._logger.debug('DefaultRoomPromise(); mount');
     try {
       const room = await promise;
       if (this._unmounted) {
         return;
       }
 
-      this._logger.debug('DefaultRoomPromise(); mount resolved', { roomId: this._roomId });
+      this._logger.debug('DefaultRoomPromise(); mount resolved');
       this._onUnmount = this._onResolve(room);
     } catch (error) {
-      this._logger.error('DefaultRoomPromise(); mount error', { roomId: this._roomId, error });
+      this._logger.error('DefaultRoomPromise(); mount error', { error });
     }
   }
 
@@ -115,7 +115,7 @@ class DefaultRoomPromise implements RoomPromise {
     }
 
     return () => {
-      this._logger.debug('DefaultRoomPromise(); unmount', { roomId: this._roomId });
+      this._logger.debug('DefaultRoomPromise(); unmount');
       this._unmounted = true;
       this._onUnmount?.();
     };

--- a/src/react/helper/use-eventual-room.ts
+++ b/src/react/helper/use-eventual-room.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { Room } from '../../core/room.js';
-import { useLogger } from '../hooks/use-logger.js';
+import { useRoomLogger } from '../hooks/use-logger.js';
 import { useRoomContext } from './use-room-context.js';
 import { useStableReference } from './use-stable-reference.js';
 
@@ -16,28 +16,28 @@ import { useStableReference } from './use-stable-reference.js';
 export const useEventualRoom = (): Room | undefined => {
   const [roomState, setRoomState] = useState<Room | undefined>();
   const context = useRoomContext('useEventualRoom');
-  const logger = useLogger();
-  logger.trace('useEventualRoom();', { roomId: context.roomId });
+  const logger = useRoomLogger();
+  logger.trace('useEventualRoom();');
 
   useEffect(() => {
-    logger.debug('useEventualRoom(); running useEffect', { roomId: context.roomId });
+    logger.debug('useEventualRoom(); running useEffect');
     let unmounted = false;
     void context.room
       .then((room: Room) => {
         if (unmounted) {
-          logger.debug('useEventualRoom(); already unmounted', { roomId: context.roomId });
+          logger.debug('useEventualRoom(); already unmounted');
           return;
         }
 
-        logger.debug('useEventualRoom(); resolved', { roomId: context.roomId });
+        logger.debug('useEventualRoom(); resolved');
         setRoomState(room);
       })
       .catch((error: unknown) => {
-        logger.error('Failed to get room', { roomId: context.roomId, error });
+        logger.error('Failed to get room', { error });
       });
 
     return () => {
-      logger.debug('useEventualRoom(); cleanup', { roomId: context.roomId });
+      logger.debug('useEventualRoom(); cleanup');
       unmounted = true;
     };
   }, [context, logger]);
@@ -57,29 +57,29 @@ export const useEventualRoom = (): Room | undefined => {
 export const useEventualRoomProperty = <T>(onResolve: (room: Room) => T) => {
   const [roomState, setRoomState] = useState<T | undefined>();
   const context = useRoomContext('useEventualRoomProperty');
-  const logger = useLogger();
-  logger.trace('useEventualRoomProperty();', { roomId: context.roomId });
+  const logger = useRoomLogger();
+  logger.trace('useEventualRoomProperty();');
   const onResolveRef = useStableReference(onResolve);
 
   useEffect(() => {
     let unmounted = false;
-    logger.debug('useEventualRoomProperty(); running useEffect', { roomId: context.roomId });
+    logger.debug('useEventualRoomProperty(); running useEffect');
     void context.room
       .then((room: Room) => {
         if (unmounted) {
-          logger.debug('useEventualRoomProperty(); already unmounted', { roomId: context.roomId });
+          logger.debug('useEventualRoomProperty(); already unmounted');
           return;
         }
 
-        logger.debug('useEventualRoomProperty(); resolved', { roomId: context.roomId });
+        logger.debug('useEventualRoomProperty(); resolved');
         setRoomState(onResolveRef(room));
       })
       .catch((error: unknown) => {
-        logger.error('Failed to get room', { roomId: context.roomId, error });
+        logger.error('Failed to get room', { error });
       });
 
     return () => {
-      logger.debug('useEventualRoomProperty(); cleanup', { roomId: context.roomId });
+      logger.debug('useEventualRoomProperty(); cleanup');
       unmounted = true;
     };
   }, [context, logger, onResolveRef]);

--- a/src/react/helper/use-room-status.ts
+++ b/src/react/helper/use-room-status.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 
 import { Room } from '../../core/room.js';
 import { RoomStatus, RoomStatusChange } from '../../core/room-status.js';
-import { useLogger } from '../hooks/use-logger.js';
+import { useRoomLogger } from '../hooks/use-logger.js';
 import { wrapRoomPromise } from './room-promise.js';
 import { useEventListenerRef } from './use-event-listener-ref.js';
 import { useRoomContext } from './use-room-context.js';
@@ -45,7 +45,7 @@ export const useRoomStatus = (params?: UseRoomStatusParams): UseRoomStatusRespon
 
   const [status, setStatus] = useState<RoomStatus>(RoomStatus.Initializing);
   const [error, setError] = useState<Ably.ErrorInfo | undefined>();
-  const logger = useLogger();
+  const logger = useRoomLogger();
 
   // create stable references for the listeners and register the user-provided callbacks
   const onRoomStatusChangeRef = useEventListenerRef(params?.onRoomStatusChange);

--- a/src/react/hooks/use-logger.ts
+++ b/src/react/hooks/use-logger.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 
 import { Logger } from '../../core/logger.js';
+import { useRoomContext } from '../helper/use-room-context.js';
 import { useChatClient } from './use-chat-client.js';
-
 /**
  * A hook that provides access to the {@link Logger} instance of the {@link ChatClient}.
  * It will use the instance belonging to the {@link ChatClient} in the nearest {@link ChatClientProvider} in the component tree.
@@ -13,4 +13,20 @@ import { useChatClient } from './use-chat-client.js';
 export const useLogger = (): Logger => {
   const chatClient = useChatClient();
   return useMemo(() => (chatClient as unknown as { logger: Logger }).logger, [chatClient]);
+};
+
+/**
+ * A hook that returns a logger with the room context pre-applied.
+ * @internal
+ *
+ * @returns Logger - The logger instance.
+ */
+export const useRoomLogger = (): Logger => {
+  const roomContext = useRoomContext('useRoomLogger');
+  const chatClient = useChatClient();
+
+  return useMemo(
+    () => (chatClient as unknown as { logger: Logger }).logger.withContext({ roomId: roomContext.roomId }),
+    [chatClient, roomContext],
+  );
 };

--- a/src/react/hooks/use-occupancy.ts
+++ b/src/react/hooks/use-occupancy.ts
@@ -10,7 +10,7 @@ import { ChatStatusResponse } from '../types/chat-status-response.js';
 import { Listenable } from '../types/listenable.js';
 import { StatusParams } from '../types/status-params.js';
 import { useChatConnection } from './use-chat-connection.js';
-import { useLogger } from './use-logger.js';
+import { useRoomLogger } from './use-logger.js';
 
 /**
  * The options for the {@link useOccupancy} hook.
@@ -57,8 +57,8 @@ export const useOccupancy = (params?: UseOccupancyParams): UseOccupancyResponse 
   const context = useRoomContext('useOccupancy');
   const { status: roomStatus, error: roomError } = useRoomStatus(params);
 
-  const logger = useLogger();
-  logger.trace('useOccupancy();', { params, roomId: context.roomId });
+  const logger = useRoomLogger();
+  logger.trace('useOccupancy();', { params });
 
   const [occupancyMetrics, setOccupancyMetrics] = useState<{ connections: number; presenceMembers: number }>({
     connections: 0,
@@ -75,10 +75,10 @@ export const useOccupancy = (params?: UseOccupancyParams): UseOccupancyResponse 
     return wrapRoomPromise(
       context.room,
       (room) => {
-        logger.debug('useOccupancy(); applying onDiscontinuity listener', { roomId: context.roomId });
+        logger.debug('useOccupancy(); applying onDiscontinuity listener');
         const { off } = room.occupancy.onDiscontinuity(onDiscontinuityRef);
         return () => {
-          logger.debug('useOccupancy(); removing onDiscontinuity listener', { roomId: context.roomId });
+          logger.debug('useOccupancy(); removing onDiscontinuity listener');
           off();
         };
       },
@@ -92,7 +92,7 @@ export const useOccupancy = (params?: UseOccupancyParams): UseOccupancyResponse 
     return wrapRoomPromise(
       context.room,
       (room) => {
-        logger.debug('useOccupancy(); applying internal listener', { roomId: context.roomId });
+        logger.debug('useOccupancy(); applying internal listener');
         const { unsubscribe } = room.occupancy.subscribe((occupancyEvent) => {
           setOccupancyMetrics({
             connections: occupancyEvent.connections,
@@ -100,7 +100,7 @@ export const useOccupancy = (params?: UseOccupancyParams): UseOccupancyResponse 
           });
         });
         return () => {
-          logger.debug('useOccupancy(); cleaning up internal listener', { roomId: context.roomId });
+          logger.debug('useOccupancy(); cleaning up internal listener');
           unsubscribe();
         };
       },
@@ -115,10 +115,10 @@ export const useOccupancy = (params?: UseOccupancyParams): UseOccupancyResponse 
     return wrapRoomPromise(
       context.room,
       (room) => {
-        logger.debug('useOccupancy(); applying listener', { roomId: context.roomId });
+        logger.debug('useOccupancy(); applying listener');
         const { unsubscribe } = room.occupancy.subscribe(listenerRef);
         return () => {
-          logger.debug('useOccupancy(); cleaning up listener', { roomId: context.roomId });
+          logger.debug('useOccupancy(); cleaning up listener');
           unsubscribe();
         };
       },

--- a/src/react/hooks/use-room-reactions.ts
+++ b/src/react/hooks/use-room-reactions.ts
@@ -10,7 +10,7 @@ import { ChatStatusResponse } from '../types/chat-status-response.js';
 import { Listenable } from '../types/listenable.js';
 import { StatusParams } from '../types/status-params.js';
 import { useChatConnection } from './use-chat-connection.js';
-import { useLogger } from './use-logger.js';
+import { useRoomLogger } from './use-logger.js';
 
 /**
  * The parameters for the {@link useRoomReactions} hook.
@@ -51,8 +51,8 @@ export const useRoomReactions = (params?: UseRoomReactionsParams): UseRoomReacti
 
   const context = useRoomContext('useRoomReactions');
   const { status: roomStatus, error: roomError } = useRoomStatus(params);
-  const logger = useLogger();
-  logger.trace('useRoomReactions();', { params, roomId: context.roomId });
+  const logger = useRoomLogger();
+  logger.trace('useRoomReactions();', { params });
 
   // create stable references for the listeners
   const listenerRef = useEventListenerRef(params?.listener);
@@ -64,10 +64,10 @@ export const useRoomReactions = (params?: UseRoomReactionsParams): UseRoomReacti
     return wrapRoomPromise(
       context.room,
       (room) => {
-        logger.debug('useRoomReactions(); applying onDiscontinuity listener', { roomId: context.roomId });
+        logger.debug('useRoomReactions(); applying onDiscontinuity listener');
         const { off } = room.reactions.onDiscontinuity(onDiscontinuityRef);
         return () => {
-          logger.debug('useRoomReactions(); removing onDiscontinuity listener', { roomId: context.roomId });
+          logger.debug('useRoomReactions(); removing onDiscontinuity listener');
           off();
         };
       },
@@ -82,10 +82,10 @@ export const useRoomReactions = (params?: UseRoomReactionsParams): UseRoomReacti
     return wrapRoomPromise(
       context.room,
       (room) => {
-        logger.debug('useRoomReactions(); applying listener', { roomId: context.roomId });
+        logger.debug('useRoomReactions(); applying listener');
         const { unsubscribe } = room.reactions.subscribe(listenerRef);
         return () => {
-          logger.debug('useRoomReactions(); removing listener', { roomId: context.roomId });
+          logger.debug('useRoomReactions(); removing listener');
           unsubscribe();
         };
       },

--- a/src/react/hooks/use-room.ts
+++ b/src/react/hooks/use-room.ts
@@ -8,7 +8,7 @@ import { useRoomContext } from '../helper/use-room-context.js';
 import { useRoomStatus } from '../helper/use-room-status.js';
 import { ChatStatusResponse } from '../types/chat-status-response.js';
 import { useChatConnection } from './use-chat-connection.js';
-import { useLogger } from './use-logger.js';
+import { useRoomLogger } from './use-logger.js';
 
 /**
  * The parameters for the {@link useRoom} hook.
@@ -63,8 +63,8 @@ export interface UseRoomResponse extends ChatStatusResponse {
 export const useRoom = (params?: UseRoomParams): UseRoomResponse => {
   const context = useRoomContext('useRoom');
   const roomId = context.roomId;
-  const logger = useLogger();
-  logger.debug('useRoom();', { roomId: roomId });
+  const logger = useRoomLogger();
+  logger.debug('useRoom();');
 
   const { currentStatus: connectionStatus, error: connectionError } = useChatConnection({
     onStatusChange: params?.onConnectionStatusChange,

--- a/src/react/hooks/use-typing.ts
+++ b/src/react/hooks/use-typing.ts
@@ -13,7 +13,7 @@ import { ChatStatusResponse } from '../types/chat-status-response.js';
 import { Listenable } from '../types/listenable.js';
 import { StatusParams } from '../types/status-params.js';
 import { useChatConnection } from './use-chat-connection.js';
-import { useLogger } from './use-logger.js';
+import { useRoomLogger } from './use-logger.js';
 
 /**
  * The parameters for the {@link useTyping} hook.
@@ -71,8 +71,8 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
 
   const context = useRoomContext('useTyping');
   const { status: roomStatus, error: roomError } = useRoomStatus(params);
-  const logger = useLogger();
-  logger.trace('useTyping();', { roomId: context.roomId });
+  const logger = useRoomLogger();
+  logger.trace('useTyping();');
 
   const [currentlyTyping, setCurrentlyTyping] = useState<Set<string>>(new Set());
   const [error, setError] = useState<Ably.ErrorInfo | undefined>();
@@ -94,9 +94,9 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
 
     const setErrorState = (error?: Ably.ErrorInfo) => {
       if (error === undefined) {
-        logger.debug('useTyping(); clearing error state', { roomId: context.roomId });
+        logger.debug('useTyping(); clearing error state');
       } else {
-        logger.error('useTyping(); setting error state', { error, roomId: context.roomId });
+        logger.error('useTyping(); setting error state', { error });
       }
       setError(error);
     };
@@ -118,7 +118,7 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
               setErrorState(errorInfo);
             });
         } else {
-          logger.debug('useTyping(); room not attached, setting currentlyTyping to empty', { roomId: context.roomId });
+          logger.debug('useTyping(); room not attached, setting currentlyTyping to empty');
           setCurrentlyTyping(new Set());
         }
       })
@@ -127,14 +127,14 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
     return wrapRoomPromise(
       context.room,
       (room) => {
-        logger.debug('useTyping(); subscribing to typing events', { roomId: context.roomId });
+        logger.debug('useTyping(); subscribing to typing events');
         const { unsubscribe } = room.typing.subscribe((event) => {
           setErrorState(undefined);
           setCurrentlyTyping(event.currentlyTyping);
         });
 
         return () => {
-          logger.debug('useTyping(); unsubscribing from typing events', { roomId: context.roomId });
+          logger.debug('useTyping(); unsubscribing from typing events');
           mounted = false;
           unsubscribe();
         };
@@ -150,10 +150,10 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
     return wrapRoomPromise(
       context.room,
       (room) => {
-        logger.debug('useTyping(); applying onDiscontinuity listener', { roomId: context.roomId });
+        logger.debug('useTyping(); applying onDiscontinuity listener');
         const { off } = room.typing.onDiscontinuity(onDiscontinuityRef);
         return () => {
-          logger.debug('useTyping(); removing onDiscontinuity listener', { roomId: context.roomId });
+          logger.debug('useTyping(); removing onDiscontinuity listener');
           off();
         };
       },
@@ -168,10 +168,10 @@ export const useTyping = (params?: TypingParams): UseTypingResponse => {
     return wrapRoomPromise(
       context.room,
       (room) => {
-        logger.debug('useTyping(); applying listener', { roomId: context.roomId });
+        logger.debug('useTyping(); applying listener');
         const { unsubscribe } = room.typing.subscribe(listenerRef);
         return () => {
-          logger.debug('useTyping(); removing listener', { roomId: context.roomId });
+          logger.debug('useTyping(); removing listener');
           unsubscribe();
         };
       },

--- a/test/react/helper/use-eventual-room.test.tsx
+++ b/test/react/helper/use-eventual-room.test.tsx
@@ -17,7 +17,7 @@ vi.mock('../../../src/react/helper/use-room-context.js', () => ({
 }));
 
 vi.mock('../../../src/react/hooks/use-logger.js', () => ({
-  useLogger: () => mockLogger,
+  useRoomLogger: () => mockLogger,
 }));
 
 vi.mock('ably');

--- a/test/react/helper/use-room-status.test.tsx
+++ b/test/react/helper/use-room-status.test.tsx
@@ -20,7 +20,7 @@ vi.mock('../../../src/react/helper/use-room-context.js', () => ({
 }));
 
 vi.mock('../../../src/react/hooks/use-logger.js', () => ({
-  useLogger: () => mockLogger,
+  useRoomLogger: () => mockLogger,
 }));
 
 vi.mock('ably');

--- a/test/react/hooks/use-messages.test.tsx
+++ b/test/react/hooks/use-messages.test.tsx
@@ -40,7 +40,7 @@ vi.mock('../../../src/react/helper/use-room-status.js', () => ({
 }));
 
 vi.mock('../../../src/react/hooks/use-logger.js', () => ({
-  useLogger: () => testLogger,
+  useRoomLogger: () => testLogger,
 }));
 
 vi.mock('ably');

--- a/test/react/hooks/use-occupancy.test.tsx
+++ b/test/react/hooks/use-occupancy.test.tsx
@@ -29,7 +29,7 @@ vi.mock('../../../src/react/helper/use-room-status.js', () => ({
 }));
 
 vi.mock('../../../src/react/hooks/use-logger.js', () => ({
-  useLogger: () => mockLogger,
+  useRoomLogger: () => mockLogger,
 }));
 
 vi.mock('ably');

--- a/test/react/hooks/use-presence-listener.test.tsx
+++ b/test/react/hooks/use-presence-listener.test.tsx
@@ -41,7 +41,7 @@ vi.mock('../../../src/react/helper/use-room-status.js', () => ({
 }));
 
 vi.mock('../../../src/react/hooks/use-logger.js', () => ({
-  useLogger: () => mockLogger,
+  useRoomLogger: () => mockLogger,
 }));
 
 vi.mock('ably');

--- a/test/react/hooks/use-presence.test.tsx
+++ b/test/react/hooks/use-presence.test.tsx
@@ -36,7 +36,7 @@ vi.mock('../../../src/react/helper/use-room-status.js', () => ({
 }));
 
 vi.mock('../../../src/react/hooks/use-logger.js', () => ({
-  useLogger: () => mockLogger,
+  useRoomLogger: () => mockLogger,
 }));
 
 vi.mock('ably');

--- a/test/react/hooks/use-room-reactions.test.tsx
+++ b/test/react/hooks/use-room-reactions.test.tsx
@@ -33,7 +33,7 @@ vi.mock('../../../src/react/helper/use-room-status.js', () => ({
 }));
 
 vi.mock('../../../src/react/hooks/use-logger.js', () => ({
-  useLogger: () => mockLogger,
+  useRoomLogger: () => mockLogger,
 }));
 
 vi.mock('ably');

--- a/test/react/hooks/use-room.test.tsx
+++ b/test/react/hooks/use-room.test.tsx
@@ -163,6 +163,7 @@ describe('useRoom', () => {
       />,
     );
 
+    // On the first render, the room attach should have been called once by the second component
     expect(called1).toBe(1);
     expect(called2).toBe(1);
     await vi.waitFor(() => {
@@ -171,6 +172,8 @@ describe('useRoom', () => {
     expect(room.detach).toHaveBeenCalledTimes(0);
     expect(chatClient.rooms.release).toHaveBeenCalledTimes(0);
 
+    // On this rerender, the first component is unmounted, but the second remains mounted
+    // As the first component does not do attach or release, the room should not register any changes
     r.rerender(
       <TestProvider
         room1={false}
@@ -185,6 +188,8 @@ describe('useRoom', () => {
     expect(room.detach).toHaveBeenCalledTimes(0);
     expect(chatClient.rooms.release).toHaveBeenCalledTimes(0);
 
+    // We bring back component 1, and both components are mounted
+    // Again, because component 1 does not do attach or release, the room should not register any changes
     r.rerender(
       <TestProvider
         room1={true}
@@ -199,6 +204,8 @@ describe('useRoom', () => {
     expect(room.detach).toHaveBeenCalledTimes(0);
     expect(chatClient.rooms.release).toHaveBeenCalledTimes(0);
 
+    // We unmount component 1 again
+    // The room should not be released, as component 2 is still mounted
     r.rerender(
       <TestProvider
         room1={false}
@@ -213,6 +220,8 @@ describe('useRoom', () => {
     expect(room.detach).toHaveBeenCalledTimes(0);
     expect(chatClient.rooms.release).toHaveBeenCalledTimes(0);
 
+    // We unmount both components
+    // As component 2 does attach and release, the room should be released
     r.rerender(
       <TestProvider
         room1={false}

--- a/test/react/hooks/use-typing.test.tsx
+++ b/test/react/hooks/use-typing.test.tsx
@@ -31,7 +31,7 @@ vi.mock('../../../src/react/helper/use-room-status.js', () => ({
 }));
 
 vi.mock('../../../src/react/hooks/use-logger.js', () => ({
-  useLogger: () => mockLogger,
+  useRoomLogger: () => mockLogger,
 }));
 
 vi.mock('ably');


### PR DESCRIPTION
### Description

Right now, we have repetitive context parameters passed to log messages, e.g. roomId. Its easy to miss one out, and verbose.

This change introduces a `withContext` method in the Logger interface to create a logger instance with merged context.

The log calls in the context of a room now always include the roomId, and its nonce.

Also added a useRoomLogger hook to handle this in React.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

Run the demo app in various contexts and observe roomIds in the logs!