### PR TITLE
Fix: Clear typing state on release

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -16,7 +16,8 @@
     "livestream",
     "clonedeep",
     "timeserial",
-    "rgba"
+    "rgba",
+    "retryable"
   ],
   // This will ignore anything that's formatted like a lexicographically ordered timeserial
   "ignoreRegExpList": ["/\\d{14}-\\d{3}@.*/"],

--- a/src/core/disposable.ts
+++ b/src/core/disposable.ts
@@ -1,9 +1,0 @@
-/**
- * Interface for features that have resources that need to be disposed of when a room is released.
- */
-export interface Disposable {
-  /**
-   * Disposes of resources associated with the feature.
-   */
-  dispose(): void;
-}

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -216,7 +216,7 @@ export class DefaultRoom implements Room {
       await this._lifecycleManager.release();
 
       // Dispose of all remaining resources only once we have fully released the room
-      this._typing.dispose();
+      await this._typing.dispose();
 
       finalized = true;
     };

--- a/test/core/typing.test.ts
+++ b/test/core/typing.test.ts
@@ -9,12 +9,7 @@ import { Logger } from '../../src/core/logger.ts';
 import { Room } from '../../src/core/room.ts';
 import { RoomOptions } from '../../src/core/room-options.ts';
 import { DefaultTyping, Typing } from '../../src/core/typing.ts';
-import {
-  channelEventEmitter,
-  ChannelEventEmitterReturnType,
-  channelStateEventEmitter,
-  ChannelStateEventEmitterReturnType,
-} from '../helper/channel.ts';
+import { channelEventEmitter, ChannelEventEmitterReturnType } from '../helper/channel.ts';
 import { waitForArrayLength } from '../helper/common.ts';
 import { makeTestLogger } from '../helper/logger.ts';
 import { makeRandomRoom } from '../helper/room.ts';
@@ -25,7 +20,6 @@ interface TestContext {
   chatApi: ChatApi;
   room: Room;
   emulateBackendPublish: ChannelEventEmitterReturnType<Partial<Ably.InboundMessage>>;
-  emulateChannelStateChange: ChannelStateEventEmitterReturnType;
   options: RoomOptions;
   logger: Logger;
 }
@@ -73,7 +67,6 @@ describe('Typing', () => {
     });
     const channel = context.room.channel;
     context.emulateBackendPublish = channelEventEmitter(channel);
-    context.emulateChannelStateChange = channelStateEventEmitter(channel);
   });
 
   // CHA-T8


### PR DESCRIPTION
### Context
[CHA-1006](https://ably.atlassian.net/browse/CHA-1006)
* When releasing, we don't clear any in progress typing state timers. This means resources take longer to clean up and can lead to unexpected behaviour.

### Description

- Typing now extends the Disposable interface, on release, we call dispose to clear all typing state timers as part of the finalizer step.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

* Explain how to test the changes in this PR.
* Provide specific steps or commands to execute.


[CHA-1006]: https://ably.atlassian.net/browse/CHA-1006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ