### PR TITLE
dev: improve logging on failed tests

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -7,4 +7,4 @@ VITE_ABLY_ENV=local
 VITE_ABLY_API_KEY=your-test-api-key
 
 # Whether to log during tests, valid values are "silent", "error", "warn", "info", "debug", "trace"
-VITE_TEST_LOG_LEVEL=silent
+VITE_TEST_LOG_LEVEL=trace

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -72,10 +72,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: npm run test -- --coverage
+      - run: VITE_TEST_LOG_LEVEL=trace npm run test -- --coverage
         name: test with coverage
         if: ${{ matrix.node-version == env.BASE_NODE_VERSION }}
-      - run: npm run test
+      - run: VITE_TEST_LOG_LEVEL=trace npm run test
         name: test
         if: ${{ matrix.node-version != env.BASE_NODE_VERSION }}
       - uses: davelosert/vitest-coverage-report-action@v2

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -111,7 +111,7 @@ export type LogHandler = (message: string, level: LogLevel, context?: LogContext
  * @param level The log level of the message.
  * @param context - The context of the log message as key-value pairs.
  */
-const consoleLogger = (message: string, level: LogLevel, context?: LogContext) => {
+export const consoleLogger = (message: string, level: LogLevel, context?: LogContext) => {
   const contextString = context ? `, context: ${JSON.stringify(context)}` : '';
   const formattedMessage = `[${new Date().toISOString()}] ${level.valueOf().toUpperCase()} ably-chat: ${message}${contextString}`;
 

--- a/test/helper/chat.ts
+++ b/test/helper/chat.ts
@@ -2,13 +2,14 @@ import * as Ably from 'ably';
 
 import { ChatClient } from '../../src/core/chat.ts';
 import { ChatClientOptions, normalizeClientOptions } from '../../src/core/config.js';
-import { testLoggingLevel } from './logger.js';
+import { testLoggingLevel, testLogHandler } from './logger.js';
 import { ablyRealtimeClientWithToken } from './realtime-client.js';
 
 export const newChatClient = (options?: ChatClientOptions, realtimeClient?: Ably.Realtime): ChatClient => {
   const normalizedOptions = normalizeClientOptions({
     ...options,
     logLevel: options?.logLevel ?? testLoggingLevel(),
+    logHandler: options?.logHandler ?? testLogHandler(),
   });
   realtimeClient = realtimeClient ?? ablyRealtimeClientWithToken();
 

--- a/test/helper/logger.ts
+++ b/test/helper/logger.ts
@@ -1,11 +1,14 @@
+import { onTestFailed } from 'vitest';
+
 import { normalizeClientOptions } from '../../src/core/config.js';
-import { Logger, LogLevel, makeLogger } from '../../src/core/logger.js';
+import { consoleLogger, LogContext, Logger, LogLevel, makeLogger } from '../../src/core/logger.js';
 
 // makeTestLogger creates a logger that logs at the level specified by the VITE_TEST_LOG_LEVEL environment variable.
 export const makeTestLogger = (): Logger => {
   return makeLogger(
     normalizeClientOptions({
       logLevel: testLoggingLevel(),
+      logHandler: testLogHandler(),
     }),
   );
 };
@@ -19,4 +22,32 @@ export const testLoggingLevel = (): LogLevel => {
   }
 
   return LogLevel.Silent;
+};
+
+// testLogHandler returns a log handler that will collect logs and print them out when the test fails, if
+// we're running on GitHub Actions.
+export const testLogHandler = () => {
+  // If we're not running on GitHub Actions, we don't need an explicit log handler... just do
+  // whatever the default specified is.
+  if (!process.env.GITHUB_ACTIONS) {
+    return;
+  }
+
+  // If we're running on GitHub Actions, we'll collect logs and print them out when the test fails.
+  const logs: {
+    message: string;
+    level: LogLevel;
+    context?: LogContext;
+  }[] = [];
+
+  onTestFailed(({ task }) => {
+    console.log(`FAILED TEST LOGS: ${task.file.name} ... ${task.name}\n`);
+    for (const log of logs) {
+      consoleLogger(log.message, log.level, log.context);
+    }
+  });
+
+  return (message: string, level: LogLevel, context?: LogContext) => {
+    logs.push({ message, level, context });
+  };
 };

--- a/test/react/hooks/use-chat-connection.test.tsx
+++ b/test/react/hooks/use-chat-connection.test.tsx
@@ -26,7 +26,7 @@ const createMockChatClient = (currentStatus: ConnectionStatus, error?: Ably.Erro
   };
 };
 
-let mockChatClient = createMockChatClient(ConnectionStatus.Initialized);
+let mockChatClient: object;
 
 const publishStatusChange = (statusChange: ConnectionStatusChange) => {
   for (const callback of mockCallbacks) {

--- a/test/react/hooks/use-room-reactions.integration.test.tsx
+++ b/test/react/hooks/use-room-reactions.integration.test.tsx
@@ -101,7 +101,6 @@ describe('useRoomReactions', () => {
     render(<TestProvider />);
 
     // wait for the room to be attached
-    chatClientOne.logger.info('got here');
     await waitFor(
       () => {
         expect(currentRoomStatus).toBe(RoomStatus.Attached);


### PR DESCRIPTION
### Context

Flakey tests happen and sometimes are rare - so we want to know when a test fails, rather than have to wait ages trying to reproduce.

### Description

- Changed `consoleLogger` to be exported for use in the test cases.
- Introduced a testLogHandler to the tests which overrides the default logHander. Does nothing for passed tests, but when running on Actions it will console log everything if the test fails. This will help us debugging.
- Updated `newChatClient` and `makeTestLogger` to utilize the new logging handler.


### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

Wait for a test to fail on actions... observe output!
