### PR TITLE
ci: disable `fail-fast` for test jobs

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -60,6 +60,7 @@ jobs:
       contents: read
       pull-requests: write
     strategy:
+      fail-fast: false
       matrix:
         node-version: [18, 20, 22]
     name: test node ${{ matrix.node-version }}


### PR DESCRIPTION
prevents annoying default behaviour where a test failure on one version of nodejs causes all other test runs to be cancelled.