### PR TITLE
Typing: Refactor typing events to use `SetChanged` type.

### DIFF
--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -70,14 +70,9 @@ export enum PresenceEvents {
 }
 
 /**
- * All typing events.
+ * Enum representing the typing event types.
  */
-export enum TypingEvents {
-  /**
-   * Event triggered when a change occurs in the set of typers.
-   */
-  SetChanged = 'typing.set.changed',
-
+export enum TypingEventTypes {
   /**
    * Event triggered when a user is typing.
    */
@@ -90,13 +85,23 @@ export enum TypingEvents {
 }
 
 /**
+ * Enum representing the typing set event types.
+ */
+export enum TypingSetEventTypes {
+  /**
+   * Event triggered when a change occurs in the set of typers.
+   */
+  SetChanged = 'typing.set.changed',
+}
+
+/**
  * Represents a change in the state of current typers.
  */
-export interface TypingEvent {
+export interface TypingSetEvent {
   /**
    * The type of the event.
    */
-  type: TypingEvents;
+  type: TypingSetEventTypes;
 
   /**
    * The set of clientIds that are currently typing.
@@ -113,9 +118,9 @@ export interface TypingEvent {
     clientId: string;
 
     /**
-     * Type of the change. Either `typing.started` or `typing.stopped`.
+     * Type of the change.
      */
-    type: TypingEvents.Start | TypingEvents.Stop;
+    type: TypingEventTypes;
   };
 }
 

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -74,6 +74,11 @@ export enum PresenceEvents {
  */
 export enum TypingEvents {
   /**
+   * Event triggered when a change occurs in the set of typers.
+   */
+  SetChanged = 'typing.set.changed',
+
+  /**
    * Event triggered when a user is typing.
    */
   Start = 'typing.started',
@@ -88,6 +93,11 @@ export enum TypingEvents {
  * Represents a change in the state of current typers.
  */
 export interface TypingEvent {
+  /**
+   * The type of the event.
+   */
+  type: TypingEvents;
+
   /**
    * The set of clientIds that are currently typing.
    */
@@ -105,7 +115,7 @@ export interface TypingEvent {
     /**
      * Type of the change. Either `typing.started` or `typing.stopped`.
      */
-    type: TypingEvents;
+    type: TypingEvents.Start | TypingEvents.Stop;
   };
 }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -8,7 +8,7 @@ export type { Connection, ConnectionStatusChange, ConnectionStatusListener } fro
 export { ConnectionStatus } from './connection.js';
 export type { DiscontinuityListener } from './discontinuity.js';
 export { ErrorCodes, errorInfoIs } from './errors.js';
-export type { MessageEvent, TypingEvent, TypingEvents } from './events.js';
+export type { MessageEvent, TypingEventTypes, TypingSetEvent, TypingSetEventTypes } from './events.js';
 export { ChatMessageActions, MessageEvents, PresenceEvents } from './events.js';
 export type { Headers } from './headers.js';
 export type { LogContext, Logger, LogHandler } from './logger.js';

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -85,8 +85,7 @@ export type TypingListener = (event: TypingEvent) => void;
  * Represents the typing events mapped to their respective event payloads.
  */
 interface TypingEventsMap {
-  [TypingEvents.Start]: TypingEvent;
-  [TypingEvents.Stop]: TypingEvent;
+  [TypingEvents.SetChanged]: TypingEvent;
 }
 
 /**
@@ -353,7 +352,8 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
 
       // Remove client whose timeout has expired
       this._currentlyTyping.delete(clientId);
-      this.emit(TypingEvents.Stop, {
+      this.emit(TypingEvents.SetChanged, {
+        type: TypingEvents.SetChanged,
         currentlyTyping: new Set<string>(this._currentlyTyping.keys()),
         change: {
           clientId,
@@ -391,7 +391,8 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
         roomId: this._roomId,
         clientId,
       });
-      this.emit(TypingEvents.Start, {
+      this.emit(TypingEvents.SetChanged, {
+        type: TypingEvents.SetChanged,
         currentlyTyping: new Set<string>(this._currentlyTyping.keys()),
         change: {
           clientId,
@@ -422,7 +423,8 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
     clearTimeout(existingTimeout);
     this._currentlyTyping.delete(clientId);
     // Emit stop event only when the client is removed
-    this.emit(TypingEvents.Stop, {
+    this.emit(TypingEvents.SetChanged, {
+      type: TypingEvents.SetChanged,
       currentlyTyping: new Set<string>(this._currentlyTyping.keys()),
       change: {
         clientId,

--- a/src/react/hooks/use-typing.ts
+++ b/src/react/hooks/use-typing.ts
@@ -1,7 +1,7 @@
 import * as Ably from 'ably';
 import { useCallback, useEffect, useState } from 'react';
 
-import { TypingEvent } from '../../core/events.js';
+import { TypingSetEvent } from '../../core/events.js';
 import { RoomStatus } from '../../core/room-status.js';
 import { Typing, TypingListener } from '../../core/typing.js';
 import { wrapRoomPromise } from '../helper/room-promise.js';
@@ -42,7 +42,7 @@ export interface UseTypingResponse extends ChatStatusResponse {
    * A state value representing the set of client IDs that are currently typing in the room.
    * It automatically updates based on typing events received from the room.
    */
-  readonly currentlyTyping: TypingEvent['currentlyTyping'];
+  readonly currentlyTyping: TypingSetEvent['currentlyTyping'];
 
   /**
    * Provides access to the underlying {@link Typing} instance of the room.

--- a/test/core/messages.integration.test.ts
+++ b/test/core/messages.integration.test.ts
@@ -664,7 +664,7 @@ describe('messages integration', { timeout: 10000 }, () => {
     const { getPreviousMessages: getPreviousMessagesListener2 } = room.messages.subscribe(() => {});
 
     // Check we see the latest messages
-    await new Promise((resolve) => setTimeout(resolve, 3000)); // wait for persistence - this will not be necessary in the future
+    await new Promise((resolve) => setTimeout(resolve, 3000)); // TODO wait for persistence - this will not be necessary in the future
     const historyPreSubscription2 = await getPreviousMessagesListener2({ limit: 50 });
 
     // Should have the latest messages

--- a/test/core/typing.integration.test.ts
+++ b/test/core/typing.integration.test.ts
@@ -4,7 +4,7 @@ import { dequal } from 'dequal';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { normalizeClientOptions } from '../../src/core/config.ts';
-import { TypingEvent, TypingEvents } from '../../src/core/events.ts';
+import { TypingEventTypes, TypingSetEvent, TypingSetEventTypes } from '../../src/core/events.ts';
 import { Room } from '../../src/core/room.ts';
 import { DefaultRooms, Rooms } from '../../src/core/rooms.ts';
 import { waitForArrayLength } from '../helper/common.ts';
@@ -23,7 +23,7 @@ interface TestContext {
 }
 
 // Wait for a typing event matching the expected event to be received
-const waitForTypingEvent = async (events: TypingEvent[], expected: TypingEvent) => {
+const waitForTypingEvent = async (events: TypingSetEvent[], expected: TypingSetEvent) => {
   await vi.waitFor(
     () => {
       expect(events.some((event) => dequal(event, expected))).toBe(true);
@@ -47,7 +47,7 @@ describe('Typing', () => {
   it<TestContext>(
     'successfully starts typing and then stops after the default timeout',
     async (context) => {
-      const events: TypingEvent[] = [];
+      const events: TypingSetEvent[] = [];
       // Subscribe to typing events
       context.chatRoom.typing.subscribe((event) => {
         events.push(event);
@@ -69,7 +69,7 @@ describe('Typing', () => {
   it<TestContext>(
     'subscribes to all typing events, sent by keystroke and stop',
     async (context) => {
-      const events: TypingEvent[] = [];
+      const events: TypingSetEvent[] = [];
       context.chatRoom.typing.subscribe((event) => {
         events.push(event);
       });
@@ -93,7 +93,7 @@ describe('Typing', () => {
   it<TestContext>(
     'gets the set of currently typing client ids',
     async (context) => {
-      let events: TypingEvent[] = [];
+      let events: TypingSetEvent[] = [];
       // Subscribe to typing events
       context.chatRoom.typing.subscribe((event) => {
         events.push(event);
@@ -127,14 +127,14 @@ describe('Typing', () => {
       await client2Room.typing.keystroke();
       // Wait for the typing events to be received
       await waitForTypingEvent(events, {
-        type: TypingEvents.SetChanged,
+        type: TypingSetEventTypes.SetChanged,
         currentlyTyping: new Set([clientId1]),
-        change: { clientId: clientId1, type: TypingEvents.Start },
+        change: { clientId: clientId1, type: TypingEventTypes.Start },
       });
       await waitForTypingEvent(events, {
-        type: TypingEvents.SetChanged,
+        type: TypingSetEventTypes.SetChanged,
         currentlyTyping: new Set([clientId1, clientId2]),
-        change: { clientId: clientId2, type: TypingEvents.Start },
+        change: { clientId: clientId2, type: TypingEventTypes.Start },
       });
       // Get the currently typing client ids
       const currentlyTypingClientIds = context.chatRoom.typing.get();
@@ -147,9 +147,9 @@ describe('Typing', () => {
       await client1Room.typing.stop();
       // Wait for the typing events to be received
       await waitForTypingEvent(events, {
-        type: TypingEvents.SetChanged,
+        type: TypingSetEventTypes.SetChanged,
         currentlyTyping: new Set([clientId2]),
-        change: { clientId: clientId1, type: TypingEvents.Stop },
+        change: { clientId: clientId1, type: TypingEventTypes.Stop },
       });
       // Get the currently typing client ids
       const currentlyTypingClientIdsAfterStop = context.chatRoom.typing.get();

--- a/test/core/typing.integration.test.ts
+++ b/test/core/typing.integration.test.ts
@@ -127,10 +127,12 @@ describe('Typing', () => {
       await client2Room.typing.keystroke();
       // Wait for the typing events to be received
       await waitForTypingEvent(events, {
+        type: TypingEvents.SetChanged,
         currentlyTyping: new Set([clientId1]),
         change: { clientId: clientId1, type: TypingEvents.Start },
       });
       await waitForTypingEvent(events, {
+        type: TypingEvents.SetChanged,
         currentlyTyping: new Set([clientId1, clientId2]),
         change: { clientId: clientId2, type: TypingEvents.Start },
       });
@@ -145,6 +147,7 @@ describe('Typing', () => {
       await client1Room.typing.stop();
       // Wait for the typing events to be received
       await waitForTypingEvent(events, {
+        type: TypingEvents.SetChanged,
         currentlyTyping: new Set([clientId2]),
         change: { clientId: clientId1, type: TypingEvents.Stop },
       });

--- a/test/core/typing.test.ts
+++ b/test/core/typing.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
 
 import { ChatClient } from '../../src/core/chat.ts';
 import { ChatApi } from '../../src/core/chat-api.ts';
-import { TypingEvent, TypingEvents } from '../../src/core/events.ts';
+import { TypingEventTypes, TypingSetEvent, TypingSetEventTypes } from '../../src/core/events.ts';
 import { Logger } from '../../src/core/logger.ts';
 import { Room } from '../../src/core/room.ts';
 import { RoomOptions } from '../../src/core/room-options.ts';
@@ -26,14 +26,14 @@ interface TestContext {
 const TEST_HEARTBEAT_THROTTLE_MS = 200;
 
 const startMessage: Ably.Message = {
-  name: TypingEvents.Start,
+  name: TypingEventTypes.Start,
   extras: {
     ephemeral: true,
   },
 };
 
 const stopMessage: Ably.Message = {
-  name: TypingEvents.Stop,
+  name: TypingEventTypes.Stop,
   extras: {
     ephemeral: true,
   },
@@ -75,7 +75,7 @@ describe('Typing', () => {
 
     // Emulate a typing event
     context.emulateBackendPublish({
-      name: TypingEvents.Start,
+      name: TypingEventTypes.Start,
       clientId: 'some',
     });
 
@@ -277,20 +277,20 @@ describe('Typing', () => {
         const { room } = context;
 
         // Add a listener
-        const receivedEvents: TypingEvent[] = [];
-        const { unsubscribe } = room.typing.subscribe((event: TypingEvent) => {
+        const receivedEvents: TypingSetEvent[] = [];
+        const { unsubscribe } = room.typing.subscribe((event: TypingSetEvent) => {
           receivedEvents.push(event);
         });
 
         // Another listener used to receive all events, to make sure events were emitted
-        const allEvents: TypingEvent[] = [];
-        const allSubscription = room.typing.subscribe((event: TypingEvent) => {
+        const allEvents: TypingSetEvent[] = [];
+        const allSubscription = room.typing.subscribe((event: TypingSetEvent) => {
           allEvents.push(event);
         });
 
         // Emulate a typing event
         context.emulateBackendPublish({
-          name: TypingEvents.Start,
+          name: TypingEventTypes.Start,
           clientId: 'otherClient',
         });
 
@@ -299,10 +299,10 @@ describe('Typing', () => {
         // Ensure that the listener received the event
         expect(receivedEvents).toHaveLength(1);
         expect(receivedEvents[0]).toEqual({
-          type: TypingEvents.SetChanged,
+          type: TypingSetEventTypes.SetChanged,
           change: {
             clientId: 'otherClient',
-            type: TypingEvents.Start,
+            type: TypingEventTypes.Start,
           },
           currentlyTyping: new Set(['otherClient']),
         });
@@ -312,7 +312,7 @@ describe('Typing', () => {
 
         // Emulate another typing event for anotherClient
         context.emulateBackendPublish({
-          name: TypingEvents.Start,
+          name: TypingEventTypes.Start,
           clientId: 'anotherClient',
         });
 
@@ -335,20 +335,20 @@ describe('Typing', () => {
         const { room } = context;
 
         // Add a listener
-        const receivedEvents: TypingEvent[] = [];
-        const { unsubscribe } = room.typing.subscribe((event: TypingEvent) => {
+        const receivedEvents: TypingSetEvent[] = [];
+        const { unsubscribe } = room.typing.subscribe((event: TypingSetEvent) => {
           receivedEvents.push(event);
         });
 
         // Add another
-        const receivedEvents2: TypingEvent[] = [];
-        const { unsubscribe: unsubscribe2 } = room.typing.subscribe((event: TypingEvent) => {
+        const receivedEvents2: TypingSetEvent[] = [];
+        const { unsubscribe: unsubscribe2 } = room.typing.subscribe((event: TypingSetEvent) => {
           receivedEvents2.push(event);
         });
 
         // Emulate a typing event
         context.emulateBackendPublish({
-          name: TypingEvents.Start,
+          name: TypingEventTypes.Start,
           clientId: 'otherClient',
         });
 
@@ -357,10 +357,10 @@ describe('Typing', () => {
         // Ensure that the listener received the event
         expect(receivedEvents).toHaveLength(1);
         expect(receivedEvents[0]).toEqual({
-          type: TypingEvents.SetChanged,
+          type: TypingSetEventTypes.SetChanged,
           change: {
             clientId: 'otherClient',
-            type: TypingEvents.Start,
+            type: TypingEventTypes.Start,
           },
           currentlyTyping: new Set(['otherClient']),
         });
@@ -369,10 +369,10 @@ describe('Typing', () => {
         // Ensure that the second listener received the event
         expect(receivedEvents2).toHaveLength(1);
         expect(receivedEvents2[0]).toEqual({
-          type: TypingEvents.SetChanged,
+          type: TypingSetEventTypes.SetChanged,
           change: {
             clientId: 'otherClient',
-            type: TypingEvents.Start,
+            type: TypingEventTypes.Start,
           },
           currentlyTyping: new Set(['otherClient']),
         });
@@ -381,14 +381,14 @@ describe('Typing', () => {
         room.typing.unsubscribeAll();
 
         // subscribe a check subscriber
-        const checkEvents: TypingEvent[] = [];
+        const checkEvents: TypingSetEvent[] = [];
         room.typing.subscribe((event) => {
           checkEvents.push(event);
         });
 
         // Emulate another typing event
         context.emulateBackendPublish({
-          name: TypingEvents.Start,
+          name: TypingEventTypes.Start,
           clientId: 'anotherClient2',
         });
 
@@ -409,7 +409,7 @@ describe('Typing', () => {
         [
           'no client id',
           {
-            name: TypingEvents.Start,
+            name: TypingEventTypes.Start,
             connectionId: '',
             id: '',
             encoding: '',
@@ -421,7 +421,7 @@ describe('Typing', () => {
         [
           'empty client id',
           {
-            name: TypingEvents.Start,
+            name: TypingEventTypes.Start,
             clientId: '',
             connectionId: '',
             id: '',
@@ -449,8 +449,8 @@ describe('Typing', () => {
           const { room } = context;
 
           // Subscribe to typing events
-          const receivedEvents: TypingEvent[] = [];
-          room.typing.subscribe((event: TypingEvent) => {
+          const receivedEvents: TypingSetEvent[] = [];
+          room.typing.subscribe((event: TypingSetEvent) => {
             receivedEvents.push(event);
           });
 
@@ -469,14 +469,14 @@ describe('Typing', () => {
         const { room } = context;
 
         // Subscribe to typing events
-        const receivedEvents: TypingEvent[] = [];
-        room.typing.subscribe((event: TypingEvent) => {
+        const receivedEvents: TypingSetEvent[] = [];
+        room.typing.subscribe((event: TypingSetEvent) => {
           receivedEvents.push(event);
         });
 
         // Emulate a typing event
         context.emulateBackendPublish({
-          name: TypingEvents.Start,
+          name: TypingEventTypes.Start,
           clientId: 'otherClient',
         });
 
@@ -484,10 +484,10 @@ describe('Typing', () => {
         await waitForArrayLength(receivedEvents, 1);
         expect(receivedEvents).toHaveLength(1);
         expect(receivedEvents[0]).toEqual({
-          type: TypingEvents.SetChanged,
+          type: TypingSetEventTypes.SetChanged,
           change: {
             clientId: 'otherClient',
-            type: TypingEvents.Start,
+            type: TypingEventTypes.Start,
           },
           currentlyTyping: new Set(['otherClient']),
         });
@@ -506,14 +506,14 @@ describe('Typing', () => {
         const { room } = context;
 
         // Subscribe to typing events
-        const receivedEvents: TypingEvent[] = [];
-        room.typing.subscribe((event: TypingEvent) => {
+        const receivedEvents: TypingSetEvent[] = [];
+        room.typing.subscribe((event: TypingSetEvent) => {
           receivedEvents.push(event);
         });
 
         // Emulate a typing event
         context.emulateBackendPublish({
-          name: TypingEvents.Start,
+          name: TypingEventTypes.Start,
           clientId: 'otherClient',
         });
 
@@ -521,10 +521,10 @@ describe('Typing', () => {
         await waitForArrayLength(receivedEvents, 1);
         expect(receivedEvents).toHaveLength(1);
         expect(receivedEvents[0]).toEqual({
-          type: TypingEvents.SetChanged,
+          type: TypingSetEventTypes.SetChanged,
           change: {
             clientId: 'otherClient',
-            type: TypingEvents.Start,
+            type: TypingEventTypes.Start,
           },
           currentlyTyping: new Set(['otherClient']),
         });
@@ -536,7 +536,7 @@ describe('Typing', () => {
 
         // Now send another typing event
         context.emulateBackendPublish({
-          name: TypingEvents.Start,
+          name: TypingEventTypes.Start,
           clientId: 'otherClient',
         });
 
@@ -556,14 +556,14 @@ describe('Typing', () => {
         const { room } = context;
 
         // Subscribe to typing events
-        const receivedEvents: TypingEvent[] = [];
-        room.typing.subscribe((event: TypingEvent) => {
+        const receivedEvents: TypingSetEvent[] = [];
+        room.typing.subscribe((event: TypingSetEvent) => {
           receivedEvents.push(event);
         });
 
         // Emulate a typing event
         context.emulateBackendPublish({
-          name: TypingEvents.Start,
+          name: TypingEventTypes.Start,
           clientId: 'otherClient',
         });
 
@@ -571,10 +571,10 @@ describe('Typing', () => {
         await waitForArrayLength(receivedEvents, 1);
         expect(receivedEvents).toHaveLength(1);
         expect(receivedEvents[0]).toEqual({
-          type: TypingEvents.SetChanged,
+          type: TypingSetEventTypes.SetChanged,
           change: {
             clientId: 'otherClient',
-            type: TypingEvents.Start,
+            type: TypingEventTypes.Start,
           },
           currentlyTyping: new Set(['otherClient']),
         });
@@ -591,10 +591,10 @@ describe('Typing', () => {
         await waitForArrayLength(receivedEvents, 2);
         expect(receivedEvents).toHaveLength(2);
         expect(receivedEvents[1]).toEqual({
-          type: TypingEvents.SetChanged,
+          type: TypingSetEventTypes.SetChanged,
           change: {
             clientId: 'otherClient',
-            type: TypingEvents.Stop,
+            type: TypingEventTypes.Stop,
           },
           currentlyTyping: new Set(),
         });
@@ -605,14 +605,14 @@ describe('Typing', () => {
         const { room } = context;
 
         // Subscribe to typing events
-        const receivedEvents: TypingEvent[] = [];
-        room.typing.subscribe((event: TypingEvent) => {
+        const receivedEvents: TypingSetEvent[] = [];
+        room.typing.subscribe((event: TypingSetEvent) => {
           receivedEvents.push(event);
         });
 
         // Emulate a typing event
         context.emulateBackendPublish({
-          name: TypingEvents.Start,
+          name: TypingEventTypes.Start,
           clientId: 'otherClient',
         });
 
@@ -620,10 +620,10 @@ describe('Typing', () => {
         await waitForArrayLength(receivedEvents, 1);
         expect(receivedEvents).toHaveLength(1);
         expect(receivedEvents[0]).toEqual({
-          type: TypingEvents.SetChanged,
+          type: TypingSetEventTypes.SetChanged,
           change: {
             clientId: 'otherClient',
-            type: TypingEvents.Start,
+            type: TypingEventTypes.Start,
           },
           currentlyTyping: new Set(['otherClient']),
         });
@@ -635,7 +635,7 @@ describe('Typing', () => {
 
         // Emulate a typing stop event
         context.emulateBackendPublish({
-          name: TypingEvents.Stop,
+          name: TypingEventTypes.Stop,
           clientId: 'otherClient',
         });
 
@@ -643,10 +643,10 @@ describe('Typing', () => {
         await waitForArrayLength(receivedEvents, 2);
         expect(receivedEvents).toHaveLength(2);
         expect(receivedEvents[1]).toEqual({
-          type: TypingEvents.SetChanged,
+          type: TypingSetEventTypes.SetChanged,
           change: {
             clientId: 'otherClient',
-            type: TypingEvents.Stop,
+            type: TypingEventTypes.Stop,
           },
           currentlyTyping: new Set(),
         });
@@ -660,14 +660,14 @@ describe('Typing', () => {
         const { room } = context;
 
         // Subscribe to typing events
-        const receivedEvents: TypingEvent[] = [];
-        room.typing.subscribe((event: TypingEvent) => {
+        const receivedEvents: TypingSetEvent[] = [];
+        room.typing.subscribe((event: TypingSetEvent) => {
           receivedEvents.push(event);
         });
 
         // Emulate a typing stop event
         context.emulateBackendPublish({
-          name: TypingEvents.Stop,
+          name: TypingEventTypes.Stop,
           clientId: 'otherClient',
         });
 
@@ -677,16 +677,16 @@ describe('Typing', () => {
 
       it<TestContext>('should only unsubscribe the correct subscription', async (context) => {
         const { room } = context;
-        const received: TypingEvent[] = [];
+        const received: TypingSetEvent[] = [];
 
-        const emulateTypingEvent = (clientId: string, event: TypingEvents) => {
+        const emulateTypingEvent = (clientId: string, event: TypingEventTypes) => {
           context.emulateBackendPublish({
             name: event,
             clientId: clientId,
           });
         };
 
-        const listener = (event: TypingEvent) => {
+        const listener = (event: TypingSetEvent) => {
           received.push(event);
         };
 
@@ -695,15 +695,15 @@ describe('Typing', () => {
         const subscription2 = room.typing.subscribe(listener);
 
         // Both subscriptions should trigger the listener
-        emulateTypingEvent('user1', TypingEvents.Start);
+        emulateTypingEvent('user1', TypingEventTypes.Start);
         await waitForArrayLength(received, 2);
 
         // Unsubscribe first subscription
         subscription1.unsubscribe();
 
         // One subscription should still trigger the listener
-        emulateTypingEvent('user2', TypingEvents.Start);
-        emulateTypingEvent('user2', TypingEvents.Start);
+        emulateTypingEvent('user2', TypingEventTypes.Start);
+        emulateTypingEvent('user2', TypingEventTypes.Start);
         await waitForArrayLength(received, 3);
 
         // Unsubscribe second subscription

--- a/test/core/typing.test.ts
+++ b/test/core/typing.test.ts
@@ -299,6 +299,7 @@ describe('Typing', () => {
         // Ensure that the listener received the event
         expect(receivedEvents).toHaveLength(1);
         expect(receivedEvents[0]).toEqual({
+          type: TypingEvents.SetChanged,
           change: {
             clientId: 'otherClient',
             type: TypingEvents.Start,
@@ -356,6 +357,7 @@ describe('Typing', () => {
         // Ensure that the listener received the event
         expect(receivedEvents).toHaveLength(1);
         expect(receivedEvents[0]).toEqual({
+          type: TypingEvents.SetChanged,
           change: {
             clientId: 'otherClient',
             type: TypingEvents.Start,
@@ -367,6 +369,7 @@ describe('Typing', () => {
         // Ensure that the second listener received the event
         expect(receivedEvents2).toHaveLength(1);
         expect(receivedEvents2[0]).toEqual({
+          type: TypingEvents.SetChanged,
           change: {
             clientId: 'otherClient',
             type: TypingEvents.Start,
@@ -481,6 +484,7 @@ describe('Typing', () => {
         await waitForArrayLength(receivedEvents, 1);
         expect(receivedEvents).toHaveLength(1);
         expect(receivedEvents[0]).toEqual({
+          type: TypingEvents.SetChanged,
           change: {
             clientId: 'otherClient',
             type: TypingEvents.Start,
@@ -517,6 +521,7 @@ describe('Typing', () => {
         await waitForArrayLength(receivedEvents, 1);
         expect(receivedEvents).toHaveLength(1);
         expect(receivedEvents[0]).toEqual({
+          type: TypingEvents.SetChanged,
           change: {
             clientId: 'otherClient',
             type: TypingEvents.Start,
@@ -566,6 +571,7 @@ describe('Typing', () => {
         await waitForArrayLength(receivedEvents, 1);
         expect(receivedEvents).toHaveLength(1);
         expect(receivedEvents[0]).toEqual({
+          type: TypingEvents.SetChanged,
           change: {
             clientId: 'otherClient',
             type: TypingEvents.Start,
@@ -585,6 +591,7 @@ describe('Typing', () => {
         await waitForArrayLength(receivedEvents, 2);
         expect(receivedEvents).toHaveLength(2);
         expect(receivedEvents[1]).toEqual({
+          type: TypingEvents.SetChanged,
           change: {
             clientId: 'otherClient',
             type: TypingEvents.Stop,
@@ -613,6 +620,7 @@ describe('Typing', () => {
         await waitForArrayLength(receivedEvents, 1);
         expect(receivedEvents).toHaveLength(1);
         expect(receivedEvents[0]).toEqual({
+          type: TypingEvents.SetChanged,
           change: {
             clientId: 'otherClient',
             type: TypingEvents.Start,
@@ -635,6 +643,7 @@ describe('Typing', () => {
         await waitForArrayLength(receivedEvents, 2);
         expect(receivedEvents).toHaveLength(2);
         expect(receivedEvents[1]).toEqual({
+          type: TypingEvents.SetChanged,
           change: {
             clientId: 'otherClient',
             type: TypingEvents.Stop,

--- a/test/react/hooks/use-typing.integration.test.tsx
+++ b/test/react/hooks/use-typing.integration.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render, waitFor } from '@testing-library/react';
 import React, { useEffect } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { TypingEvent } from '../../../src/core/events.ts';
+import { TypingSetEvent } from '../../../src/core/events.ts';
 import { RoomStatus } from '../../../src/core/room-status.ts';
 import { TypingListener } from '../../../src/core/typing.ts';
 import { useTyping } from '../../../src/react/hooks/use-typing.ts';
@@ -28,7 +28,7 @@ describe('useTyping', () => {
     await roomTwo.attach();
 
     // start listening for typing events on room two
-    const typingEventsRoomTwo: TypingEvent[] = [];
+    const typingEventsRoomTwo: TypingSetEvent[] = [];
     roomTwo.typing.subscribe((typingEvent) => typingEventsRoomTwo.push(typingEvent));
 
     const TestComponent = () => {
@@ -72,7 +72,7 @@ describe('useTyping', () => {
     await roomTwo.attach();
 
     // store the received typing events for room one
-    const typingEventsRoomOne: TypingEvent[] = [];
+    const typingEventsRoomOne: TypingSetEvent[] = [];
 
     // store the currently typing state from the hook
     let currentlyTypingSet = new Set<string>();

--- a/test/react/hooks/use-typing.test.tsx
+++ b/test/react/hooks/use-typing.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ConnectionStatus } from '../../../src/core/connection.ts';
 import { DiscontinuityListener } from '../../../src/core/discontinuity.ts';
-import { TypingEvent, TypingEvents } from '../../../src/core/events.ts';
+import { TypingEventTypes, TypingSetEvent, TypingSetEventTypes } from '../../../src/core/events.ts';
 import { Logger } from '../../../src/core/logger.ts';
 import { Room } from '../../../src/core/room.ts';
 import { DefaultRoomLifecycle, InternalRoomLifecycle, RoomStatus } from '../../../src/core/room-status.ts';
@@ -91,9 +91,9 @@ describe('useTyping', () => {
     await waitForEventualHookValueToBeDefined(result, (value) => value.typingIndicators);
 
     // verify that subscribe was called with the mock listener on mount by triggering an event
-    const typingEvent: TypingEvent = {
-      type: TypingEvents.SetChanged,
-      change: { clientId: 'someClientId', type: TypingEvents.Stop },
+    const typingEvent: TypingSetEvent = {
+      type: TypingSetEventTypes.SetChanged,
+      change: { clientId: 'someClientId', type: TypingEventTypes.Stop },
       currentlyTyping: new Set<string>(),
     };
     for (const listener of mockTyping.listeners) {
@@ -169,8 +169,8 @@ describe('useTyping', () => {
     act(() => {
       if (subscribedListener) {
         subscribedListener({
-          type: TypingEvents.SetChanged,
-          change: { clientId: 'user2', type: TypingEvents.Start },
+          type: TypingSetEventTypes.SetChanged,
+          change: { clientId: 'user2', type: TypingEventTypes.Start },
           currentlyTyping: testSet,
         });
       }

--- a/test/react/hooks/use-typing.test.tsx
+++ b/test/react/hooks/use-typing.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ConnectionStatus } from '../../../src/core/connection.ts';
 import { DiscontinuityListener } from '../../../src/core/discontinuity.ts';
-import { TypingEvents } from '../../../src/core/events.ts';
+import { TypingEvent, TypingEvents } from '../../../src/core/events.ts';
 import { Logger } from '../../../src/core/logger.ts';
 import { Room } from '../../../src/core/room.ts';
 import { DefaultRoomLifecycle, InternalRoomLifecycle, RoomStatus } from '../../../src/core/room-status.ts';
@@ -91,7 +91,8 @@ describe('useTyping', () => {
     await waitForEventualHookValueToBeDefined(result, (value) => value.typingIndicators);
 
     // verify that subscribe was called with the mock listener on mount by triggering an event
-    const typingEvent = {
+    const typingEvent: TypingEvent = {
+      type: TypingEvents.SetChanged,
       change: { clientId: 'someClientId', type: TypingEvents.Stop },
       currentlyTyping: new Set<string>(),
     };
@@ -167,7 +168,11 @@ describe('useTyping', () => {
     // emit a typing event which should update the DOM
     act(() => {
       if (subscribedListener) {
-        subscribedListener({ change: { clientId: 'user2', type: TypingEvents.Start }, currentlyTyping: testSet });
+        subscribedListener({
+          type: TypingEvents.SetChanged,
+          change: { clientId: 'user2', type: TypingEvents.Start },
+          currentlyTyping: testSet,
+        });
       }
     });
 


### PR DESCRIPTION
### Context

To provide better consistency with other events in Chat, the typing event payload now contains a `type` field at the root level. This also means `TypingEvents.Start` and `TypingEvents.Stop` have been replaced with `TypingEvents.SetChanged` for event emission.


### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).
