### PR TITLE
Add support for custom agent/version handling

### DIFF
--- a/src/core/chat.ts
+++ b/src/core/chat.ts
@@ -115,12 +115,24 @@ export class ChatClient {
   }
 
   /**
-   * Sets the agent string for the client.
+   * Adds additional agent information to the client.
+   * This is used internally to add a specific agent with a version.
    * @param agent - The agent to add.
+   * @param version - The version of the agent, defaults to the current client version.
    * @internal
    */
-  private _addAgent(agent: string): void {
+  public addAgentWithVersion(agent:string, version:string): void {
+    this._addAgent(agent, version);
+    this._logger.trace(`Added agent ${agent} with version ${version}`);
+  }
+  /**
+   * Sets the agent string for the client.
+   * @param agent - The agent to add.
+   * @param version - The version of the agent, defaults to the current client version.
+   * @internal
+   */
+  private _addAgent(agent: string, version?:string): void {
     const realtime = this._realtime as RealtimeWithOptions;
-    realtime.options.agents = { ...(realtime.options.agents ?? realtime.options.agents), [agent]: VERSION };
+    realtime.options.agents = { ...(realtime.options.agents ?? realtime.options.agents), [agent]: version ?? VERSION };
   }
 }

--- a/src/core/chat.ts
+++ b/src/core/chat.ts
@@ -121,7 +121,7 @@ export class ChatClient {
    * @param version - The version of the agent, defaults to the current client version.
    * @internal
    */
-  public addAgentWithVersion(agent:string, version:string): void {
+  public addAgentWithVersion(agent: string, version: string): void {
     this._addAgent(agent, version);
     this._logger.trace(`Added agent ${agent} with version ${version}`);
   }
@@ -131,7 +131,7 @@ export class ChatClient {
    * @param version - The version of the agent, defaults to the current client version.
    * @internal
    */
-  private _addAgent(agent: string, version?:string): void {
+  private _addAgent(agent: string, version?: string): void {
     const realtime = this._realtime as RealtimeWithOptions;
     realtime.options.agents = { ...(realtime.options.agents ?? realtime.options.agents), [agent]: version ?? VERSION };
   }

--- a/src/react/chat-client-internals.d.ts
+++ b/src/react/chat-client-internals.d.ts
@@ -1,0 +1,8 @@
+export {};
+
+declare module '../core/chat.js' {
+  interface ChatClient {
+    addReactAgent(): void;
+    addAgentWithVersion(agent: string, version: string): void;
+  }
+}

--- a/src/react/chat-client-internals.d.ts
+++ b/src/react/chat-client-internals.d.ts
@@ -1,8 +1,0 @@
-export {};
-
-declare module '../core/chat.js' {
-  interface ChatClient {
-    addReactAgent(): void;
-    addAgentWithVersion(agent: string, version: string): void;
-  }
-}

--- a/src/react/global.d.ts
+++ b/src/react/global.d.ts
@@ -1,0 +1,11 @@
+// src/global.d.ts
+export {};
+
+declare global {
+  interface Window {
+    /** Version injected by the Ably Chat React UI Components bundle */
+    __ABLY_CHAT_REACT_UI_COMPONENTS_VERSION__?: string;
+  }
+  // eslint-disable-next-line no-var
+  var __ABLY_CHAT_REACT_UI_COMPONENTS_VERSION__: string | undefined;
+}

--- a/src/react/providers/chat-client-provider.tsx
+++ b/src/react/providers/chat-client-provider.tsx
@@ -35,15 +35,13 @@ export interface ChatClientProviderProps {
 export const ChatClientProvider = ({ children, client }: ChatClientProviderProps) => {
   const context = React.useContext(ChatClientContext);
   const value: ChatClientContextValue = React.useMemo(() => {
-    // Set the internal useReact option to true to enable React-specific agent.
-    (client as unknown as { addReactAgent(): void }).addReactAgent();
-
-    const uiKitVersion = (globalThis as Record<string, unknown>).__ABLY_CHAT_REACT_UI_COMPONENTS_VERSION__;
-    if (typeof uiKitVersion === 'string'){
-      (client as unknown as { addAgentWithVersion(agent: string, version:string): void }).addAgentWithVersion('chat-ui-kit', uiKitVersion);
+    client.addReactAgent();
+    const uiKitVersion = globalThis.__ABLY_CHAT_REACT_UI_COMPONENTS_VERSION__;
+    if (typeof uiKitVersion === 'string') {
+      client.addAgentWithVersion('chat-ui-kit', uiKitVersion);
     }
 
-    return { ...context, [DEFAULT_CHAT_CLIENT_ID]: { client: client } };
+    return { ...context, [DEFAULT_CHAT_CLIENT_ID]: { client } };
   }, [client, context]);
 
   return <ChatClientContext.Provider value={value}>{children}</ChatClientContext.Provider>;

--- a/src/react/providers/chat-client-provider.tsx
+++ b/src/react/providers/chat-client-provider.tsx
@@ -37,6 +37,12 @@ export const ChatClientProvider = ({ children, client }: ChatClientProviderProps
   const value: ChatClientContextValue = React.useMemo(() => {
     // Set the internal useReact option to true to enable React-specific agent.
     (client as unknown as { addReactAgent(): void }).addReactAgent();
+
+    const uiKitVersion = (globalThis as Record<string, unknown>).__ABLY_CHAT_REACT_UI_COMPONENTS_VERSION__;
+    if (typeof uiKitVersion === 'string'){
+      (client as unknown as { addAgentWithVersion(agent: string, version:string): void }).addAgentWithVersion('chat-ui-kit', uiKitVersion);
+    }
+
     return { ...context, [DEFAULT_CHAT_CLIENT_ID]: { client: client } };
   }, [client, context]);
 

--- a/src/react/providers/chat-client-provider.tsx
+++ b/src/react/providers/chat-client-provider.tsx
@@ -34,14 +34,20 @@ export interface ChatClientProviderProps {
  */
 export const ChatClientProvider = ({ children, client }: ChatClientProviderProps) => {
   const context = React.useContext(ChatClientContext);
+
   const value: ChatClientContextValue = React.useMemo(() => {
-    client.addReactAgent();
+    (client as unknown as { addReactAgent(): void }).addReactAgent();
+
     const uiKitVersion = globalThis.__ABLY_CHAT_REACT_UI_COMPONENTS_VERSION__;
     if (typeof uiKitVersion === 'string') {
-      client.addAgentWithVersion('chat-ui-kit', uiKitVersion);
+      (
+        client as unknown as {
+          addAgentWithVersion(agent: string, version: string): void;
+        }
+      ).addAgentWithVersion('chat-ui-kit', uiKitVersion);
     }
 
-    return { ...context, [DEFAULT_CHAT_CLIENT_ID]: { client } };
+    return { ...context, [DEFAULT_CHAT_CLIENT_ID]: { client: client } };
   }, [client, context]);
 
   return <ChatClientContext.Provider value={value}>{children}</ChatClientContext.Provider>;

--- a/test/core/chat.integration.test.ts
+++ b/test/core/chat.integration.test.ts
@@ -43,6 +43,15 @@ describe('Chat', () => {
     });
   });
 
+  it('should add an agent/version pair', () => {
+    const chat = newChatClient(testClientOptions());
+    chat.addAgentWithVersion('test-agent', '1.0.0');
+    expect((chat.realtime as RealtimeWithOptions).options.agents).toEqual({
+      'test-agent': '1.0.0',
+      'chat-js': VERSION,
+    });
+  });
+
   it('should set react channel agents', async () => {
     const chat = newChatClient(testClientOptions());
     chat.addReactAgent();

--- a/test/react/hooks/use-chat-client.test.tsx
+++ b/test/react/hooks/use-chat-client.test.tsx
@@ -50,6 +50,23 @@ describe('useChatClient', () => {
     render(<TestProvider />);
   });
 
+  it('should get the chat client from the context without error and ui kit agent if set', () => {
+    (globalThis as Record<string, unknown>).__ABLY_UI_KIT_VERSION__ = '1.0.0';
+    const chatClient = newChatClient();
+    const TestProvider = () => (
+      <ChatClientProvider client={chatClient}>
+        <TestComponent
+          callback={(client) => {
+            expect(client).toBe(chatClient);
+            const agents = (client.realtime as RealtimeWithOptions).options.agents;
+            expect(agents).toEqual({ 'chat-js': VERSION, 'chat-react': VERSION, 'chat-ui-kit': '1.0.0'});
+          }}
+        />
+      </ChatClientProvider>
+    );
+    render(<TestProvider />);
+  });
+
   it('should provide the same chat client to nested components', () => {
     let client1: ChatClient | undefined;
     let client2: ChatClient | undefined;

--- a/test/react/hooks/use-chat-client.test.tsx
+++ b/test/react/hooks/use-chat-client.test.tsx
@@ -51,7 +51,7 @@ describe('useChatClient', () => {
   });
 
   it('should get the chat client from the context without error and ui kit agent if set', () => {
-    (globalThis as Record<string, unknown>).__ABLY_UI_KIT_VERSION__ = '1.0.0';
+    (globalThis as Record<string, unknown>).__ABLY_CHAT_REACT_UI_COMPONENTS_VERSION__ = '1.0.0';
     const chatClient = newChatClient();
     const TestProvider = () => (
       <ChatClientProvider client={chatClient}>
@@ -59,7 +59,7 @@ describe('useChatClient', () => {
           callback={(client) => {
             expect(client).toBe(chatClient);
             const agents = (client.realtime as RealtimeWithOptions).options.agents;
-            expect(agents).toEqual({ 'chat-js': VERSION, 'chat-react': VERSION, 'chat-ui-kit': '1.0.0'});
+            expect(agents).toEqual({ 'chat-js': VERSION, 'chat-react': VERSION, 'chat-ui-kit': '1.0.0' });
           }}
         />
       </ChatClientProvider>


### PR DESCRIPTION
### Context

* To allow us to gain insights into ui kit usage, we need a way to append the agent onto the connection.

### Description

* Added a new method `addAgentWithVersion` to the `ChatClient` class to allow for custom agent/version handling.
* ChatClientProvider now checks globalThis to see if an expected key exists for the ui kit.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

* Explain how to test the changes in this PR.
* Provide specific steps or commands to execute.
