### PR TITLE
refactor: rename room reactions params type to name

### DIFF
--- a/demo/src/components/ReactionInput/ReactionInput.tsx
+++ b/demo/src/components/ReactionInput/ReactionInput.tsx
@@ -21,7 +21,7 @@ export const ReactionInput: FC<ReactionInputProps> = ({ reactions, onSend, disab
       onClick={(e) => {
         e.preventDefault();
         if (!disabled) {
-          onSend({ type: reaction });
+          onSend({ name: reaction });
         }
       }}
       href="#"

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -13,12 +13,12 @@ import EventEmitter, { wrap } from './utils/event-emitter.js';
  */
 export interface SendReactionParams {
   /**
-   * The type of the reaction, for example an emoji or a short string such as
+   * The name of the reaction, for example an emoji or a short string such as
    * "like".
    *
    * It is the only mandatory parameter to send a room-level reaction.
    */
-  type: string;
+  name: string;
 
   /**
    * Optional metadata of the reaction.
@@ -135,10 +135,10 @@ export class DefaultRoomReactions implements RoomReactions {
   send(params: SendReactionParams): Promise<void> {
     this._logger.trace('RoomReactions.send();', params);
 
-    const { type, metadata, headers } = params;
+    const { name, metadata, headers } = params;
 
-    if (!type) {
-      return Promise.reject(new Ably.ErrorInfo('unable to send reaction; type not set and it is required', 40001, 400));
+    if (!name) {
+      return Promise.reject(new Ably.ErrorInfo('unable to send reaction; name not set and it is required', 40001, 400));
     }
 
     // CHA-ER3f
@@ -147,7 +147,7 @@ export class DefaultRoomReactions implements RoomReactions {
     }
 
     const payload: ReactionPayload = {
-      type: type,
+      type: name,
       metadata: metadata ?? {},
     };
 

--- a/test/core/room-reactions.integration.test.ts
+++ b/test/core/room-reactions.integration.test.ts
@@ -69,8 +69,8 @@ describe('room-level reactions integration test', () => {
     await room.attach();
 
     // Send reactions
-    for (const type of expectedReactions) {
-      await room.reactions.send({ type });
+    for (const name of expectedReactions) {
+      await room.reactions.send({ name });
     }
 
     await waitForReactions(reactions, expectedReactions);

--- a/test/core/room-reactions.test.ts
+++ b/test/core/room-reactions.test.ts
@@ -275,7 +275,7 @@ describe('Reactions', () => {
           done();
         });
 
-        void room.reactions.send({ type: 'love' });
+        void room.reactions.send({ name: 'love' });
       }));
 
     // CHA-ER3f
@@ -285,7 +285,7 @@ describe('Reactions', () => {
       // Mock connection status to be disconnected
       vi.spyOn(context.realtime.connection, 'state', 'get').mockReturnValue(ConnectionStatus.Disconnected);
 
-      await expect(room.reactions.send({ type: 'love' })).rejects.toBeErrorInfoWithCode(40000);
+      await expect(room.reactions.send({ name: 'love' })).rejects.toBeErrorInfoWithCode(40000);
     });
 
     it<TestContext>('should be able to send a reaction and receive a reaction with metadata and headers', (context) =>
@@ -323,7 +323,7 @@ describe('Reactions', () => {
         });
 
         void room.reactions.send({
-          type: 'love',
+          name: 'love',
           metadata: { side: 'empire', bla: { abc: true, xyz: 3.14 } },
           headers: { action: 'strike back', number: 1980 },
         });

--- a/test/react/hooks/use-room-reactions.integration.test.tsx
+++ b/test/react/hooks/use-room-reactions.integration.test.tsx
@@ -42,7 +42,7 @@ describe('useRoomReactions', () => {
       // should send a reaction when mounted and the room is attached
       useEffect(() => {
         if (roomStatus !== RoomStatus.Attached) return;
-        void send({ type: 'like' });
+        void send({ name: 'like' });
       }, [send, roomStatus]);
 
       return null;
@@ -110,7 +110,7 @@ describe('useRoomReactions', () => {
     );
 
     // send a reaction from the second room
-    await roomTwo.reactions.send({ type: 'love' });
+    await roomTwo.reactions.send({ name: 'love' });
 
     await waitForArrayLength(reactions, 1);
 

--- a/test/react/hooks/use-room-reactions.test.tsx
+++ b/test/react/hooks/use-room-reactions.test.tsx
@@ -79,11 +79,11 @@ describe('useRoomReactions', () => {
 
     // call the send method with a 'like' reaction
     await act(async () => {
-      await result.current.send({ type: 'like' });
+      await result.current.send({ name: 'like' });
     });
 
     // verify that the send method was called with the correct arguments
-    expect(sendSpy).toHaveBeenCalledWith({ type: 'like' });
+    expect(sendSpy).toHaveBeenCalledWith({ name: 'like' });
   });
 
   it('should correctly subscribe and unsubscribe to reactions', async () => {


### PR DESCRIPTION
### Description

Extracted from https://github.com/ably/ably-chat-js/pull/575

Renames `type` to `name` for sending a room reaction, for consistency with the underlying type.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).