### PR TITLE
Use `cloneDeep` instead of `structuredClone`

### DIFF
--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -1,4 +1,5 @@
 import * as Ably from 'ably';
+import cloneDeep from 'lodash.clonedeep';
 
 import {
   ChatMessageAction,
@@ -437,9 +438,9 @@ export class DefaultMessage implements Message {
       }
 
       const newReactions: MessageReactions = {
-        unique: structuredClone(event.summary.unique),
-        distinct: structuredClone(event.summary.distinct),
-        multiple: structuredClone(event.summary.multiple),
+        unique: cloneDeep(event.summary.unique),
+        distinct: cloneDeep(event.summary.distinct),
+        multiple: cloneDeep(event.summary.multiple),
       };
 
       return DefaultMessage._clone(this, { reactions: newReactions });
@@ -478,14 +479,14 @@ export class DefaultMessage implements Message {
       serial: replace?.serial ?? source.serial,
       clientId: replace?.clientId ?? source.clientId,
       text: replace?.text ?? source.text,
-      metadata: replace?.metadata ?? structuredClone(source.metadata),
-      headers: replace?.headers ?? structuredClone(source.headers),
+      metadata: replace?.metadata ?? cloneDeep(source.metadata),
+      headers: replace?.headers ?? cloneDeep(source.headers),
       action: replace?.action ?? source.action,
       version: replace?.version ?? source.version,
       createdAt: replace?.createdAt ?? source.createdAt,
       timestamp: replace?.timestamp ?? source.timestamp,
-      reactions: replace?.reactions ?? structuredClone(source.reactions),
-      operation: replace?.operation ?? structuredClone(source.operation),
+      reactions: replace?.reactions ?? cloneDeep(source.reactions),
+      operation: replace?.operation ?? cloneDeep(source.operation),
     });
   }
 


### PR DESCRIPTION
### Context

* The Expo framework does not support structuredClone yet.

### Description

* Use lodash `cloneDeep` instead of `structuredClone` in the `DefaultMessage` class to ensure compatibility with the Expo framework.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [ ] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

* Explain how to test the changes in this PR.
* Provide specific steps or commands to execute.


[CHA-101]: https://ably.atlassian.net/browse/CHA-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ