### PR TITLE
Bugfix: empty summaries were dropped as invalid but in fact they are valid and mean there are no reactions (annotations)

### DIFF
--- a/src/core/messages-reactions.ts
+++ b/src/core/messages-reactions.ts
@@ -207,7 +207,9 @@ export class DefaultMessageReactions implements MessagesReactions {
       return;
     }
     if (!event.summary) {
-      return;
+      // This means the summary is now empty, which is valid.
+      // Happens when there are no reactions such as after deleting the last reaction.
+      event.summary = {};
     }
 
     // they must have a serial

--- a/test/core/messages-reactions.integration.test.ts
+++ b/test/core/messages-reactions.integration.test.ts
@@ -104,6 +104,12 @@ describe('message reactions integration', { timeout: 60000 }, () => {
       found.push(event);
     });
 
+    // wait 1s
+    // todo: reminder to remove this when no longer needed
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1000);
+    });
+
     await room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '👍' });
     await room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '👍', count: 10 });
     await room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '❤️', count: 3 });

--- a/test/core/messages-reactions.test.ts
+++ b/test/core/messages-reactions.test.ts
@@ -140,6 +140,8 @@ describe('MessagesReactions', () => {
             messageSerial: '01672531200002-123@xyzdefghij',
             multiple: { '🍌': { clientIds: { user1: 10 }, total: 10 } },
           },
+          { messageSerial: '01672531200002-123@xyzdefghij' },
+          { messageSerial: '01672531200002-123@xyzdefghij' },
         ];
 
         let nextExpected = 0;
@@ -196,6 +198,23 @@ describe('MessagesReactions', () => {
           summary: {
             [MessageReactionType.Multiple]: { '🍌': { clientIds: { user1: 10 }, total: 10, totalUnidentified: 0 } },
           },
+        });
+
+        context.emulateBackendPublish({
+          name: 'chat.message',
+          serial: '01672531200002-123@xyzdefghij',
+          version: '01672531200002-123@abcdefghij',
+          action: ChatMessageActions.MessageAnnotationSummary,
+          timestamp: publishTimestamp,
+          summary: {},
+        });
+
+        context.emulateBackendPublish({
+          name: 'chat.message',
+          serial: '01672531200002-123@xyzdefghij',
+          version: '01672531200002-123@abcdefghij',
+          action: ChatMessageActions.MessageAnnotationSummary,
+          timestamp: publishTimestamp,
         });
       }));
 


### PR DESCRIPTION
This happens when deleting the last reaction of a message.
