### PR TITLE
Refactor: Rename `send` and `update` names in use-messages

### DIFF
--- a/demo/src/components/ChatBoxComponent/ChatBoxComponent.tsx
+++ b/demo/src/components/ChatBoxComponent/ChatBoxComponent.tsx
@@ -15,7 +15,7 @@ export const ChatBoxComponent: FC<ChatBoxComponentProps> = () => {
   const chatClient = useChatClient();
   const clientId = chatClient.clientId;
 
-  const { historyBeforeSubscribe, deleteMessage, update, sendReaction, deleteReaction } = useMessages({
+  const { historyBeforeSubscribe, deleteMessage, updateMessage, sendReaction, deleteReaction } = useMessages({
     listener: (event: ChatMessageEvent) => {
       const message = event.message;
       switch (event.type) {
@@ -135,7 +135,7 @@ export const ChatBoxComponent: FC<ChatBoxComponentProps> = () => {
       if (!newText) {
         return;
       }
-      update(
+      updateMessage(
         message,
         message.copy({
           text: newText,
@@ -150,7 +150,7 @@ export const ChatBoxComponent: FC<ChatBoxComponentProps> = () => {
           console.warn('Failed to update message', error);
         });
     },
-    [update],
+    [updateMessage],
   );
 
   const onDeleteMessage = useCallback(

--- a/demo/src/components/MessageInput/MessageInput.tsx
+++ b/demo/src/components/MessageInput/MessageInput.tsx
@@ -7,7 +7,7 @@ import { SettingsModal } from '../SettingsModal';
 interface MessageInputProps {}
 
 export const MessageInput: FC<MessageInputProps> = ({}) => {
-  const { send } = useMessages();
+  const { sendMessage } = useMessages();
   const { keystroke, stop } = useTyping();
   const { currentStatus } = useChatConnection();
   const [shouldDisable, setShouldDisable] = useState(true);
@@ -54,7 +54,7 @@ export const MessageInput: FC<MessageInputProps> = ({}) => {
     }
 
     // send the message and reset the input field
-    send({ text: messageInputRef.current.value })
+    sendMessage({ text: messageInputRef.current.value })
       .then(() => {
         if (messageInputRef.current) {
           messageInputRef.current.value = '';

--- a/demo/src/components/ReactionComponent/ReactionComponent.tsx
+++ b/demo/src/components/ReactionComponent/ReactionComponent.tsx
@@ -10,7 +10,7 @@ export const ReactionComponent: FC<ReactionComponentProps> = () => {
   const { currentStatus } = useChatConnection();
   const [roomReactions, setRoomReactions] = useState<RoomReaction[]>([]);
   const { roomName } = useRoom();
-  const { send: sendReaction } = useRoomReactions({
+  const { sendRoomReaction } = useRoomReactions({
     listener: (event: RoomReactionEvent) => {
       setRoomReactions([...roomReactions, event.reaction]);
     },
@@ -33,7 +33,7 @@ export const ReactionComponent: FC<ReactionComponentProps> = () => {
       <div>
         <ReactionInput
           reactions={[]}
-          onSend={sendReaction}
+          onSendRoomReaction={sendRoomReaction}
           disabled={!isConnected}
         ></ReactionInput>
       </div>

--- a/demo/src/components/ReactionInput/ReactionInput.tsx
+++ b/demo/src/components/ReactionInput/ReactionInput.tsx
@@ -4,12 +4,12 @@ import { SendReactionParams } from '@ably/chat';
 interface ReactionInputProps {
   reactions: string[];
 
-  onSend(params: SendReactionParams): void;
+  onSendRoomReaction(params: SendReactionParams): void;
 
   disabled: boolean;
 }
 
-export const ReactionInput: FC<ReactionInputProps> = ({ reactions, onSend, disabled = false }) => {
+export const ReactionInput: FC<ReactionInputProps> = ({ reactions, onSendRoomReaction, disabled = false }) => {
   // set default reactions if empty or not set
   if (!reactions || reactions.length === 0) {
     reactions = ['👍', '❤️', '💥', '🚀', '👎', '💔'];
@@ -21,7 +21,7 @@ export const ReactionInput: FC<ReactionInputProps> = ({ reactions, onSend, disab
       onClick={(e) => {
         e.preventDefault();
         if (!disabled) {
-          onSend({ name: reaction });
+          onSendRoomReaction({ name: reaction });
         }
       }}
       href="#"

--- a/src/react/hooks/use-messages.ts
+++ b/src/react/hooks/use-messages.ts
@@ -37,12 +37,12 @@ export interface UseMessagesResponse extends ChatStatusResponse {
   /**
    * A shortcut to the {@link Messages.send} method.
    */
-  readonly send: Messages['send'];
+  readonly sendMessage: Messages['send'];
 
   /**
    * A shortcut to the {@link Messages.update} method.
    */
-  readonly update: Messages['update'];
+  readonly updateMessage: Messages['update'];
 
   /**
    * A shortcut to the {@link Messages.history} method.
@@ -135,7 +135,7 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
   const rawReactionsListenerRef = useEventListenerRef(params?.rawReactionsListener);
   const onDiscontinuityRef = useEventListenerRef(params?.onDiscontinuity);
 
-  const send = useCallback(
+  const sendMessage = useCallback(
     (params: SendMessageParams) => context.room.then((room) => room.messages.send(params)),
     [context],
   );
@@ -148,7 +148,7 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
     (options: QueryOptions) => context.room.then((room) => room.messages.history(options)),
     [context],
   );
-  const update = useCallback(
+  const updateMessage = useCallback(
     (serial: Serial, updateParams: UpdateMessageParams, details?: OperationDetails) =>
       context.room.then((room) => room.messages.update(serial, updateParams, details)),
     [context],
@@ -264,8 +264,8 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
     connectionError,
     roomStatus,
     roomError,
-    send,
-    update,
+    sendMessage,
+    updateMessage,
     history,
     deleteMessage,
     sendReaction,

--- a/src/react/hooks/use-room-reactions.ts
+++ b/src/react/hooks/use-room-reactions.ts
@@ -29,7 +29,7 @@ export interface UseRoomReactionsResponse extends ChatStatusResponse {
   /**
    * A shortcut to the {@link RoomReactions.send} method.
    */
-  readonly send: RoomReactions['send'];
+  readonly sendRoomReaction: RoomReactions['send'];
 
   /**
    * Provides access to the underlying {@link RoomReactions} instance of the room.
@@ -92,7 +92,7 @@ export const useRoomReactions = (params?: UseRoomReactionsParams): UseRoomReacti
     ).unmount();
   }, [context, listenerRef, logger]);
 
-  const send = useCallback(
+  const sendRoomReaction = useCallback(
     (params: SendReactionParams) => context.room.then((room) => room.reactions.send(params)),
     [context],
   );
@@ -103,6 +103,6 @@ export const useRoomReactions = (params?: UseRoomReactionsParams): UseRoomReacti
     connectionError,
     roomStatus,
     roomError,
-    send,
+    sendRoomReaction,
   };
 };

--- a/test/react/hooks/use-messages.integration.test.tsx
+++ b/test/react/hooks/use-messages.integration.test.tsx
@@ -39,11 +39,11 @@ describe('useMessages', () => {
     roomTwo.messages.subscribe((message) => messagesRoomTwo.push(message.message));
 
     const TestComponent = () => {
-      const { send, roomStatus } = useMessages();
+      const { sendMessage, roomStatus } = useMessages();
 
       useEffect(() => {
         if (roomStatus === RoomStatus.Attached) {
-          void send({ text: 'hello world' });
+          void sendMessage({ text: 'hello world' });
         }
       }, [roomStatus]);
 
@@ -84,11 +84,11 @@ describe('useMessages', () => {
     });
 
     const TestComponent = () => {
-      const { send, deleteMessage, roomStatus } = useMessages();
+      const { sendMessage, deleteMessage, roomStatus } = useMessages();
 
       useEffect(() => {
         if (roomStatus === RoomStatus.Attached) {
-          void send({ text: 'hello world' }).then((message) => {
+          void sendMessage({ text: 'hello world' }).then((message) => {
             void deleteMessage(message, {
               description: 'deleted',
               metadata: { reason: 'test' },
@@ -135,12 +135,12 @@ describe('useMessages', () => {
     });
 
     const TestComponent = () => {
-      const { send, update, roomStatus } = useMessages();
+      const { sendMessage, updateMessage, roomStatus } = useMessages();
 
       useEffect(() => {
         if (roomStatus === RoomStatus.Attached) {
-          void send({ text: 'hello world' }).then((message) => {
-            void update(
+          void sendMessage({ text: 'hello world' }).then((message) => {
+            void updateMessage(
               message.serial,
               message.copy({
                 text: 'hello universe',
@@ -541,11 +541,11 @@ describe('useMessages', () => {
     let sentMessage: Message | undefined;
 
     const TestComponent = () => {
-      const { send, sendReaction, roomStatus } = useMessages();
+      const { sendMessage, sendReaction, roomStatus } = useMessages();
 
       useEffect(() => {
         if (roomStatus === RoomStatus.Attached) {
-          void send({ text: 'hello world' }).then(async (message) => {
+          void sendMessage({ text: 'hello world' }).then(async (message) => {
             sentMessage = message;
 
             // Wait for 1 second
@@ -593,11 +593,11 @@ describe('useMessages', () => {
     let sentMessage: Message | undefined;
 
     const TestComponent = () => {
-      const { send, sendReaction, deleteReaction, roomStatus } = useMessages();
+      const { sendMessage, sendReaction, deleteReaction, roomStatus } = useMessages();
 
       useEffect(() => {
         if (roomStatus === RoomStatus.Attached) {
-          void send({ text: 'hello world' }).then(async (message) => {
+          void sendMessage({ text: 'hello world' }).then(async (message) => {
             sentMessage = message;
 
             // Wait for 1 second

--- a/test/react/hooks/use-messages.test.tsx
+++ b/test/react/hooks/use-messages.test.tsx
@@ -204,7 +204,7 @@ describe('useMessages', () => {
     });
     // call both methods and ensure they call the underlying messages methods
     await act(async () => {
-      await result.current.send({ text: 'test message' });
+      await result.current.sendMessage({ text: 'test message' });
       await result.current.history({ limit: 10 });
       await result.current.deleteMessage(message, {
         description: 'deleted',

--- a/test/react/hooks/use-room-reactions.integration.test.tsx
+++ b/test/react/hooks/use-room-reactions.integration.test.tsx
@@ -37,13 +37,13 @@ describe('useRoomReactions', () => {
 
     // the test component should send a reaction
     const TestComponent = () => {
-      const { send, roomStatus } = useRoomReactions();
+      const { sendRoomReaction, roomStatus } = useRoomReactions();
 
       // should send a reaction when mounted and the room is attached
       useEffect(() => {
         if (roomStatus !== RoomStatus.Attached) return;
-        void send({ name: 'like' });
-      }, [send, roomStatus]);
+        void sendRoomReaction({ name: 'like' });
+      }, [sendRoomReaction, roomStatus]);
 
       return null;
     };

--- a/test/react/hooks/use-room-reactions.test.tsx
+++ b/test/react/hooks/use-room-reactions.test.tsx
@@ -79,7 +79,7 @@ describe('useRoomReactions', () => {
 
     // call the send method with a 'like' reaction
     await act(async () => {
-      await result.current.send({ name: 'like' });
+      await result.current.sendRoomReaction({ name: 'like' });
     });
 
     // verify that the send method was called with the correct arguments


### PR DESCRIPTION
### Description

* Refactored the `send` and `update` method names in the `useMessages` hook to `sendMessage` and `updateMessage` for consistency with the other functions there now.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).
