### PR TITLE
Occupancy events rename

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -52,7 +52,7 @@ const App: FC<AppProps> = () => {
       id={roomIdState}
       release={true}
       attach={true}
-      options={{ occupancy: { enableInboundOccupancy: true } }}
+      options={{ occupancy: { enableOccupancyEvents: true } }}
     >
       <div
         style={{ display: 'flex', justifyContent: 'space-between', width: '800px', margin: 'auto', height: '650px' }}

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -52,7 +52,7 @@ const App: FC<AppProps> = () => {
       id={roomIdState}
       release={true}
       attach={true}
-      options={{ occupancy: { enableOccupancyEvents: true } }}
+      options={{ occupancy: { enableEvents: true } }}
     >
       <div
         style={{ display: 'flex', justifyContent: 'space-between', width: '800px', margin: 'auto', height: '650px' }}

--- a/src/core/occupancy.ts
+++ b/src/core/occupancy.ts
@@ -18,7 +18,7 @@ export interface Occupancy {
   /**
    * Subscribe a given listener to occupancy updates of the chat room.
    *
-   * Note: This requires occupancy events to be enabled via the `enableOccupancyEvents` option in
+   * Note: This requires occupancy events to be enabled via the `enableEvents` option in
    * the room options. If this is not enabled, an error will be thrown.
    *
    * @param listener A listener to be called when the occupancy of the room changes.
@@ -118,7 +118,7 @@ export class DefaultOccupancy implements Occupancy {
   subscribe(listener: OccupancyListener): Subscription {
     this._logger.trace('Occupancy.subscribe();');
 
-    if (!this._roomOptions.occupancy.enableOccupancyEvents) {
+    if (!this._roomOptions.occupancy.enableEvents) {
       throw new Ably.ErrorInfo(
         'cannot subscribe to occupancy; occupancy events are not enabled in room options',
         40000,
@@ -225,7 +225,7 @@ export class DefaultOccupancy implements Occupancy {
   static channelOptionMerger(roomOptions: InternalRoomOptions): ChannelOptionsMerger {
     return (options) => {
       // Occupancy not required, so we can skip this.
-      if (!roomOptions.occupancy.enableOccupancyEvents) {
+      if (!roomOptions.occupancy.enableEvents) {
         return options;
       }
 

--- a/src/core/presence.ts
+++ b/src/core/presence.ts
@@ -139,7 +139,7 @@ export interface Presence {
    * Subscribe the given listener from the given list of events.
    *
    * Note that this method will throw an error if presence events are not enabled in the room options.
-   * Make sure to set `enablePresenceEvents: true` in your room options to use this feature.
+   * Make sure to set `enableEvents: true` in your room options to use this feature.
    *
    * @param eventOrEvents {'enter' | 'leave' | 'update' | 'present'} single event name or array of events to subscribe to
    * @param listener listener to subscribe
@@ -151,7 +151,7 @@ export interface Presence {
    * Subscribe the given listener to all presence events.
    *
    * Note that this method will throw an error if presence events are not enabled in the room options.
-   * Make sure to set `enablePresenceEvents: true` in your room options to use this feature.
+   * Make sure to set `enableEvents: true` in your room options to use this feature.
    *
    * @param listener listener to subscribe
    * @throws {@link Ably.ErrorInfo} with code 40000 if presence events are not enabled
@@ -269,7 +269,7 @@ export class DefaultPresence implements Presence {
    * Subscribe the given listener from the given list of events.
    *
    * Note that this method will throw an error if presence events are not enabled in the room options.
-   * Make sure to set `enablePresenceEvents: true` in your room options to use this feature.
+   * Make sure to set `enableEvents: true` in your room options to use this feature.
    *
    * @param eventOrEvents {'enter' | 'leave' | 'update' | 'present'} single event name or array of events to subscribe to
    * @param listener listener to subscribe
@@ -280,7 +280,7 @@ export class DefaultPresence implements Presence {
    * Subscribe the given listener to all presence events.
    *
    * Note that this method will throw an error if presence events are not enabled in the room options.
-   * Make sure to set `enablePresenceEvents: true` in your room options to use this feature.
+   * Make sure to set `enableEvents: true` in your room options to use this feature.
    *
    * @param listener listener to subscribe
    * @throws {@link Ably.ErrorInfo} with code 40000 if presence events are not enabled
@@ -293,7 +293,7 @@ export class DefaultPresence implements Presence {
     this._logger.trace('Presence.subscribe(); listenerOrEvents', { listenerOrEvents });
 
     // Check if presence events are enabled
-    if (!this._options.presence.enablePresenceEvents) {
+    if (!this._options.presence.enableEvents) {
       this._logger.error('could not subscribe to presence; presence events are not enabled');
       throw new Ably.ErrorInfo('could not subscribe to presence; presence events are not enabled', 40000, 400);
     }
@@ -369,7 +369,7 @@ export class DefaultPresence implements Presence {
   static channelOptionMerger(roomOptions: InternalRoomOptions): ChannelOptionsMerger {
     return (options) => {
       // User wants to receive presence events, so we don't need to do anything.
-      if (roomOptions.presence.enablePresenceEvents) {
+      if (roomOptions.presence.enableEvents) {
         return options;
       }
 

--- a/src/core/presence.ts
+++ b/src/core/presence.ts
@@ -143,7 +143,7 @@ export interface Presence {
    *
    * @param eventOrEvents {'enter' | 'leave' | 'update' | 'present'} single event name or array of events to subscribe to
    * @param listener listener to subscribe
-   * @throws {@link Ably.ErrorInfo} with code 40000 if presence events are not enabled
+   * @throws An {@link Ably.ErrorInfo} with code 40000 if presence events are not enabled
    */
   subscribe(eventOrEvents: PresenceEvents | PresenceEvents[], listener?: PresenceListener): Subscription;
 
@@ -154,7 +154,7 @@ export interface Presence {
    * Make sure to set `enableEvents: true` in your room options to use this feature.
    *
    * @param listener listener to subscribe
-   * @throws {@link Ably.ErrorInfo} with code 40000 if presence events are not enabled
+   * @throws An {@link Ably.ErrorInfo} with code 40000 if presence events are not enabled
    */
   subscribe(listener?: PresenceListener): Subscription;
 

--- a/src/core/room-options.ts
+++ b/src/core/room-options.ts
@@ -23,14 +23,14 @@ const DefaultRoomOptions: Omit<InternalRoomOptions, 'isReactClient'> = {
     /**
      * Whether to enable occupancy events.
      */
-    enableOccupancyEvents: false,
+    enableEvents: false,
   },
 
   /**
    * The default presence options for the room.
    */
   presence: {
-    enablePresenceEvents: true,
+    enableEvents: true,
   },
 };
 
@@ -62,7 +62,7 @@ export interface OccupancyOptions {
    *
    * @defaultValue false
    */
-  enableOccupancyEvents?: boolean;
+  enableEvents?: boolean;
 }
 
 /**
@@ -76,7 +76,7 @@ export interface PresenceOptions {
    *
    * @defaultValue true
    */
-  enablePresenceEvents?: boolean;
+  enableEvents?: boolean;
 }
 
 /**

--- a/src/core/room-options.ts
+++ b/src/core/room-options.ts
@@ -21,9 +21,9 @@ const DefaultRoomOptions: Omit<InternalRoomOptions, 'isReactClient'> = {
    */
   occupancy: {
     /**
-     * Whether to enable inbound occupancy events.
+     * Whether to enable occupancy events.
      */
-    enableInboundOccupancy: false,
+    enableOccupancyEvents: false,
   },
 
   /**
@@ -55,13 +55,14 @@ export interface TypingOptions {
  */
 export interface OccupancyOptions {
   /**
-   * Whether to enable inbound occupancy events.
+   * Whether to enable occupancy events.
    *
-   * Note that enabling this feature will increase the number of messages received by the client.
+   * Note that enabling this feature will increase the number of messages received by the client as additional
+   * messages will be sent by the server to indicate occupancy changes.
    *
    * @defaultValue false
    */
-  enableInboundOccupancy?: boolean;
+  enableOccupancyEvents?: boolean;
 }
 
 /**

--- a/src/core/room-options.ts
+++ b/src/core/room-options.ts
@@ -30,7 +30,7 @@ const DefaultRoomOptions: Omit<InternalRoomOptions, 'isReactClient'> = {
    * The default presence options for the room.
    */
   presence: {
-    receivePresenceEvents: true,
+    enablePresenceEvents: true,
   },
 };
 
@@ -76,7 +76,7 @@ export interface PresenceOptions {
    *
    * @defaultValue true
    */
-  receivePresenceEvents?: boolean;
+  enablePresenceEvents?: boolean;
 }
 
 /**

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -183,7 +183,7 @@ export class DefaultRoom implements Room {
 
     // Setup features
     this._messages = new DefaultMessages(roomId, channel, this._chatApi, realtime.auth.clientId, this._logger);
-    this._presence = new DefaultPresence(channel, realtime.auth.clientId, this._logger);
+    this._presence = new DefaultPresence(channel, realtime.auth.clientId, this._logger, options);
     this._typing = new DefaultTyping(roomId, options.typing, channel, realtime.auth.clientId, this._logger);
     this._reactions = new DefaultRoomReactions(roomId, channel, realtime.auth.clientId, this._logger);
     this._occupancy = new DefaultOccupancy(roomId, channel, this._chatApi, this._logger, options);

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -186,7 +186,7 @@ export class DefaultRoom implements Room {
     this._presence = new DefaultPresence(channel, realtime.auth.clientId, this._logger);
     this._typing = new DefaultTyping(roomId, options.typing, channel, realtime.auth.clientId, this._logger);
     this._reactions = new DefaultRoomReactions(roomId, channel, realtime.auth.clientId, this._logger);
-    this._occupancy = new DefaultOccupancy(roomId, channel, this._chatApi, this._logger);
+    this._occupancy = new DefaultOccupancy(roomId, channel, this._chatApi, this._logger, options);
 
     // Set the lifecycle manager last, so it becomes the last thing to find out about channel state changes
     // This is to allow Messages to reset subscription points before users get told of a discontinuity

--- a/test/core/occupancy.integration.test.ts
+++ b/test/core/occupancy.integration.test.ts
@@ -90,7 +90,7 @@ describe('occupancy', () => {
   it<TestContext>('allows subscriptions to inband occupancy', { timeout: TEST_TIMEOUT }, async (context) => {
     const { chat } = context;
 
-    const room = await getRandomRoom(chat, { occupancy: { enableInboundOccupancy: true } });
+    const room = await getRandomRoom(chat, { occupancy: { enableOccupancyEvents: true } });
 
     // Subscribe to occupancy
     const occupancyUpdates: OccupancyEvent[] = [];

--- a/test/core/occupancy.integration.test.ts
+++ b/test/core/occupancy.integration.test.ts
@@ -90,7 +90,7 @@ describe('occupancy', () => {
   it<TestContext>('allows subscriptions to inband occupancy', { timeout: TEST_TIMEOUT }, async (context) => {
     const { chat } = context;
 
-    const room = await getRandomRoom(chat, { occupancy: { enableOccupancyEvents: true } });
+    const room = await getRandomRoom(chat, { occupancy: { enableEvents: true } });
 
     // Subscribe to occupancy
     const occupancyUpdates: OccupancyEvent[] = [];

--- a/test/core/occupancy.test.ts
+++ b/test/core/occupancy.test.ts
@@ -27,7 +27,7 @@ describe('Occupancy', () => {
       realtime: context.realtime,
       options: {
         occupancy: {
-          enableOccupancyEvents: true,
+          enableEvents: true,
         },
       },
     });
@@ -35,13 +35,13 @@ describe('Occupancy', () => {
     context.emulateOccupancyUpdate = channelEventEmitter(channel);
   });
 
-  it<TestContext>('throws an error when subscribing with enableOccupancyEvents disabled', (context) => {
+  it<TestContext>('throws an error when subscribing with enableEvents disabled', (context) => {
     const room = makeRandomRoom({
       chatApi: context.chatApi,
       realtime: context.realtime,
       options: {
         occupancy: {
-          enableOccupancyEvents: false,
+          enableEvents: false,
         },
       },
     });
@@ -55,13 +55,13 @@ describe('Occupancy', () => {
 
   it<TestContext>('receives occupancy updates', (context) =>
     new Promise<void>((done, reject) => {
-      // Setup room with enableOccupancyEvents enabled
+      // Setup room with enableEvents enabled
       const room = makeRandomRoom({
         chatApi: context.chatApi,
         realtime: context.realtime,
         options: {
           occupancy: {
-            enableOccupancyEvents: true,
+            enableEvents: true,
           },
         },
       });

--- a/test/core/presence.test.ts
+++ b/test/core/presence.test.ts
@@ -36,6 +36,17 @@ describe('Presence', () => {
       });
     });
 
+    it<TestContext>('throws ErrorInfo if presence events are not enabled', (context) => {
+      const room = context.makeRoom({ presence: { enablePresenceEvents: false } });
+
+      expect(() => {
+        room.presence.subscribe(() => {});
+      }).toThrowErrorInfo({
+        message: 'could not subscribe to presence; presence events are not enabled',
+        code: 40000,
+      });
+    });
+
     it<TestContext>('should only unsubscribe the correct subscription', (context) => {
       const { room } = context;
       const received: PresenceEvent[] = [];
@@ -87,7 +98,7 @@ describe('Presence', () => {
   describe<TestContext>('room configuration', () => {
     it<TestContext>('removes the presence channel mode if room option disabled', (context) => {
       vi.spyOn(context.realtime.channels, 'get');
-      const room = context.makeRoom({ presence: { receivePresenceEvents: false } });
+      const room = context.makeRoom({ presence: { enablePresenceEvents: false } });
 
       // Check the channel was called as planned
       expect(context.realtime.channels.get).toHaveBeenCalledOnce();
@@ -102,7 +113,7 @@ describe('Presence', () => {
 
   it<TestContext>('does not remove mode if option enabled', (context) => {
     vi.spyOn(context.realtime.channels, 'get');
-    const room = context.makeRoom({ presence: { receivePresenceEvents: true } });
+    const room = context.makeRoom({ presence: { enablePresenceEvents: true } });
 
     // Check the channel was called as planned
     expect(context.realtime.channels.get).toHaveBeenCalledOnce();

--- a/test/core/presence.test.ts
+++ b/test/core/presence.test.ts
@@ -37,7 +37,7 @@ describe('Presence', () => {
     });
 
     it<TestContext>('throws ErrorInfo if presence events are not enabled', (context) => {
-      const room = context.makeRoom({ presence: { enablePresenceEvents: false } });
+      const room = context.makeRoom({ presence: { enableEvents: false } });
 
       expect(() => {
         room.presence.subscribe(() => {});
@@ -98,7 +98,7 @@ describe('Presence', () => {
   describe<TestContext>('room configuration', () => {
     it<TestContext>('removes the presence channel mode if room option disabled', (context) => {
       vi.spyOn(context.realtime.channels, 'get');
-      const room = context.makeRoom({ presence: { enablePresenceEvents: false } });
+      const room = context.makeRoom({ presence: { enableEvents: false } });
 
       // Check the channel was called as planned
       expect(context.realtime.channels.get).toHaveBeenCalledOnce();
@@ -113,7 +113,7 @@ describe('Presence', () => {
 
   it<TestContext>('does not remove mode if option enabled', (context) => {
     vi.spyOn(context.realtime.channels, 'get');
-    const room = context.makeRoom({ presence: { enablePresenceEvents: true } });
+    const room = context.makeRoom({ presence: { enableEvents: true } });
 
     // Check the channel was called as planned
     expect(context.realtime.channels.get).toHaveBeenCalledOnce();

--- a/test/core/room-options.test.ts
+++ b/test/core/room-options.test.ts
@@ -11,7 +11,7 @@ describe('normalizeRoomOptions', () => {
         heartbeatThrottleMs: 10000,
       },
       occupancy: {
-        enableInboundOccupancy: false,
+        enableOccupancyEvents: false,
       },
       presence: {
         receivePresenceEvents: true,
@@ -45,14 +45,14 @@ describe('normalizeRoomOptions', () => {
   it('should merge provided occupancy options with defaults', () => {
     const options: RoomOptions = {
       occupancy: {
-        enableInboundOccupancy: true,
+        enableOccupancyEvents: true,
       },
     };
 
     const result = normalizeRoomOptions(options, false);
 
     expect(result.occupancy).toEqual({
-      enableInboundOccupancy: true,
+      enableOccupancyEvents: true,
     });
   });
 
@@ -87,7 +87,7 @@ describe('normalizeRoomOptions', () => {
         heartbeatThrottleMs: 3000,
       },
       occupancy: {
-        enableInboundOccupancy: false, // Default preserved
+        enableOccupancyEvents: false, // Default preserved
       },
       presence: {
         receivePresenceEvents: false,

--- a/test/core/room-options.test.ts
+++ b/test/core/room-options.test.ts
@@ -11,10 +11,10 @@ describe('normalizeRoomOptions', () => {
         heartbeatThrottleMs: 10000,
       },
       occupancy: {
-        enableOccupancyEvents: false,
+        enableEvents: false,
       },
       presence: {
-        enablePresenceEvents: true,
+        enableEvents: true,
       },
       isReactClient: false,
     });
@@ -38,35 +38,35 @@ describe('normalizeRoomOptions', () => {
       heartbeatThrottleMs: 5000,
     });
     expect(result.presence).toEqual({
-      enablePresenceEvents: true,
+      enableEvents: true,
     });
   });
 
   it('should merge provided occupancy options with defaults', () => {
     const options: RoomOptions = {
       occupancy: {
-        enableOccupancyEvents: true,
+        enableEvents: true,
       },
     };
 
     const result = normalizeRoomOptions(options, false);
 
     expect(result.occupancy).toEqual({
-      enableOccupancyEvents: true,
+      enableEvents: true,
     });
   });
 
   it('should merge provided presence options with defaults', () => {
     const options: RoomOptions = {
       presence: {
-        enablePresenceEvents: false,
+        enableEvents: false,
       },
     };
 
     const result = normalizeRoomOptions(options, false);
 
     expect(result.presence).toEqual({
-      enablePresenceEvents: false,
+      enableEvents: false,
     });
   });
 
@@ -76,7 +76,7 @@ describe('normalizeRoomOptions', () => {
         heartbeatThrottleMs: 3000,
       },
       presence: {
-        enablePresenceEvents: false,
+        enableEvents: false,
       },
     };
 
@@ -87,10 +87,10 @@ describe('normalizeRoomOptions', () => {
         heartbeatThrottleMs: 3000,
       },
       occupancy: {
-        enableOccupancyEvents: false, // Default preserved
+        enableEvents: false, // Default preserved
       },
       presence: {
-        enablePresenceEvents: false,
+        enableEvents: false,
       },
       isReactClient: false,
     });

--- a/test/core/room-options.test.ts
+++ b/test/core/room-options.test.ts
@@ -14,7 +14,7 @@ describe('normalizeRoomOptions', () => {
         enableOccupancyEvents: false,
       },
       presence: {
-        receivePresenceEvents: true,
+        enablePresenceEvents: true,
       },
       isReactClient: false,
     });
@@ -38,7 +38,7 @@ describe('normalizeRoomOptions', () => {
       heartbeatThrottleMs: 5000,
     });
     expect(result.presence).toEqual({
-      receivePresenceEvents: true,
+      enablePresenceEvents: true,
     });
   });
 
@@ -59,14 +59,14 @@ describe('normalizeRoomOptions', () => {
   it('should merge provided presence options with defaults', () => {
     const options: RoomOptions = {
       presence: {
-        receivePresenceEvents: false,
+        enablePresenceEvents: false,
       },
     };
 
     const result = normalizeRoomOptions(options, false);
 
     expect(result.presence).toEqual({
-      receivePresenceEvents: false,
+      enablePresenceEvents: false,
     });
   });
 
@@ -76,7 +76,7 @@ describe('normalizeRoomOptions', () => {
         heartbeatThrottleMs: 3000,
       },
       presence: {
-        receivePresenceEvents: false,
+        enablePresenceEvents: false,
       },
     };
 
@@ -90,7 +90,7 @@ describe('normalizeRoomOptions', () => {
         enableOccupancyEvents: false, // Default preserved
       },
       presence: {
-        receivePresenceEvents: false,
+        enablePresenceEvents: false,
       },
       isReactClient: false,
     });

--- a/test/core/room.test.ts
+++ b/test/core/room.test.ts
@@ -82,7 +82,7 @@ describe('Room', () => {
       const room = context.getRoom(
         {
           occupancy: {
-            enableOccupancyEvents: true,
+            enableEvents: true,
           },
         },
         setReact,

--- a/test/core/room.test.ts
+++ b/test/core/room.test.ts
@@ -82,7 +82,7 @@ describe('Room', () => {
       const room = context.getRoom(
         {
           occupancy: {
-            enableInboundOccupancy: true,
+            enableOccupancyEvents: true,
           },
         },
         setReact,

--- a/test/react/hooks/use-occupancy.integration.test.tsx
+++ b/test/react/hooks/use-occupancy.integration.test.tsx
@@ -53,7 +53,7 @@ describe('useOccupancy', () => {
           id={roomId}
           options={{
             occupancy: {
-              enableInboundOccupancy: true,
+              enableOccupancyEvents: true,
             },
           }}
         >

--- a/test/react/hooks/use-occupancy.integration.test.tsx
+++ b/test/react/hooks/use-occupancy.integration.test.tsx
@@ -53,7 +53,7 @@ describe('useOccupancy', () => {
           id={roomId}
           options={{
             occupancy: {
-              enableOccupancyEvents: true,
+              enableEvents: true,
             },
           }}
         >

--- a/test/react/providers/room-provider.test.tsx
+++ b/test/react/providers/room-provider.test.tsx
@@ -46,7 +46,7 @@ describe('ChatRoomProvider', () => {
       expect(roomResolved).toBeTruthy();
     });
     await expect(() =>
-      chatClient.rooms.get(roomId, { occupancy: { enableOccupancyEvents: true } }),
+      chatClient.rooms.get(roomId, { occupancy: { enableEvents: true } }),
     ).rejects.toBeErrorInfoWithCode(40000);
 
     // Now try it with the right options, should be fine
@@ -77,7 +77,7 @@ describe('ChatRoomProvider', () => {
 
     // Try to get the client to get a room with different options, should fail
     await expect(() =>
-      chatClient.rooms.get(roomId, { occupancy: { enableOccupancyEvents: true } }),
+      chatClient.rooms.get(roomId, { occupancy: { enableEvents: true } }),
     ).rejects.toBeErrorInfoWithCode(40000);
 
     // Now try it with the right options, should be fine
@@ -132,7 +132,7 @@ describe('ChatRoomProvider', () => {
 
     // Try to get the client to get a room with different options, should fail
     await expect(() =>
-      chatClient.rooms.get(roomId, { occupancy: { enableOccupancyEvents: true } }),
+      chatClient.rooms.get(roomId, { occupancy: { enableEvents: true } }),
     ).rejects.toBeErrorInfoWithCode(40000);
   });
 
@@ -173,7 +173,7 @@ describe('ChatRoomProvider', () => {
 
     // Try to get the client to get a room with different options, should fail (since it should not be released)
     await expect(() =>
-      chatClient.rooms.get(roomId, { occupancy: { enableOccupancyEvents: true } }),
+      chatClient.rooms.get(roomId, { occupancy: { enableEvents: true } }),
     ).rejects.toBeErrorInfoWithCode(40000);
 
     await chatClient.rooms.release(roomId);

--- a/test/react/providers/room-provider.test.tsx
+++ b/test/react/providers/room-provider.test.tsx
@@ -46,7 +46,7 @@ describe('ChatRoomProvider', () => {
       expect(roomResolved).toBeTruthy();
     });
     await expect(() =>
-      chatClient.rooms.get(roomId, { occupancy: { enableInboundOccupancy: true } }),
+      chatClient.rooms.get(roomId, { occupancy: { enableOccupancyEvents: true } }),
     ).rejects.toBeErrorInfoWithCode(40000);
 
     // Now try it with the right options, should be fine
@@ -77,7 +77,7 @@ describe('ChatRoomProvider', () => {
 
     // Try to get the client to get a room with different options, should fail
     await expect(() =>
-      chatClient.rooms.get(roomId, { occupancy: { enableInboundOccupancy: true } }),
+      chatClient.rooms.get(roomId, { occupancy: { enableOccupancyEvents: true } }),
     ).rejects.toBeErrorInfoWithCode(40000);
 
     // Now try it with the right options, should be fine
@@ -132,7 +132,7 @@ describe('ChatRoomProvider', () => {
 
     // Try to get the client to get a room with different options, should fail
     await expect(() =>
-      chatClient.rooms.get(roomId, { occupancy: { enableInboundOccupancy: true } }),
+      chatClient.rooms.get(roomId, { occupancy: { enableOccupancyEvents: true } }),
     ).rejects.toBeErrorInfoWithCode(40000);
   });
 
@@ -173,7 +173,7 @@ describe('ChatRoomProvider', () => {
 
     // Try to get the client to get a room with different options, should fail (since it should not be released)
     await expect(() =>
-      chatClient.rooms.get(roomId, { occupancy: { enableInboundOccupancy: true } }),
+      chatClient.rooms.get(roomId, { occupancy: { enableOccupancyEvents: true } }),
     ).rejects.toBeErrorInfoWithCode(40000);
 
     await chatClient.rooms.release(roomId);


### PR DESCRIPTION
### Description

* Renames the RoomOption for occupancy to remove the deprecated word "inband"
* Renames the RoomOption for presence events to have the same naming convention
* Adds check to presence/occupancy subscription to throw an error if trying to subscribe whilst this is turned off.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).
