### PR TITLE
Fix flakey presence tests

### DIFF
--- a/test/core/presence.integration.test.ts
+++ b/test/core/presence.integration.test.ts
@@ -91,6 +91,9 @@ describe('UserPresence', { timeout: 30000 }, () => {
     context.chat = newChatClient(undefined, context.realtime);
     context.defaultTestClientId = context.realtime.auth.clientId;
     context.chatRoom = await context.chat.rooms.get(roomId);
+
+    // Ensure we have just performed a sync so we don't get a `present` event instead of an `enter` event
+    await context.chatRoom.presence.get({ waitForSync: true });
   });
 
   // Test for successful entering with clientId and custom user data
@@ -99,7 +102,7 @@ describe('UserPresence', { timeout: 30000 }, () => {
     const messageChannelName = messageChannel.name;
     const enterEventPromise = waitForEvent(
       context.realtime,
-      ['enter', 'present'],
+      ['enter'],
       messageChannelName,
       (member: Ably.PresenceMessage) => {
         expect(member.clientId, 'client id should be equal to defaultTestClientId').toEqual(

--- a/test/core/presence.integration.test.ts
+++ b/test/core/presence.integration.test.ts
@@ -105,7 +105,9 @@ describe('UserPresence', { timeout: 30000 }, () => {
     context.defaultTestClientId = context.realtime.auth.clientId;
     context.chatRoom = await context.chat.rooms.get(roomId);
 
-    // Ensure we have just performed a sync so we don't get a `present` event instead of an `enter` event
+    // Attach the chat room to ensure it is ready for presence operations
+    await context.chatRoom.attach();
+    // Ensure we have just performed a sync so we don't get a `present` events instead of an `enter` event
     await context.chatRoom.presence.get({ waitForSync: true });
   });
 


### PR DESCRIPTION
### Context

[CHA-1003](https://ably.atlassian.net/browse/CHA-1003)

Presence tests were flakey, due to a race condition with sycn messages. A room is not subscribed on attach and the presence state is not in sync, if we then enter presence (and thus attach to the underlying channel) it is possible that the first protocol message we get will be a SYNC. If this is the case, then instead of an `enter` event being emitted back to our local listener, a `present` event is emitted. 

This isn't so much of a bug, as it is expected behaviour that we should account for in the tests.

### Description

* Presence integration tests now sync their state first by calling `presence.get()`, after which, `enter` events should be correctly received. 

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).


[CHA-101]: https://ably.atlassian.net/browse/CHA-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CHA-1003]: https://ably.atlassian.net/browse/CHA-1003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ