### PR TITLE
readme: remove feature callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,6 @@ This SDK supports the following platforms:
 
 **Android and iOS** are also supported by the [Kotlin](https://github.com/ably/ably-chat-kotlin) and [Swift](https://github.com/ably/ably-chat-swift) SDKs respectively.
 
-## Supported chat features
-
-This project is under development so we will be incrementally adding new features. At this stage, you'll find APIs for the following chat features:
-
-- Chat rooms for 1:1, 1:many, many:1 and many:many participation.
-- Sending, receiving, editing and deleting chat messages.
-- Online status aka presence of chat participants.
-- Chat room occupancy, i.e total number of connections and presence members.
-- Typing indicators
-- Room-level reactions (ephemeral at this stage)
-
-If there are other features you'd like us to prioritize, please [let us know](https://forms.gle/mBw9M53NYuCBLFpMA).
-
 ## Prerequisites
 
 You will need the following prerequisites:


### PR DESCRIPTION
### Context

N/A

### Description

We have the feature callouts in 3x SDK readmes, which require updating on each release. Instead
we're going to remove them and use the docs page as the source-of-truth for features.

### Checklist

* [ ] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [ ] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A
