### PR TITLE
Export MessageReactionEvents enum as value, not type

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -8,16 +8,11 @@ export type { Connection, ConnectionStatusChange, ConnectionStatusListener } fro
 export { ConnectionStatus } from './connection.js';
 export type { DiscontinuityListener } from './discontinuity.js';
 export { ErrorCodes, errorInfoIs } from './errors.js';
-export type {
-  MessageEvent,
-  MessageReactionEvents,
-  MessageReactionRawEvent,
-  MessageReactionSummaryEvent,
-  TypingSetEvent,
-} from './events.js';
+export type { MessageEvent, MessageReactionRawEvent, MessageReactionSummaryEvent, TypingSetEvent } from './events.js';
 export {
   ChatMessageActions,
   MessageEvents,
+  MessageReactionEvents,
   MessageReactionType as MessageReactionType,
   PresenceEvents,
   TypingEventTypes,


### PR DESCRIPTION
### Context

I found this while working on adding message reactions the ably-cli. The enum is supposed to be exported as value, not as type.

### Checklist

* [x] QA'd by the author.
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).