### PR TITLE
refactor: rename Reaction to RoomReaction

### DIFF
--- a/demo/src/components/ReactionComponent/ReactionComponent.tsx
+++ b/demo/src/components/ReactionComponent/ReactionComponent.tsx
@@ -1,6 +1,6 @@
 import { ReactionInput } from '../ReactionInput';
 import { FC, useEffect, useState } from 'react';
-import { ConnectionStatus, Reaction, RoomReactionEvent } from '@ably/chat';
+import { ConnectionStatus, RoomReaction, RoomReactionEvent } from '@ably/chat';
 import { useChatConnection, useRoom, useRoomReactions } from '@ably/chat/react';
 
 interface ReactionComponentProps {}
@@ -8,7 +8,7 @@ interface ReactionComponentProps {}
 export const ReactionComponent: FC<ReactionComponentProps> = () => {
   const [isConnected, setIsConnected] = useState(true);
   const { currentStatus } = useChatConnection();
-  const [roomReactions, setRoomReactions] = useState<Reaction[]>([]);
+  const [roomReactions, setRoomReactions] = useState<RoomReaction[]>([]);
   const { roomName } = useRoom();
   const { send: sendReaction } = useRoomReactions({
     listener: (event: RoomReactionEvent) => {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "modulereport": "tsc --noEmit --esModuleInterop scripts/moduleReport.ts && esr scripts/moduleReport.ts",
     "cspell": "cspell '{src,test}/**' './*.md'",
     "test:no-integration": "vitest run --exclude \"test/**/*.integration.test.ts?(x)\"",
-    "precommit": "npm run format:check && npm run lint && npm run cspell && npm run test:typescript"
+    "precommit": "npm run format:check && npm run lint && npm run test:typescript"
   },
   "files": [
     "dist/**",

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -1,7 +1,7 @@
 import * as Ably from 'ably';
 
 import { Message } from './message.js';
-import { Reaction } from './reaction.js';
+import { RoomReaction } from './room-reaction.js';
 
 /**
  * All chat message events.
@@ -165,7 +165,7 @@ export interface RoomReactionEvent {
   /**
    * The reaction that was received.
    */
-  readonly reaction: Reaction;
+  readonly reaction: RoomReaction;
 }
 
 /**

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -64,9 +64,9 @@ export type { Occupancy, OccupancyData, OccupancyListener } from './occupancy.js
 export type { OperationMetadata } from './operation-metadata.js';
 export type { Presence, PresenceData, PresenceEvent, PresenceListener, PresenceMember } from './presence.js';
 export type { PaginatedResult } from './query.js';
-export type { Reaction, ReactionHeaders, ReactionMetadata } from './reaction.js';
 export type { Room } from './room.js';
 export type { MessageOptions, OccupancyOptions, PresenceOptions, RoomOptions, TypingOptions } from './room-options.js';
+export type { RoomReaction, RoomReactionHeaders, RoomReactionMetadata } from './room-reaction.js';
 export type { RoomReactionListener, RoomReactions, SendReactionParams } from './room-reactions.js';
 export type { RoomStatusChange, RoomStatusListener } from './room-status.js';
 export { RoomStatus } from './room-status.js';

--- a/src/core/room-reaction-parser.ts
+++ b/src/core/room-reaction-parser.ts
@@ -1,38 +1,38 @@
 import * as Ably from 'ably';
 
-import { DefaultReaction, Reaction, ReactionHeaders, ReactionMetadata } from './reaction.js';
+import { DefaultRoomReaction, RoomReaction, RoomReactionHeaders, RoomReactionMetadata } from './room-reaction.js';
 
 interface ReactionPayload {
   data?: {
     type: unknown;
-    metadata?: ReactionMetadata;
+    metadata?: RoomReactionMetadata;
   };
   clientId?: string;
   timestamp: number;
   extras?: {
-    headers?: ReactionHeaders;
+    headers?: RoomReactionHeaders;
   };
 }
 
-export function parseReaction(message: Ably.InboundMessage, clientId?: string): Reaction {
+export function parseRoomReaction(message: Ably.InboundMessage, clientId?: string): RoomReaction {
   const reactionCreatedMessage = message as ReactionPayload;
   if (!reactionCreatedMessage.data) {
-    throw new Ably.ErrorInfo(`received incoming message without data`, 50000, 500);
+    throw new Ably.ErrorInfo(`received incoming room reaction message without data`, 50000, 500);
   }
 
   if (!reactionCreatedMessage.data.type || typeof reactionCreatedMessage.data.type !== 'string') {
-    throw new Ably.ErrorInfo('invalid reaction message with no type', 50000, 500);
+    throw new Ably.ErrorInfo('invalid room reaction message with no type', 50000, 500);
   }
 
   if (!reactionCreatedMessage.clientId) {
-    throw new Ably.ErrorInfo(`received incoming message without clientId`, 50000, 500);
+    throw new Ably.ErrorInfo(`received incoming room reaction message without clientId`, 50000, 500);
   }
 
   if (!reactionCreatedMessage.timestamp) {
-    throw new Ably.ErrorInfo(`received incoming message without timestamp`, 50000, 500);
+    throw new Ably.ErrorInfo(`received incoming room reaction message without timestamp`, 50000, 500);
   }
 
-  return new DefaultReaction(
+  return new DefaultRoomReaction(
     reactionCreatedMessage.data.type,
     reactionCreatedMessage.clientId,
     new Date(reactionCreatedMessage.timestamp),

--- a/src/core/room-reaction.ts
+++ b/src/core/room-reaction.ts
@@ -4,17 +4,17 @@ import { Metadata } from './metadata.js';
 /**
  * {@link Headers} type for chat messages.
  */
-export type ReactionHeaders = Headers;
+export type RoomReactionHeaders = Headers;
 
 /**
  * {@link Metadata} type for chat messages.
  */
-export type ReactionMetadata = Metadata;
+export type RoomReactionMetadata = Metadata;
 
 /**
  * Represents a room-level reaction.
  */
-export interface Reaction {
+export interface RoomReaction {
   /**
    * The name of the reaction, for example "like" or "love".
    */
@@ -23,12 +23,12 @@ export interface Reaction {
   /**
    * Metadata of the reaction. If no metadata was set this is an empty object.
    */
-  readonly metadata: ReactionMetadata;
+  readonly metadata: RoomReactionMetadata;
 
   /**
    * Headers of the reaction. If no headers were set this is an empty object.
    */
-  readonly headers: ReactionHeaders;
+  readonly headers: RoomReactionHeaders;
 
   /**
    * The timestamp at which the reaction was sent.
@@ -47,16 +47,16 @@ export interface Reaction {
 }
 
 /**
- * An implementation of the Reaction interface for room-level reactions.
+ * An implementation of the RoomReaction interface for room-level reactions.
  */
-export class DefaultReaction implements Reaction {
+export class DefaultRoomReaction implements RoomReaction {
   constructor(
     public readonly name: string,
     public readonly clientId: string,
     public readonly createdAt: Date,
     public readonly isSelf: boolean,
-    public readonly metadata: ReactionMetadata,
-    public readonly headers: ReactionHeaders,
+    public readonly metadata: RoomReactionMetadata,
+    public readonly headers: RoomReactionHeaders,
   ) {
     // The object is frozen after constructing to enforce readonly at runtime too
     Object.freeze(this);

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -2,9 +2,9 @@ import * as Ably from 'ably';
 
 import { RoomReactionEvent, RoomReactionEventType, RoomReactionRealtimeEventType } from './events.js';
 import { Logger } from './logger.js';
-import { Reaction, ReactionHeaders, ReactionMetadata } from './reaction.js';
-import { parseReaction } from './reaction-parser.js';
 import { messageToEphemeral } from './realtime.js';
+import { RoomReaction, RoomReactionHeaders, RoomReactionMetadata } from './room-reaction.js';
+import { parseRoomReaction } from './room-reaction-parser.js';
 import { Subscription } from './subscription.js';
 import EventEmitter, { wrap } from './utils/event-emitter.js';
 
@@ -31,7 +31,7 @@ export interface SendReactionParams {
    * validation. When reading the metadata treat it like user input.
    *
    */
-  metadata?: ReactionMetadata;
+  metadata?: RoomReactionMetadata;
 
   /**
    * Optional headers of the room reaction.
@@ -47,7 +47,7 @@ export interface SendReactionParams {
    * input.
    *
    */
-  headers?: ReactionHeaders;
+  headers?: RoomReactionHeaders;
 }
 
 /**
@@ -92,7 +92,7 @@ interface RoomReactionEventsMap {
 
 interface ReactionPayload {
   type: string;
-  metadata?: ReactionMetadata;
+  metadata?: RoomReactionMetadata;
 }
 
 /**
@@ -191,9 +191,9 @@ export class DefaultRoomReactions implements RoomReactions {
     });
   };
 
-  private _parseNewReaction(inbound: Ably.InboundMessage, clientId: string): Reaction | undefined {
+  private _parseNewReaction(inbound: Ably.InboundMessage, clientId: string): RoomReaction | undefined {
     try {
-      return parseReaction(inbound, clientId);
+      return parseRoomReaction(inbound, clientId);
     } catch (error: unknown) {
       this._logger.error(`failed to parse incoming reaction;`, {
         inbound,

--- a/test/core/room-reaction-parser.test.ts
+++ b/test/core/room-reaction-parser.test.ts
@@ -1,40 +1,40 @@
 import * as Ably from 'ably';
 import { describe, expect, it } from 'vitest';
 
-import { DefaultReaction } from '../../src/core/reaction.js';
-import { parseReaction } from '../../src/core/reaction-parser.js';
+import { DefaultRoomReaction } from '../../src/core/room-reaction.js';
+import { parseRoomReaction } from '../../src/core/room-reaction-parser.js';
 
-describe('parseReaction', () => {
+describe('parseRoomReaction', () => {
   describe.each([
     {
       description: 'message.data is undefined',
       message: {} as Ably.InboundMessage,
-      expectedError: 'received incoming message without data',
+      expectedError: 'received incoming room reaction message without data',
     },
     {
       description: 'message.data.type is undefined',
       message: { data: {}, clientId: 'client1', timestamp: 1234567890 },
-      expectedError: 'invalid reaction message with no type',
+      expectedError: 'invalid room reaction message with no type',
     },
     {
       description: 'message.data.type is not a string',
       message: { data: { type: 123 }, clientId: 'client1', timestamp: 1234567890 },
-      expectedError: 'invalid reaction message with no type',
+      expectedError: 'invalid room reaction message with no type',
     },
     {
       description: 'message.clientId is undefined',
       message: { data: { type: 'like' }, timestamp: 1234567890 },
-      expectedError: 'received incoming message without clientId',
+      expectedError: 'received incoming room reaction message without clientId',
     },
     {
       description: 'message.timestamp is undefined',
       message: { data: { type: 'like' }, clientId: 'client1' },
-      expectedError: 'received incoming message without timestamp',
+      expectedError: 'received incoming room reaction message without timestamp',
     },
   ])('should throw an error', ({ description, message, expectedError }) => {
     it(`should throw the error if ${description}`, () => {
       expect(() => {
-        parseReaction(message as Ably.InboundMessage);
+        parseRoomReaction(message as Ably.InboundMessage);
       }).toThrowErrorInfo({
         code: 50000,
         message: expectedError,
@@ -50,9 +50,9 @@ describe('parseReaction', () => {
       extras: { headers: { headerKey: 'headerValue' } },
     } as Ably.InboundMessage;
 
-    const result = parseReaction(message);
+    const result = parseRoomReaction(message);
 
-    expect(result).toBeInstanceOf(DefaultReaction);
+    expect(result).toBeInstanceOf(DefaultRoomReaction);
     expect(result.name).toBe('like');
     expect(result.clientId).toBe('client1');
     expect(result.createdAt).toEqual(new Date(1234567890));
@@ -68,7 +68,7 @@ describe('parseReaction', () => {
       timestamp: 1234567890,
     } as Ably.InboundMessage;
 
-    const result = parseReaction(message, 'client1');
+    const result = parseRoomReaction(message, 'client1');
 
     expect(result.isSelf).toBe(true);
   });

--- a/test/core/room-reactions.test.ts
+++ b/test/core/room-reactions.test.ts
@@ -4,8 +4,8 @@ import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { ChatApi } from '../../src/core/chat-api.ts';
 import { ConnectionStatus } from '../../src/core/connection.ts';
 import { RoomReactionEventType } from '../../src/core/events.ts';
-import { Reaction } from '../../src/core/reaction.ts';
 import { Room } from '../../src/core/room.ts';
+import { RoomReaction } from '../../src/core/room-reaction.ts';
 import { channelEventEmitter } from '../helper/channel.ts';
 import { makeTestLogger } from '../helper/logger.ts';
 import { makeRandomRoom } from '../helper/room.ts';
@@ -121,7 +121,7 @@ describe('Reactions', () => {
     const publishTimestamp = Date.now();
     const { room } = context;
 
-    const receivedReactions: Reaction[] = [];
+    const receivedReactions: RoomReaction[] = [];
     const { unsubscribe } = room.reactions.subscribe((event) => {
       receivedReactions.push(event.reaction);
     });
@@ -166,7 +166,7 @@ describe('Reactions', () => {
     const { room } = context;
 
     const received: string[] = [];
-    const listener = (event: { reaction: Reaction }) => {
+    const listener = (event: { reaction: RoomReaction }) => {
       received.push(event.reaction.name);
     };
     const subscription1 = room.reactions.subscribe(listener);

--- a/test/react/hooks/use-room-reactions.integration.test.tsx
+++ b/test/react/hooks/use-room-reactions.integration.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render, waitFor } from '@testing-library/react';
 import React, { useEffect } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { Reaction } from '../../../src/core/reaction.ts';
+import { RoomReaction } from '../../../src/core/room-reaction.ts';
 import { RoomReactionListener } from '../../../src/core/room-reactions.ts';
 import { RoomStatus } from '../../../src/core/room-status.ts';
 import { useRoomReactions } from '../../../src/react/hooks/use-room-reactions.ts';
@@ -28,7 +28,7 @@ describe('useRoomReactions', () => {
     await roomTwo.attach();
 
     // store the received reactions
-    const reactions: Reaction[] = [];
+    const reactions: RoomReaction[] = [];
 
     // subscribe to the reactions
     roomTwo.reactions.subscribe((event) => {
@@ -76,7 +76,7 @@ describe('useRoomReactions', () => {
     await roomTwo.attach();
 
     // store the received reactions
-    const reactions: Reaction[] = [];
+    const reactions: RoomReaction[] = [];
 
     let currentRoomStatus: RoomStatus;
 


### PR DESCRIPTION
### Context

CHADR-101.
[CHA-1039]

### Description

This pull request introduces a significant refactor to rename the `Reaction` interface and related types to `RoomReaction`. The changes span multiple files across the codebase, including core functionality, tests, and type exports. The refactor aims to improve clarity and consistency by aligning naming conventions with room-specific reactions.

### Core functionality changes:

* [`src/core/reaction.ts`](diffhunk://#diff-58e26e02e7b2b3577c57c965085b653a8bad02581a303a1ae1a383ebcfbfcb9bL7-R17): Renamed `Reaction` to `RoomReaction`, along with associated types (`ReactionHeaders`, `ReactionMetadata`) and the implementation class (`DefaultReaction` to `DefaultRoomReaction`). Updated all references accordingly. [[1]](diffhunk://#diff-58e26e02e7b2b3577c57c965085b653a8bad02581a303a1ae1a383ebcfbfcb9bL7-R17) [[2]](diffhunk://#diff-58e26e02e7b2b3577c57c965085b653a8bad02581a303a1ae1a383ebcfbfcb9bL26-R31) [[3]](diffhunk://#diff-58e26e02e7b2b3577c57c965085b653a8bad02581a303a1ae1a383ebcfbfcb9bL50-R59)
* [`src/core/reaction-parser.ts`](diffhunk://#diff-01240aa4d6d1da097a6e086386518c49d7032312a3d36a0574c558f8cabaf49eL3-R17): Updated the `parseReaction` function to use `RoomReaction` and `DefaultRoomReaction` instead of `Reaction` and `DefaultReaction`. Renamed associated types (`ReactionHeaders` to `RoomReactionHeaders`, `ReactionMetadata` to `RoomReactionMetadata`). [[1]](diffhunk://#diff-01240aa4d6d1da097a6e086386518c49d7032312a3d36a0574c558f8cabaf49eL3-R17) [[2]](diffhunk://#diff-01240aa4d6d1da097a6e086386518c49d7032312a3d36a0574c558f8cabaf49eL35-R35)
* [`src/core/room-reactions.ts`](diffhunk://#diff-dd58a9bdc638dad0b8827b58afd89feaa70a2a6c5e8dc4191822e181ecf7aeaeL5-R5): Updated interfaces and methods to replace `Reaction` with `RoomReaction` and associated types (`ReactionHeaders`, `ReactionMetadata`). [[1]](diffhunk://#diff-dd58a9bdc638dad0b8827b58afd89feaa70a2a6c5e8dc4191822e181ecf7aeaeL5-R5) [[2]](diffhunk://#diff-dd58a9bdc638dad0b8827b58afd89feaa70a2a6c5e8dc4191822e181ecf7aeaeL34-R34) [[3]](diffhunk://#diff-dd58a9bdc638dad0b8827b58afd89feaa70a2a6c5e8dc4191822e181ecf7aeaeL50-R50) [[4]](diffhunk://#diff-dd58a9bdc638dad0b8827b58afd89feaa70a2a6c5e8dc4191822e181ecf7aeaeL95-R95) [[5]](diffhunk://#diff-dd58a9bdc638dad0b8827b58afd89feaa70a2a6c5e8dc4191822e181ecf7aeaeL194-R194)

### Type exports and dependencies:

* [`src/core/index.ts`](diffhunk://#diff-dc2669ef0e27412381cdc1f36fb65119ab6e912ea36b58225471ecbb8e657b37L67-R67): Updated type exports to replace `Reaction` and related types with `RoomReaction` equivalents.
* [`src/core/events.ts`](diffhunk://#diff-0ae3ab27650283ec0a6f27e0a01dd5ee1655b7dc5d8fa3e569109862ad33d6f8L4-R4): Updated the `RoomReactionEvent` interface to use `RoomReaction` instead of `Reaction`. [[1]](diffhunk://#diff-0ae3ab27650283ec0a6f27e0a01dd5ee1655b7dc5d8fa3e569109862ad33d6f8L4-R4) [[2]](diffhunk://#diff-0ae3ab27650283ec0a6f27e0a01dd5ee1655b7dc5d8fa3e569109862ad33d6f8L168-R168)

### Component and test updates:

* [`demo/src/components/ReactionComponent/ReactionComponent.tsx`](diffhunk://#diff-d44817cc3910fe8651080114bbc5506c3cb768f9e5390d63c735d9ed6412ab6fL3-R11): Updated state and event handling to use `RoomReaction` instead of `Reaction`.
* Test files (`reaction-parser.test.ts`, `room-reactions.test.ts`, `use-room-reactions.integration.test.tsx`): Updated all test cases to reflect the new naming conventions and types. [[1]](diffhunk://#diff-a99c27973afb9fa7b9907962cea5e9d047b029214c838a14fe9d88547579f116L4-R4) [[2]](diffhunk://#diff-a99c27973afb9fa7b9907962cea5e9d047b029214c838a14fe9d88547579f116L55-R55) [[3]](diffhunk://#diff-52575df98b2e860836ceb068ca86c6429c2d3d693114b6b72d5cc79249a1c77cL7-R7) [[4]](diffhunk://#diff-52575df98b2e860836ceb068ca86c6429c2d3d693114b6b72d5cc79249a1c77cL124-R124) [[5]](diffhunk://#diff-52575df98b2e860836ceb068ca86c6429c2d3d693114b6b72d5cc79249a1c77cL169-R169) [[6]](diffhunk://#diff-20533e84f607693f60e8c11654a96219bd37fe6ccf7dae79a8f52c634dbaae16L5-R5) [[7]](diffhunk://#diff-20533e84f607693f60e8c11654a96219bd37fe6ccf7dae79a8f52c634dbaae16L31-R31) [[8]](diffhunk://#diff-20533e84f607693f60e8c11654a96219bd37fe6ccf7dae79a8f52c634dbaae16L79-R79)

### Miscellaneous:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L50-R50): Removed `cspell` from the `precommit` script to streamline checks.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).


[CHA-1039]: https://ably.atlassian.net/browse/CHA-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ