### PR TITLE
Rename reaction to name

### DIFF
--- a/demo/src/components/MessageReactions/MessageReactionsDistinct.tsx
+++ b/demo/src/components/MessageReactions/MessageReactionsDistinct.tsx
@@ -18,34 +18,32 @@ export const MessageReactionsDistinct: React.FC<MessageReactionsDistinctProps> =
 }) => {
   const distinct = message.reactions.distinct ?? {};
 
-  const handleReactionClick = (emoji: string) => {
-    if (distinct[emoji]?.clientIds.includes(clientId)) {
-      onReactionRemove(message, { type: MessageReactionType.Distinct, reaction: emoji });
+  const handleReactionClick = (name: string) => {
+    if (distinct[name]?.clientIds.includes(clientId)) {
+      onReactionRemove(message, { type: MessageReactionType.Distinct, name: name });
     } else {
-      onReactionAdd(message, { type: MessageReactionType.Distinct, reaction: emoji });
+      onReactionAdd(message, { type: MessageReactionType.Distinct, name: name });
     }
   };
 
   const currentEmojis = emojis.slice();
-  if (distinct) {
-    for (const emoji in distinct) {
-      if (!currentEmojis.includes(emoji)) {
-        currentEmojis.push(emoji);
-      }
+  for (const emoji in distinct) {
+    if (!currentEmojis.includes(emoji)) {
+      currentEmojis.push(emoji);
     }
   }
 
   return (
     <>
-      {currentEmojis.map((emoji) => (
+      {currentEmojis.map((name) => (
         <button
-          key={emoji}
+          key={name}
           onClick={(e) => {
             e.preventDefault();
-            handleReactionClick(emoji);
+            handleReactionClick(name);
           }}
         >
-          {emoji} ({distinct[emoji]?.total || 0})
+          {name} ({distinct[name]?.total || 0})
         </button>
       ))}
     </>

--- a/demo/src/components/MessageReactions/MessageReactionsMultiple.tsx
+++ b/demo/src/components/MessageReactions/MessageReactionsMultiple.tsx
@@ -14,12 +14,12 @@ export const MessageReactionsMultiple: React.FC<MessageReactionsMultipleProps> =
   onReactionAdd,
   onReactionDelete: onReactionRemove,
 }) => {
-  const handleReactionClick = (emoji: string) => {
-    onReactionAdd(message, { type: MessageReactionType.Multiple, reaction: emoji });
+  const handleReactionClick = (name: string) => {
+    onReactionAdd(message, { type: MessageReactionType.Multiple, name: name });
   };
 
-  const handleReactionRemoveClick = (emoji: string) => {
-    onReactionRemove(message, { type: MessageReactionType.Multiple, reaction: emoji });
+  const handleReactionRemoveClick = (name: string) => {
+    onReactionRemove(message, { type: MessageReactionType.Multiple, name: name });
   };
 
   const multiple = message.reactions.multiple ?? {};
@@ -33,23 +33,23 @@ export const MessageReactionsMultiple: React.FC<MessageReactionsMultipleProps> =
 
   return (
     <>
-      {currentEmojis.map((emoji) => (
+      {currentEmojis.map((name) => (
         <button
-          key={emoji}
+          key={name}
           onClick={(e) => {
             e.preventDefault();
             if (e.type === 'contextmenu') {
-              handleReactionRemoveClick(emoji);
+              handleReactionRemoveClick(name);
             } else {
-              handleReactionClick(emoji);
+              handleReactionClick(name);
             }
           }}
           onContextMenu={(e) => {
             e.preventDefault();
-            handleReactionRemoveClick(emoji);
+            handleReactionRemoveClick(name);
           }}
         >
-          {emoji} ({multiple[emoji]?.total || 0})
+          {name} ({multiple[name]?.total || 0})
         </button>
       ))}
     </>

--- a/demo/src/components/MessageReactions/MessageReactionsUnique.tsx
+++ b/demo/src/components/MessageReactions/MessageReactionsUnique.tsx
@@ -18,11 +18,11 @@ export const MessageReactionsUnique: React.FC<MessageReactionsUniqueProps> = ({
 }) => {
   const unique = message.reactions.unique ?? {};
 
-  const handleReactionClick = (emoji: string) => {
-    if (unique[emoji]?.clientIds.includes(clientId)) {
-      onReactionRemove(message, { type: MessageReactionType.Unique, reaction: emoji });
+  const handleReactionClick = (name: string) => {
+    if (unique[name]?.clientIds.includes(clientId)) {
+      onReactionRemove(message, { type: MessageReactionType.Unique, name: name });
     } else {
-      onReactionAdd(message, { type: MessageReactionType.Unique, reaction: emoji });
+      onReactionAdd(message, { type: MessageReactionType.Unique, name: name });
     }
   };
 
@@ -35,15 +35,15 @@ export const MessageReactionsUnique: React.FC<MessageReactionsUniqueProps> = ({
 
   return (
     <>
-      {currentEmojis.map((emoji) => (
+      {currentEmojis.map((name) => (
         <button
-          key={emoji}
+          key={name}
           onClick={(e) => {
             e.preventDefault();
-            handleReactionClick(emoji);
+            handleReactionClick(name);
           }}
         >
-          {emoji} ({unique[emoji]?.total || 0})
+          {name} ({unique[name]?.total || 0})
         </button>
       ))}
     </>

--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -102,9 +102,9 @@ export interface AddMessageReactionParams {
   type: string;
 
   /**
-   * The reaction to add; ie. the emoji.
+   * The reaction name to add; ie. the emoji.
    */
-  reaction: string;
+  name: string;
 
   /**
    * The count of the reaction for type {@link MessageReactionType.Multiple}.
@@ -124,10 +124,10 @@ export interface DeleteMessageReactionParams {
   type: string;
 
   /**
-   * The reaction to remove, ie. the emoji. Required for all reaction types
+   * The reaction name to remove, ie. the emoji. Required for all reaction types
    * except {@link MessageReactionType.Unique}.
    */
-  reaction?: string;
+  name?: string;
 }
 
 /**

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -219,8 +219,8 @@ export interface MessageReactionRawEvent {
     /** Type of reaction */
     type: MessageReactionType;
 
-    /** The reaction (typically an emoji) */
-    reaction: string;
+    /** The reaction name (typically an emoji) */
+    name: string;
 
     /** Count of the reaction (only for type Multiple, if set) */
     count?: number;

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -240,9 +240,6 @@ export interface MessageReactionSummaryEvent {
 
   /** The message reactions summary. */
   summary: {
-    /** When the summary was generated */
-    timestamp: Date;
-
     /** Reference to the original message's serial number */
     messageSerial: string;
 

--- a/src/core/messages-reactions.ts
+++ b/src/core/messages-reactions.ts
@@ -225,7 +225,6 @@ export class DefaultMessageReactions implements MessagesReactions {
     this._emitter.emit(MessageReactionEvents.Summary, {
       type: MessageReactionEvents.Summary,
       summary: {
-        timestamp: new Date(event.timestamp),
         messageSerial: event.serial,
         unique: unique,
         distinct: distinct,

--- a/src/core/messages-reactions.ts
+++ b/src/core/messages-reactions.ts
@@ -16,7 +16,7 @@ import {
 import { Logger } from './logger.js';
 import { InternalRoomOptions, MessageOptions } from './room-options.js';
 import { Subscription } from './subscription.js';
-import EventEmitter from './utils/event-emitter.js';
+import EventEmitter, { wrap } from './utils/event-emitter.js';
 
 /**
  * A listener for summary message reaction events.
@@ -279,13 +279,11 @@ export class DefaultMessageReactions implements MessagesReactions {
   subscribe(listener: MessageReactionListener): Subscription {
     this._logger.trace('MessagesReactions.subscribe();');
 
-    const unique = (event: MessageReactionSummaryEvent) => {
-      listener(event);
-    };
-    this._emitter.on(MessageReactionEvents.Summary, unique);
+    const wrapped = wrap(listener);
+    this._emitter.on(MessageReactionEvents.Summary, wrapped);
     return {
       unsubscribe: () => {
-        this._emitter.off(unique);
+        this._emitter.off(wrapped);
       },
     };
   }
@@ -299,13 +297,11 @@ export class DefaultMessageReactions implements MessagesReactions {
     if (!this._options?.rawMessageReactions) {
       throw new Ably.ErrorInfo('Raw message reactions are not enabled', 40001, 400);
     }
-    const unique = (event: MessageReactionRawEvent) => {
-      listener(event);
-    };
-    this._emitter.on([MessageReactionEvents.Create, MessageReactionEvents.Delete], unique);
+    const wrapped = wrap(listener);
+    this._emitter.on([MessageReactionEvents.Create, MessageReactionEvents.Delete], wrapped);
     return {
       unsubscribe: () => {
-        this._emitter.off(unique);
+        this._emitter.off(wrapped);
       },
     };
   }

--- a/src/core/messages-reactions.ts
+++ b/src/core/messages-reactions.ts
@@ -36,9 +36,9 @@ export type MessageRawReactionListener = (event: MessageReactionRawEvent) => voi
  */
 export interface AddMessageReactionParams {
   /**
-   * The reaction to add; ie. the emoji.
+   * The reaction name to add; ie. the emoji.
    */
-  reaction: string;
+  name: string;
 
   /**
    * The type of reaction, must be one of {@link MessageReactionType}.
@@ -59,10 +59,10 @@ export interface AddMessageReactionParams {
  */
 export interface DeleteMessageReactionParams {
   /**
-   * The reaction to add; ie. the emoji. Required for all reaction types
+   * The reaction name to delete; ie. the emoji. Required for all reaction types
    * except {@link MessageReactionType.Unique}.
    */
-  reaction?: string;
+  name?: string;
 
   /**
    * The type of reaction, must be one of {@link MessageReactionType}.
@@ -187,7 +187,7 @@ export class DefaultMessageReactions implements MessagesReactions {
       reaction: {
         messageSerial: event.messageSerial,
         type: reactionType,
-        reaction: name,
+        name: name,
         clientId: event.clientId ?? '',
       },
     };
@@ -246,7 +246,7 @@ export class DefaultMessageReactions implements MessagesReactions {
     if (type === MessageReactionType.Multiple && !count) {
       count = 1;
     }
-    const apiParams: APIAddMessageReactionParams = { type, reaction: params.reaction };
+    const apiParams: APIAddMessageReactionParams = { type, name: params.name };
     if (count) {
       apiParams.count = count;
     }
@@ -263,12 +263,12 @@ export class DefaultMessageReactions implements MessagesReactions {
     if (!type) {
       type = this._defaultType;
     }
-    if (type !== MessageReactionType.Unique && !params?.reaction) {
-      throw new Ably.ErrorInfo(`cannot delete reaction of type ${type} without a reaction`, 40001, 400);
+    if (type !== MessageReactionType.Unique && !params?.name) {
+      throw new Ably.ErrorInfo(`cannot delete reaction of type ${type} without a name`, 40001, 400);
     }
     const apiParams: APIDeleteMessageReactionParams = { type };
     if (type !== MessageReactionType.Unique) {
-      apiParams.reaction = params?.reaction;
+      apiParams.name = params?.name;
     }
     return this._api.deleteMessageReaction(this._roomID, message.serial, apiParams);
   }

--- a/test/core/messages-reactions.integration.test.ts
+++ b/test/core/messages-reactions.integration.test.ts
@@ -104,13 +104,9 @@ describe('message reactions integration', { timeout: 60000 }, () => {
       found.push(event);
     });
 
-    await Promise.all([
-      room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '👍' }),
-      room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '👍', count: 10 }),
-      room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '🚀', count: 2 }),
-      room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '💚' }),
-      room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '❤️', count: 3 }),
-    ]);
+    await room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '👍' });
+    await room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '👍', count: 10 });
+    await room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '❤️', count: 3 });
 
     await vi.waitFor(
       () => {
@@ -125,18 +121,6 @@ describe('message reactions integration', { timeout: 60000 }, () => {
                 total: 11,
                 clientIds: {
                   [chat.clientId]: 11,
-                },
-              },
-              '🚀': {
-                total: 2,
-                clientIds: {
-                  [chat.clientId]: 2,
-                },
-              },
-              '💚': {
-                total: 1,
-                clientIds: {
-                  [chat.clientId]: 1,
                 },
               },
               '❤️': {
@@ -149,11 +133,13 @@ describe('message reactions integration', { timeout: 60000 }, () => {
           },
         });
       },
-      { timeout: 30_000 },
+      {
+        timeout: 50_000,
+        interval: 2000,
+      },
     );
 
     await room.messages.reactions.delete(message1, { type: MessageReactionType.Multiple, name: '❤️' });
-    await room.messages.reactions.delete(message1, { type: MessageReactionType.Multiple, name: '💚' });
     await vi.waitFor(
       () => {
         expect(found.length).toBeGreaterThanOrEqual(1);
@@ -169,17 +155,11 @@ describe('message reactions integration', { timeout: 60000 }, () => {
                   [chat.clientId]: 11,
                 },
               },
-              '🚀': {
-                total: 2,
-                clientIds: {
-                  [chat.clientId]: 2,
-                },
-              },
             },
           },
         });
       },
-      { timeout: 30_000 },
+      { timeout: 50_000 },
     );
   });
 

--- a/test/core/messages-reactions.integration.test.ts
+++ b/test/core/messages-reactions.integration.test.ts
@@ -37,10 +37,10 @@ describe('message reactions integration', { timeout: 60000 }, () => {
       found.push(reactionEvent);
     });
 
-    await room.messages.reactions.add(message1, { type: MessageReactionType.Unique, reaction: '👍' });
-    await room.messages.reactions.add(message1, { type: MessageReactionType.Distinct, reaction: '🚀' });
-    await room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, reaction: '🙈', count: 10 });
-    await room.messages.reactions.delete(message1, { type: MessageReactionType.Distinct, reaction: '🚀' });
+    await room.messages.reactions.add(message1, { type: MessageReactionType.Unique, name: '👍' });
+    await room.messages.reactions.add(message1, { type: MessageReactionType.Distinct, name: '🚀' });
+    await room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '🙈', count: 10 });
+    await room.messages.reactions.delete(message1, { type: MessageReactionType.Distinct, name: '🚀' });
 
     await waitForArrayLength(found, 4);
 
@@ -48,7 +48,7 @@ describe('message reactions integration', { timeout: 60000 }, () => {
       type: MessageReactionEvents.Create,
       reaction: {
         type: MessageReactionType.Unique,
-        reaction: '👍',
+        name: '👍',
         messageSerial: message1.serial,
         clientId: chat.clientId,
       },
@@ -58,7 +58,7 @@ describe('message reactions integration', { timeout: 60000 }, () => {
       type: MessageReactionEvents.Create,
       reaction: {
         type: MessageReactionType.Distinct,
-        reaction: '🚀',
+        name: '🚀',
         messageSerial: message1.serial,
         clientId: chat.clientId,
       },
@@ -68,7 +68,7 @@ describe('message reactions integration', { timeout: 60000 }, () => {
       type: MessageReactionEvents.Create,
       reaction: {
         type: MessageReactionType.Multiple,
-        reaction: '🙈',
+        name: '🙈',
         count: 10,
         messageSerial: message1.serial,
         clientId: chat.clientId,
@@ -79,7 +79,7 @@ describe('message reactions integration', { timeout: 60000 }, () => {
       type: MessageReactionEvents.Delete,
       reaction: {
         type: MessageReactionType.Distinct,
-        reaction: '🚀',
+        name: '🚀',
         messageSerial: message1.serial,
         clientId: chat.clientId,
       },
@@ -105,11 +105,11 @@ describe('message reactions integration', { timeout: 60000 }, () => {
     });
 
     await Promise.all([
-      room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, reaction: '👍' }),
-      room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, reaction: '👍', count: 10 }),
-      room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, reaction: '🚀', count: 2 }),
-      room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, reaction: '💚' }),
-      room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, reaction: '❤️', count: 3 }),
+      room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '👍' }),
+      room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '👍', count: 10 }),
+      room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '🚀', count: 2 }),
+      room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '💚' }),
+      room.messages.reactions.add(message1, { type: MessageReactionType.Multiple, name: '❤️', count: 3 }),
     ]);
 
     await vi.waitFor(
@@ -152,8 +152,8 @@ describe('message reactions integration', { timeout: 60000 }, () => {
       { timeout: 30_000 },
     );
 
-    await room.messages.reactions.delete(message1, { type: MessageReactionType.Multiple, reaction: '❤️' });
-    await room.messages.reactions.delete(message1, { type: MessageReactionType.Multiple, reaction: '💚' });
+    await room.messages.reactions.delete(message1, { type: MessageReactionType.Multiple, name: '❤️' });
+    await room.messages.reactions.delete(message1, { type: MessageReactionType.Multiple, name: '💚' });
     await vi.waitFor(
       () => {
         expect(found.length).toBeGreaterThanOrEqual(1);
@@ -210,13 +210,13 @@ describe('message reactions integration', { timeout: 60000 }, () => {
     await room3.attach();
 
     await Promise.all([
-      room.messages.reactions.add(message1, { type: MessageReactionType.Distinct, reaction: '👍' }),
-      room.messages.reactions.add(message1, { type: MessageReactionType.Distinct, reaction: '🥦' }),
-      room2.messages.reactions.add(message1, { type: MessageReactionType.Distinct, reaction: '👍' }),
-      room2.messages.reactions.add(message1, { type: MessageReactionType.Distinct, reaction: '❤️' }),
-      room2.messages.reactions.add(message1, { type: MessageReactionType.Distinct, reaction: '❤️' }),
-      room3.messages.reactions.add(message1, { type: MessageReactionType.Distinct, reaction: '🥥' }),
-      room3.messages.reactions.add(message1, { type: MessageReactionType.Distinct, reaction: '🥥' }),
+      room.messages.reactions.add(message1, { type: MessageReactionType.Distinct, name: '👍' }),
+      room.messages.reactions.add(message1, { type: MessageReactionType.Distinct, name: '🥦' }),
+      room2.messages.reactions.add(message1, { type: MessageReactionType.Distinct, name: '👍' }),
+      room2.messages.reactions.add(message1, { type: MessageReactionType.Distinct, name: '❤️' }),
+      room2.messages.reactions.add(message1, { type: MessageReactionType.Distinct, name: '❤️' }),
+      room3.messages.reactions.add(message1, { type: MessageReactionType.Distinct, name: '🥥' }),
+      room3.messages.reactions.add(message1, { type: MessageReactionType.Distinct, name: '🥥' }),
     ]);
 
     void room2.detach();
@@ -255,7 +255,7 @@ describe('message reactions integration', { timeout: 60000 }, () => {
       { timeout: 30_000 },
     );
 
-    await room.messages.reactions.delete(message1, { type: MessageReactionType.Distinct, reaction: '👍' });
+    await room.messages.reactions.delete(message1, { type: MessageReactionType.Distinct, name: '👍' });
     await vi.waitFor(
       () => {
         expect(found.length).toBeGreaterThanOrEqual(1);
@@ -312,12 +312,12 @@ describe('message reactions integration', { timeout: 60000 }, () => {
     await room2.attach();
 
     // First client reactions - only the last one (❤️) should remain
-    await room.messages.reactions.add(message1, { type: MessageReactionType.Unique, reaction: '👍' });
-    await room.messages.reactions.add(message1, { type: MessageReactionType.Unique, reaction: '🚀' });
-    await room.messages.reactions.add(message1, { type: MessageReactionType.Unique, reaction: '❤️' });
+    await room.messages.reactions.add(message1, { type: MessageReactionType.Unique, name: '👍' });
+    await room.messages.reactions.add(message1, { type: MessageReactionType.Unique, name: '🚀' });
+    await room.messages.reactions.add(message1, { type: MessageReactionType.Unique, name: '❤️' });
     // Second client reactions - only the last one (👍) should remain
-    await room2.messages.reactions.add(message1, { type: MessageReactionType.Unique, reaction: '🌟' });
-    await room2.messages.reactions.add(message1, { type: MessageReactionType.Unique, reaction: '👍' });
+    await room2.messages.reactions.add(message1, { type: MessageReactionType.Unique, name: '🌟' });
+    await room2.messages.reactions.add(message1, { type: MessageReactionType.Unique, name: '👍' });
     await vi.waitFor(
       () => {
         expect(found.length).toBeGreaterThanOrEqual(1);
@@ -367,8 +367,8 @@ describe('message reactions integration', { timeout: 60000 }, () => {
     // Send another message and react with same emojis, make sure emojis are unique per-message
     const message2 = await room.messages.send({ text: 'Another message' });
     await Promise.all([
-      room.messages.reactions.add(message2, { type: MessageReactionType.Unique, reaction: '❤️' }),
-      room2.messages.reactions.add(message2, { type: MessageReactionType.Unique, reaction: '👍' }),
+      room.messages.reactions.add(message2, { type: MessageReactionType.Unique, name: '❤️' }),
+      room2.messages.reactions.add(message2, { type: MessageReactionType.Unique, name: '👍' }),
     ]);
 
     await vi.waitFor(

--- a/test/core/messages-reactions.test.ts
+++ b/test/core/messages-reactions.test.ts
@@ -50,37 +50,37 @@ describe('MessagesReactions', () => {
 
       const msg = { serial: serial };
 
-      await context.room.messages.reactions.add(msg, { type: MessageReactionType.Unique, reaction: '🥕' });
+      await context.room.messages.reactions.add(msg, { type: MessageReactionType.Unique, name: '🥕' });
       expect(chatApi.addMessageReaction).toHaveBeenLastCalledWith(context.room.roomId, serial, {
         type: MessageReactionType.Unique,
-        reaction: '🥕',
+        name: '🥕',
       });
 
-      await context.room.messages.reactions.add(msg, { type: MessageReactionType.Distinct, reaction: '🥕' });
+      await context.room.messages.reactions.add(msg, { type: MessageReactionType.Distinct, name: '🥕' });
       expect(chatApi.addMessageReaction).toHaveBeenLastCalledWith(context.room.roomId, serial, {
         type: MessageReactionType.Distinct,
-        reaction: '🥕',
+        name: '🥕',
       });
 
-      await context.room.messages.reactions.add(msg, { type: MessageReactionType.Multiple, reaction: '🥕' });
+      await context.room.messages.reactions.add(msg, { type: MessageReactionType.Multiple, name: '🥕' });
       expect(chatApi.addMessageReaction).toHaveBeenLastCalledWith(context.room.roomId, serial, {
         type: MessageReactionType.Multiple,
-        reaction: '🥕',
+        name: '🥕',
         count: 1,
       });
 
-      await context.room.messages.reactions.add(msg, { type: MessageReactionType.Multiple, reaction: '🥕', count: 10 });
+      await context.room.messages.reactions.add(msg, { type: MessageReactionType.Multiple, name: '🥕', count: 10 });
       expect(chatApi.addMessageReaction).toHaveBeenLastCalledWith(context.room.roomId, serial, {
         type: MessageReactionType.Multiple,
-        reaction: '🥕',
+        name: '🥕',
         count: 10,
       });
 
       // default is distinct for AllFeaturesEnabled
-      await context.room.messages.reactions.add(msg, { reaction: '👻' });
+      await context.room.messages.reactions.add(msg, { name: '👻' });
       expect(chatApi.addMessageReaction).toHaveBeenLastCalledWith(context.room.roomId, serial, {
         type: MessageReactionType.Distinct,
-        reaction: '👻',
+        name: '👻',
       });
     });
   });
@@ -99,23 +99,23 @@ describe('MessagesReactions', () => {
         type: MessageReactionType.Unique,
       });
 
-      await context.room.messages.reactions.delete(msg, { type: MessageReactionType.Distinct, reaction: '🥕' });
+      await context.room.messages.reactions.delete(msg, { type: MessageReactionType.Distinct, name: '🥕' });
       expect(chatApi.deleteMessageReaction).toHaveBeenLastCalledWith(context.room.roomId, serial, {
         type: MessageReactionType.Distinct,
-        reaction: '🥕',
+        name: '🥕',
       });
 
-      await context.room.messages.reactions.delete(msg, { type: MessageReactionType.Multiple, reaction: '🥕' });
+      await context.room.messages.reactions.delete(msg, { type: MessageReactionType.Multiple, name: '🥕' });
       expect(chatApi.deleteMessageReaction).toHaveBeenLastCalledWith(context.room.roomId, serial, {
         type: MessageReactionType.Multiple,
-        reaction: '🥕',
+        name: '🥕',
       });
 
       // default is distinct for AllFeaturesEnabled
-      await context.room.messages.reactions.delete(msg, { reaction: '👻' });
+      await context.room.messages.reactions.delete(msg, { name: '👻' });
       expect(chatApi.deleteMessageReaction).toHaveBeenLastCalledWith(context.room.roomId, serial, {
         type: MessageReactionType.Distinct,
-        reaction: '👻',
+        name: '👻',
       });
     });
   });
@@ -213,7 +213,7 @@ describe('MessagesReactions', () => {
             timestamp: new Date(publishTimestamp),
             reaction: {
               messageSerial: '01672531200000-123@xyzdefghij',
-              reaction: '🥦',
+              name: '🥦',
               clientId: 'u1',
               type: MessageReactionType.Unique,
             },
@@ -223,7 +223,7 @@ describe('MessagesReactions', () => {
             timestamp: new Date(publishTimestamp),
             reaction: {
               messageSerial: '01672531200000-123@xyzdefghij',
-              reaction: '',
+              name: '',
               clientId: 'u1',
               type: MessageReactionType.Unique,
             },
@@ -233,7 +233,7 @@ describe('MessagesReactions', () => {
             timestamp: new Date(publishTimestamp),
             reaction: {
               messageSerial: '01672531200000-123@xyzdefghij',
-              reaction: '🚀',
+              name: '🚀',
               clientId: 'u1',
               type: MessageReactionType.Distinct,
             },
@@ -243,7 +243,7 @@ describe('MessagesReactions', () => {
             timestamp: new Date(publishTimestamp),
             reaction: {
               messageSerial: '01672531200000-123@xyzdefghij',
-              reaction: '🔥',
+              name: '🔥',
               clientId: 'u1',
               type: MessageReactionType.Multiple,
               count: 10,
@@ -254,7 +254,7 @@ describe('MessagesReactions', () => {
             timestamp: new Date(publishTimestamp),
             reaction: {
               messageSerial: '01672531200000-123@xyzdefghij',
-              reaction: '👍',
+              name: '👍',
               clientId: 'u1',
               type: MessageReactionType.Multiple,
               count: 1,
@@ -265,7 +265,7 @@ describe('MessagesReactions', () => {
             timestamp: new Date(publishTimestamp),
             reaction: {
               messageSerial: '01672531200000-123@xyzdefghij',
-              reaction: '🍌',
+              name: '🍌',
               clientId: 'u1',
               type: MessageReactionType.Multiple,
             },


### PR DESCRIPTION
### Context

- https://ably.atlassian.net/browse/CHA-980

### Description

Rename the `reaction` field to `name` in message reactions: raw reaction events, add reaction API, delete reaction API.

### Checklist

* [x] QA'd by the author.
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] In repo demo app updated (if applicable).