### PR TITLE
refactor: rename TypingEventType values to match Swift/Kotlin

### DIFF
--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -84,12 +84,12 @@ export enum TypingEventType {
   /**
    * Event triggered when a user is typing.
    */
-  Start = 'typing.started',
+  Started = 'typing.started',
 
   /**
    * Event triggered when a user stops typing.
    */
-  Stop = 'typing.stopped',
+  Stopped = 'typing.stopped',
 }
 
 /**

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -147,7 +147,7 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
     // CHA-T8
     // attachOnSubscribe is set to false in the default channel options, so this call cannot fail
     void this._channel.subscribe(
-      [TypingEventType.Start, TypingEventType.Stop],
+      [TypingEventType.Started, TypingEventType.Stopped],
       this._internalSubscribeToEvents.bind(this),
     );
   }
@@ -258,7 +258,7 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
 
       // Perform the publish
       // CHA-T4a3
-      await this._channel.publish(ephemeralMessage(TypingEventType.Start));
+      await this._channel.publish(ephemeralMessage(TypingEventType.Started));
 
       // Start the timer after publishing
       // CHA-T4a5
@@ -304,7 +304,7 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
       }
 
       // CHA-T5d
-      await this._channel.publish(ephemeralMessage(TypingEventType.Stop));
+      await this._channel.publish(ephemeralMessage(TypingEventType.Stopped));
       this._logger.trace(`DefaultTyping.stop(); clearing timers`);
 
       // CHA-T5e
@@ -378,7 +378,7 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
   private _updateCurrentlyTyping(clientId: string, event: TypingEventType): void {
     this._logger.trace(`DefaultTyping._updateCurrentlyTyping();`, { clientId, event });
 
-    if (event === TypingEventType.Start) {
+    if (event === TypingEventType.Started) {
       this._handleTypingStart(clientId);
     } else {
       this._handleTypingStop(clientId);
@@ -415,7 +415,7 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
         currentlyTyping: new Set<string>(this._currentlyTyping.keys()),
         change: {
           clientId,
-          type: TypingEventType.Stop,
+          type: TypingEventType.Stopped,
         },
       });
     }, this._heartbeatThrottleMs + this._timeoutMs);
@@ -423,7 +423,7 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
   }
 
   /**
-   * Handles logic for TypingEventType.Start, including starting a new timeout or resetting an existing one.
+   * Handles logic for TypingEventType.Started, including starting a new timeout or resetting an existing one.
    * @param clientId
    */
   private _handleTypingStart(clientId: string): void {
@@ -452,14 +452,14 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
         currentlyTyping: new Set<string>(this._currentlyTyping.keys()),
         change: {
           clientId,
-          type: TypingEventType.Start,
+          type: TypingEventType.Started,
         },
       });
     }
   }
 
   /**
-   * Handles logic for TypingEventType.Stop, including clearing the timeout for the client.
+   * Handles logic for TypingEventType.Stopped, including clearing the timeout for the client.
    * @param clientId
    * @private
    */
@@ -484,7 +484,7 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
       currentlyTyping: new Set<string>(this._currentlyTyping.keys()),
       change: {
         clientId,
-        type: TypingEventType.Stop,
+        type: TypingEventType.Stopped,
       },
     });
   }
@@ -507,7 +507,7 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
     }
 
     // Safety check to ensure we are handling only typing events
-    if (name === TypingEventType.Start || name === TypingEventType.Stop) {
+    if (name === TypingEventType.Started || name === TypingEventType.Stopped) {
       this._updateCurrentlyTyping(clientId, name);
     } else {
       this._logger.warn(`DefaultTyping._internalSubscribeToEvents(); unrecognized event`, {

--- a/test/core/typing.integration.test.ts
+++ b/test/core/typing.integration.test.ts
@@ -129,12 +129,12 @@ describe('Typing', () => {
       await waitForTypingEvent(events, {
         type: TypingSetEventType.SetChanged,
         currentlyTyping: new Set([clientId1]),
-        change: { clientId: clientId1, type: TypingEventType.Start },
+        change: { clientId: clientId1, type: TypingEventType.Started },
       });
       await waitForTypingEvent(events, {
         type: TypingSetEventType.SetChanged,
         currentlyTyping: new Set([clientId1, clientId2]),
-        change: { clientId: clientId2, type: TypingEventType.Start },
+        change: { clientId: clientId2, type: TypingEventType.Started },
       });
       // Get the currently typing client ids
       const currentlyTypingClientIds = context.chatRoom.typing.current();
@@ -149,7 +149,7 @@ describe('Typing', () => {
       await waitForTypingEvent(events, {
         type: TypingSetEventType.SetChanged,
         currentlyTyping: new Set([clientId2]),
-        change: { clientId: clientId1, type: TypingEventType.Stop },
+        change: { clientId: clientId1, type: TypingEventType.Stopped },
       });
       // Get the currently typing client ids
       const currentlyTypingClientIdsAfterStop = context.chatRoom.typing.current();

--- a/test/core/typing.test.ts
+++ b/test/core/typing.test.ts
@@ -27,14 +27,14 @@ interface TestContext {
 const TEST_HEARTBEAT_THROTTLE_MS = 200;
 
 const startMessage: Ably.Message = {
-  name: TypingEventType.Start,
+  name: TypingEventType.Started,
   extras: {
     ephemeral: true,
   },
 };
 
 const stopMessage: Ably.Message = {
-  name: TypingEventType.Stop,
+  name: TypingEventType.Stopped,
   extras: {
     ephemeral: true,
   },
@@ -82,7 +82,7 @@ describe('Typing', () => {
 
     // Emulate a typing event
     context.emulateBackendPublish({
-      name: TypingEventType.Start,
+      name: TypingEventType.Started,
       clientId: 'some',
     });
 
@@ -413,7 +413,7 @@ describe('Typing', () => {
 
       // Emulate a typing event
       context.emulateBackendPublish({
-        name: TypingEventType.Start,
+        name: TypingEventType.Started,
         clientId: 'otherClient',
       });
 
@@ -425,7 +425,7 @@ describe('Typing', () => {
         type: TypingSetEventType.SetChanged,
         change: {
           clientId: 'otherClient',
-          type: TypingEventType.Start,
+          type: TypingEventType.Started,
         },
         currentlyTyping: new Set(['otherClient']),
       });
@@ -435,7 +435,7 @@ describe('Typing', () => {
 
       // Emulate another typing event for anotherClient
       context.emulateBackendPublish({
-        name: TypingEventType.Start,
+        name: TypingEventType.Started,
         clientId: 'anotherClient',
       });
 
@@ -458,7 +458,7 @@ describe('Typing', () => {
       [
         'no client id',
         {
-          name: TypingEventType.Start,
+          name: TypingEventType.Started,
           connectionId: '',
           id: '',
           encoding: '',
@@ -470,7 +470,7 @@ describe('Typing', () => {
       [
         'empty client id',
         {
-          name: TypingEventType.Start,
+          name: TypingEventType.Started,
           clientId: '',
           connectionId: '',
           id: '',
@@ -525,7 +525,7 @@ describe('Typing', () => {
 
       // Emulate a typing event
       context.emulateBackendPublish({
-        name: TypingEventType.Start,
+        name: TypingEventType.Started,
         clientId: 'otherClient',
       });
 
@@ -536,7 +536,7 @@ describe('Typing', () => {
         type: TypingSetEventType.SetChanged,
         change: {
           clientId: 'otherClient',
-          type: TypingEventType.Start,
+          type: TypingEventType.Started,
         },
         currentlyTyping: new Set(['otherClient']),
       });
@@ -562,7 +562,7 @@ describe('Typing', () => {
 
       // Emulate a typing event
       context.emulateBackendPublish({
-        name: TypingEventType.Start,
+        name: TypingEventType.Started,
         clientId: 'otherClient',
       });
 
@@ -573,7 +573,7 @@ describe('Typing', () => {
         type: TypingSetEventType.SetChanged,
         change: {
           clientId: 'otherClient',
-          type: TypingEventType.Start,
+          type: TypingEventType.Started,
         },
         currentlyTyping: new Set(['otherClient']),
       });
@@ -585,7 +585,7 @@ describe('Typing', () => {
 
       // Now send another typing event
       context.emulateBackendPublish({
-        name: TypingEventType.Start,
+        name: TypingEventType.Started,
         clientId: 'otherClient',
       });
 
@@ -612,7 +612,7 @@ describe('Typing', () => {
 
       // Emulate a typing event
       context.emulateBackendPublish({
-        name: TypingEventType.Start,
+        name: TypingEventType.Started,
         clientId: 'otherClient',
       });
 
@@ -623,7 +623,7 @@ describe('Typing', () => {
         type: TypingSetEventType.SetChanged,
         change: {
           clientId: 'otherClient',
-          type: TypingEventType.Start,
+          type: TypingEventType.Started,
         },
         currentlyTyping: new Set(['otherClient']),
       });
@@ -643,7 +643,7 @@ describe('Typing', () => {
         type: TypingSetEventType.SetChanged,
         change: {
           clientId: 'otherClient',
-          type: TypingEventType.Stop,
+          type: TypingEventType.Stopped,
         },
         currentlyTyping: new Set(),
       });
@@ -661,7 +661,7 @@ describe('Typing', () => {
 
       // Emulate a typing event
       context.emulateBackendPublish({
-        name: TypingEventType.Start,
+        name: TypingEventType.Started,
         clientId: 'otherClient',
       });
 
@@ -672,7 +672,7 @@ describe('Typing', () => {
         type: TypingSetEventType.SetChanged,
         change: {
           clientId: 'otherClient',
-          type: TypingEventType.Start,
+          type: TypingEventType.Started,
         },
         currentlyTyping: new Set(['otherClient']),
       });
@@ -684,7 +684,7 @@ describe('Typing', () => {
 
       // Emulate a typing stop event
       context.emulateBackendPublish({
-        name: TypingEventType.Stop,
+        name: TypingEventType.Stopped,
         clientId: 'otherClient',
       });
 
@@ -695,7 +695,7 @@ describe('Typing', () => {
         type: TypingSetEventType.SetChanged,
         change: {
           clientId: 'otherClient',
-          type: TypingEventType.Stop,
+          type: TypingEventType.Stopped,
         },
         currentlyTyping: new Set(),
       });
@@ -716,7 +716,7 @@ describe('Typing', () => {
 
       // Emulate a typing stop event
       context.emulateBackendPublish({
-        name: TypingEventType.Stop,
+        name: TypingEventType.Stopped,
         clientId: 'otherClient',
       });
 
@@ -744,15 +744,15 @@ describe('Typing', () => {
       const subscription2 = room.typing.subscribe(listener);
 
       // Both subscriptions should trigger the listener
-      emulateTypingEvent('user1', TypingEventType.Start);
+      emulateTypingEvent('user1', TypingEventType.Started);
       await waitForArrayLength(received, 2);
 
       // Unsubscribe first subscription
       subscription1.unsubscribe();
 
       // One subscription should still trigger the listener
-      emulateTypingEvent('user2', TypingEventType.Start);
-      emulateTypingEvent('user2', TypingEventType.Start);
+      emulateTypingEvent('user2', TypingEventType.Started);
+      emulateTypingEvent('user2', TypingEventType.Started);
       await waitForArrayLength(received, 3);
 
       // Unsubscribe second subscription
@@ -775,7 +775,7 @@ describe('Typing', () => {
 
       // Add a typing user to the state
       context.emulateBackendPublish({
-        name: TypingEventType.Start,
+        name: TypingEventType.Started,
         clientId: 'user1',
       });
       expect(defaultTyping._currentlyTyping.get('user1')).toBeDefined();

--- a/test/react/hooks/use-typing.test.tsx
+++ b/test/react/hooks/use-typing.test.tsx
@@ -93,7 +93,7 @@ describe('useTyping', () => {
     // verify that subscribe was called with the mock listener on mount by triggering an event
     const typingEvent: TypingSetEvent = {
       type: TypingSetEventType.SetChanged,
-      change: { clientId: 'someClientId', type: TypingEventType.Stop },
+      change: { clientId: 'someClientId', type: TypingEventType.Stopped },
       currentlyTyping: new Set<string>(),
     };
     for (const listener of mockTyping.listeners) {
@@ -170,7 +170,7 @@ describe('useTyping', () => {
       if (subscribedListener) {
         subscribedListener({
           type: TypingSetEventType.SetChanged,
-          change: { clientId: 'user2', type: TypingEventType.Start },
+          change: { clientId: 'user2', type: TypingEventType.Started },
           currentlyTyping: testSet,
         });
       }


### PR DESCRIPTION
### Context

[CHA-1051]

### Description

Updated TypingEventType enum values from 'Start' to 'Started' and 'Stop' to 'Stopped' to enhance clarity and maintain consistency across the SDKs (Kotlin and Swift both do this... and it reads better).

This was a mishap on the original V1 API review changes.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A


[CHA-1051]: https://ably.atlassian.net/browse/CHA-1051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ