### PR TITLE
readme: remove react callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,7 @@ The Chat SDK can be installed either from NPM, or included directly from Ably's 
 
 ```sh
 npm install ably @ably/chat
-npm install react
 ```
-NOTE: React dependency is currently required even if you are not using Chat React components.
-This is a known issue and will be removed in a future release.
 
 ### CDN
 


### PR DESCRIPTION
### Context

N/A

### Description

Removed the react requirement callout in the README, as it's no-longer relevant since 0.6.0.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A
