### PR TITLE
refactor: room reactions wire protocol

### DIFF
--- a/src/core/room-reaction-parser.ts
+++ b/src/core/room-reaction-parser.ts
@@ -4,7 +4,7 @@ import { DefaultRoomReaction, RoomReaction, RoomReactionHeaders, RoomReactionMet
 
 interface ReactionPayload {
   data?: {
-    type: unknown;
+    name?: string;
     metadata?: RoomReactionMetadata;
   };
   clientId?: string;
@@ -20,8 +20,8 @@ export function parseRoomReaction(message: Ably.InboundMessage, clientId?: strin
     throw new Ably.ErrorInfo(`received incoming room reaction message without data`, 50000, 500);
   }
 
-  if (!reactionCreatedMessage.data.type || typeof reactionCreatedMessage.data.type !== 'string') {
-    throw new Ably.ErrorInfo('invalid room reaction message with no type', 50000, 500);
+  if (!reactionCreatedMessage.data.name || typeof reactionCreatedMessage.data.name !== 'string') {
+    throw new Ably.ErrorInfo('invalid room reaction message with no name', 50000, 500);
   }
 
   if (!reactionCreatedMessage.clientId) {
@@ -33,7 +33,7 @@ export function parseRoomReaction(message: Ably.InboundMessage, clientId?: strin
   }
 
   return new DefaultRoomReaction(
-    reactionCreatedMessage.data.type,
+    reactionCreatedMessage.data.name,
     reactionCreatedMessage.clientId,
     new Date(reactionCreatedMessage.timestamp),
     clientId ? clientId === reactionCreatedMessage.clientId : false,

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -9,7 +9,7 @@ import { Subscription } from './subscription.js';
 import EventEmitter, { wrap } from './utils/event-emitter.js';
 
 /**
- * Params for sending a room-level reactions. Only `type` is mandatory.
+ * Params for sending a room-level reactions. Only `name` is mandatory.
  */
 export interface SendReactionParams {
   /**
@@ -68,8 +68,8 @@ export interface RoomReactions {
    *
    * This method accepts parameters for a room-level reaction. It accepts an object
    *
-   * @param params an object containing {type, headers, metadata} for the room
-   * reaction to be sent. Type is required, metadata and headers are optional.
+   * @param params an object containing {name, headers, metadata} for the room
+   * reaction to be sent. Name is required, metadata and headers are optional.
    * @throws If the `Connection` is not in the `Connected` state.
    * @returns The returned promise resolves when the reaction was sent. Note
    * that it is possible to receive your own reaction via the reactions
@@ -91,7 +91,7 @@ interface RoomReactionEventsMap {
 }
 
 interface ReactionPayload {
-  type: string;
+  name: string;
   metadata?: RoomReactionMetadata;
 }
 
@@ -147,7 +147,7 @@ export class DefaultRoomReactions implements RoomReactions {
     }
 
     const payload: ReactionPayload = {
-      type: name,
+      name: name,
       metadata: metadata ?? {},
     };
 

--- a/test/core/room-reaction-parser.test.ts
+++ b/test/core/room-reaction-parser.test.ts
@@ -12,23 +12,23 @@ describe('parseRoomReaction', () => {
       expectedError: 'received incoming room reaction message without data',
     },
     {
-      description: 'message.data.type is undefined',
+      description: 'message.data.name is undefined',
       message: { data: {}, clientId: 'client1', timestamp: 1234567890 },
-      expectedError: 'invalid room reaction message with no type',
+      expectedError: 'invalid room reaction message with no name',
     },
     {
-      description: 'message.data.type is not a string',
-      message: { data: { type: 123 }, clientId: 'client1', timestamp: 1234567890 },
-      expectedError: 'invalid room reaction message with no type',
+      description: 'message.data.name is not a string',
+      message: { data: { name: 123 }, clientId: 'client1', timestamp: 1234567890 },
+      expectedError: 'invalid room reaction message with no name',
     },
     {
       description: 'message.clientId is undefined',
-      message: { data: { type: 'like' }, timestamp: 1234567890 },
+      message: { data: { name: 'like' }, timestamp: 1234567890 },
       expectedError: 'received incoming room reaction message without clientId',
     },
     {
       description: 'message.timestamp is undefined',
-      message: { data: { type: 'like' }, clientId: 'client1' },
+      message: { data: { name: 'like' }, clientId: 'client1' },
       expectedError: 'received incoming room reaction message without timestamp',
     },
   ])('should throw an error', ({ description, message, expectedError }) => {
@@ -44,7 +44,7 @@ describe('parseRoomReaction', () => {
 
   it('should return a DefaultReaction instance for a valid message', () => {
     const message = {
-      data: { type: 'like', metadata: { key: 'value' } },
+      data: { name: 'like', metadata: { key: 'value' } },
       clientId: 'client1',
       timestamp: 1234567890,
       extras: { headers: { headerKey: 'headerValue' } },
@@ -63,7 +63,7 @@ describe('parseRoomReaction', () => {
 
   it('should set isFromCurrentUser to true if clientId matches', () => {
     const message = {
-      data: { type: 'like' },
+      data: { name: 'like' },
       clientId: 'client1',
       timestamp: 1234567890,
     } as Ably.InboundMessage;

--- a/test/core/room-reactions.test.ts
+++ b/test/core/room-reactions.test.ts
@@ -78,7 +78,7 @@ describe('Reactions', () => {
           clientId: 'yoda',
           name: 'roomReaction',
           data: {
-            type: 'like',
+            name: 'like',
           },
           timestamp: publishTimestamp,
         });
@@ -110,7 +110,7 @@ describe('Reactions', () => {
           clientId: 'd.vader',
           name: 'roomReaction',
           data: {
-            type: 'hate',
+            name: 'hate',
           },
           timestamp: publishTimestamp,
         });
@@ -131,7 +131,7 @@ describe('Reactions', () => {
       clientId: 'yoda',
       name: 'roomReaction',
       data: {
-        type: 'like',
+        name: 'like',
       },
       timestamp: publishTimestamp,
     });
@@ -144,7 +144,7 @@ describe('Reactions', () => {
       clientId: 'yoda2',
       name: 'roomReaction',
       data: {
-        type: 'like',
+        name: 'like',
       },
       timestamp: publishTimestamp,
     });
@@ -177,7 +177,7 @@ describe('Reactions', () => {
       clientId: 'yoda',
       name: 'roomReaction',
       data: {
-        type: 'like',
+        name: 'like',
       },
       timestamp: publishTimestamp,
     });
@@ -190,7 +190,7 @@ describe('Reactions', () => {
       clientId: 'yoda',
       name: 'roomReaction',
       data: {
-        type: 'love',
+        name: 'love',
       },
       timestamp: publishTimestamp,
     });
@@ -261,7 +261,7 @@ describe('Reactions', () => {
             expect(publishSpy).toHaveBeenCalledWith({
               name: 'roomReaction',
               data: {
-                type: 'love',
+                name: 'love',
                 metadata: {},
               },
               extras: {


### PR DESCRIPTION
### Context

[CHA-1043]

### Description

Renames type to name in the wire protocol for room reactions, to be consistent with its external naming.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A

[CHA-1043]: https://ably.atlassian.net/browse/CHA-1043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ