### PR TITLE
feat: Update capability grants

### DIFF
--- a/demo/api/ably-token-request/index.ts
+++ b/demo/api/ably-token-request/index.ts
@@ -29,7 +29,6 @@ Please see README.md for more details on configuring your Ably API Key.`);
   const tokenRequestData = await client.auth.createTokenRequest({
     capability: {
       '[chat]*': ['*'],
-      '*': ['*'],
     },
     clientId: clientId,
   });

--- a/test/helper/realtime-client.ts
+++ b/test/helper/realtime-client.ts
@@ -57,12 +57,11 @@ const ablyRealtimeClientWithToken = (options?: Ably.ClientOptions): Ably.Realtim
   const claims = {
     iat: currentTime,
     exp: currentTime + 3600,
-    'x-ably-capability': '{"*":["*"], "[chat]*":["*"]}',
+    'x-ably-capability': '{"[chat]*":["*"]}',
     'x-ably-clientId': options.clientId,
   };
 
-  const token = jwt.sign(claims, keySecret, { header: header });
-  options.token = token;
+  options.token = jwt.sign(claims, keySecret, { header: header });
 
   return ablyRealtimeClient(options);
 };


### PR DESCRIPTION
### Context
As of the single channel updates, capabilities can be granted to any room with just the chat qualifier - `"[chat]*":["*"]` 

### Description

* Removed the un-needed channel capability grants in the demo app and testbed.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [ ] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

* Start the demo app and check all features work with no 401 errors
