### PR TITLE
refactor: remove opinionated presence structure

### DIFF
--- a/test/core/presence.integration.test.ts
+++ b/test/core/presence.integration.test.ts
@@ -1,12 +1,10 @@
-// Import necessary modules and dependencies
-import { PresenceMember } from '@ably/chat';
 import * as Ably from 'ably';
 import { PresenceAction, Realtime } from 'ably';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatClient } from '../../src/core/chat.ts';
 import { PresenceEventType } from '../../src/core/events.ts';
-import { PresenceData, PresenceEvent } from '../../src/core/presence.ts';
+import { PresenceData, PresenceEvent, PresenceMember } from '../../src/core/presence.ts';
 import { Room } from '../../src/core/room.ts';
 import { newChatClient } from '../helper/chat.ts';
 import { waitForExpectedPresenceEvent } from '../helper/common.ts';

--- a/test/react/hooks/use-presence-listener.test.tsx
+++ b/test/react/hooks/use-presence-listener.test.tsx
@@ -109,7 +109,9 @@ describe('usePresenceListener', () => {
         clientId: 'client1',
         data: undefined,
         extras: undefined,
-        updatedAt: Date.now(),
+        updatedAt: new Date(),
+        connectionId: 'connection1',
+        encoding: 'json',
       },
     };
     for (const listener of presenceListeners) {
@@ -150,13 +152,17 @@ describe('usePresenceListener', () => {
         clientId: 'client1',
         data: undefined,
         extras: undefined,
-        updatedAt: Date.now(),
+        updatedAt: new Date(),
+        connectionId: 'connection1',
+        encoding: 'json',
       },
       {
         clientId: 'client2',
         data: undefined,
         extras: undefined,
-        updatedAt: Date.now(),
+        updatedAt: new Date(),
+        connectionId: 'connection1',
+        encoding: 'json',
       },
     ];
 
@@ -247,7 +253,9 @@ describe('usePresenceListener', () => {
         clientId: 'client1',
         data: undefined,
         extras: undefined,
-        updatedAt: Date.now(),
+        updatedAt: new Date(),
+        connectionId: 'connection1',
+        encoding: 'json',
       },
     };
 
@@ -308,7 +316,9 @@ describe('usePresenceListener', () => {
             clientId: 'client1',
             data: undefined,
             extras: undefined,
-            updatedAt: Date.now(),
+            updatedAt: new Date(),
+            connectionId: 'connection1',
+            encoding: 'json',
           },
         ]);
       }
@@ -321,7 +331,9 @@ describe('usePresenceListener', () => {
         clientId: 'client1',
         data: undefined,
         extras: undefined,
-        updatedAt: Date.now(),
+        updatedAt: new Date(),
+        connectionId: 'connection1',
+        encoding: 'json',
       },
     });
 
@@ -377,7 +389,9 @@ describe('usePresenceListener', () => {
         clientId: 'client1',
         data: undefined,
         extras: undefined,
-        updatedAt: Date.now(),
+        updatedAt: new Date(),
+        connectionId: 'connection1',
+        encoding: 'json',
       },
     ];
 
@@ -386,7 +400,9 @@ describe('usePresenceListener', () => {
         clientId: 'client2',
         data: undefined,
         extras: undefined,
-        updatedAt: Date.now(),
+        updatedAt: new Date(),
+        connectionId: 'connection1',
+        encoding: 'json',
       },
     ];
 
@@ -417,7 +433,9 @@ describe('usePresenceListener', () => {
         clientId: 'client1',
         data: undefined,
         extras: undefined,
-        updatedAt: Date.now(),
+        updatedAt: new Date(),
+        connectionId: 'connection1',
+        encoding: 'json',
       },
     });
 
@@ -433,7 +451,9 @@ describe('usePresenceListener', () => {
         clientId: 'client2',
         data: undefined,
         extras: undefined,
-        updatedAt: Date.now(),
+        updatedAt: new Date(),
+        connectionId: 'connection1',
+        encoding: 'json',
       },
     });
 


### PR DESCRIPTION
### Context

[CHA-1053]

### Description

This change removes the userCustomData key from presence and takes an unopinionated view on how presence should look.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A


[CHA-1053]: https://ably.atlassian.net/browse/CHA-1053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified presence data handling by removing nested wrappers and standardizing the structure of presence data.
  * Updated the timestamp format for presence events to use Date objects instead of numeric values.

* **Tests**
  * Updated tests to reflect the new, flattened presence data structure.
  * Adjusted test expectations for timestamp and additional presence member properties.
  * Improved test clarity with more accurate comments and consistent data formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->