### PR TITLE
refactor: change add to send in message reactions

### DIFF
--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -92,9 +92,9 @@ interface DeleteMessageParams {
 }
 
 /**
- * Parameters for adding a message reaction.
+ * Parameters for sending a message reaction.
  */
-export interface AddMessageReactionParams {
+export interface SendMessageReactionParams {
   /**
    * The type of reaction, must be one of {@link MessageReactionType}.
    */
@@ -235,7 +235,7 @@ export class ChatApi {
     );
   }
 
-  addMessageReaction(roomName: string, serial: string, data: AddMessageReactionParams): Promise<void> {
+  sendMessageReaction(roomName: string, serial: string, data: SendMessageReactionParams): Promise<void> {
     const encodedSerial = encodeURIComponent(serial);
     roomName = encodeURIComponent(roomName);
     return this._makeAuthorizedRequest(`/chat/v3/rooms/${roomName}/messages/${encodedSerial}/reactions`, 'POST', data);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -53,11 +53,11 @@ export type {
 } from './messages.js';
 export { OrderBy } from './messages.js';
 export type {
-  AddMessageReactionParams,
   DeleteMessageReactionParams,
   MessageRawReactionListener,
   MessageReactionListener,
   MessagesReactions,
+  SendMessageReactionParams,
 } from './messages-reactions.js';
 export type { Metadata } from './metadata.js';
 export type { Occupancy, OccupancyListener } from './occupancy.js';

--- a/src/core/messages-reactions.ts
+++ b/src/core/messages-reactions.ts
@@ -2,9 +2,9 @@ import * as Ably from 'ably';
 
 import { ChannelOptionsMerger } from './channel-manager.js';
 import {
-  AddMessageReactionParams as APIAddMessageReactionParams,
   ChatApi,
   DeleteMessageReactionParams as APIDeleteMessageReactionParams,
+  SendMessageReactionParams as APISendMessageReactionParams,
 } from './chat-api.js';
 import {
   AnnotationTypeToReactionType,
@@ -35,11 +35,11 @@ export type MessageReactionListener = (event: MessageReactionSummaryEvent) => vo
 export type MessageRawReactionListener = (event: MessageReactionRawEvent) => void;
 
 /**
- * Parameters for adding a message reaction.
+ * Parameters for sending a message reaction.
  */
-export interface AddMessageReactionParams {
+export interface SendMessageReactionParams {
   /**
-   * The reaction name to add; ie. the emoji.
+   * The reaction name to send; ie. the emoji.
    */
   name: string;
 
@@ -75,16 +75,16 @@ export interface DeleteMessageReactionParams {
 }
 
 /**
- * Add, delete, and subscribe to message reactions.
+ * Send, delete, and subscribe to message reactions.
  */
 export interface MessagesReactions {
   /**
-   * Add a message reactions
-   * @param messageSerial The serial of the message to react to
-   * @param params Describe the reaction to add.
-   * @returns A promise that resolves when the reaction is added.
+   * Send a message reaction.
+   * @param messageSerial The serial of the message to react to.
+   * @param params Describe the reaction to send.
+   * @returns A promise that resolves when the reaction is sent.
    */
-  send(messageSerial: Serial, params: AddMessageReactionParams): Promise<void>;
+  send(messageSerial: Serial, params: SendMessageReactionParams): Promise<void>;
 
   /**
    * Delete a message reaction
@@ -216,8 +216,8 @@ export class DefaultMessageReactions implements MessagesReactions {
   /**
    * @inheritDoc
    */
-  send(messageSerial: Serial, params: AddMessageReactionParams): Promise<void> {
-    this._logger.trace('MessagesReactions.add();', { messageSerial, params });
+  send(messageSerial: Serial, params: SendMessageReactionParams): Promise<void> {
+    this._logger.trace('MessagesReactions.send();', { messageSerial, params });
     const serial = serialToString(messageSerial);
 
     let { type, count } = params;
@@ -227,11 +227,11 @@ export class DefaultMessageReactions implements MessagesReactions {
     if (type === MessageReactionType.Multiple && !count) {
       count = 1;
     }
-    const apiParams: APIAddMessageReactionParams = { type, name: params.name };
+    const apiParams: APISendMessageReactionParams = { type, name: params.name };
     if (count) {
       apiParams.count = count;
     }
-    return this._api.addMessageReaction(this._roomName, serial, apiParams);
+    return this._api.sendMessageReaction(this._roomName, serial, apiParams);
   }
 
   /**

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -297,7 +297,7 @@ export interface Messages {
   update(serial: Serial, updateParams: UpdateMessageParams, details?: OperationDetails): Promise<Message>;
 
   /**
-   * Add, delete, and subscribe to message reactions.
+   * Send, delete, and subscribe to message reactions.
    */
   reactions: MessagesReactions;
 }

--- a/src/react/hooks/use-messages.ts
+++ b/src/react/hooks/use-messages.ts
@@ -12,10 +12,10 @@ import {
   UpdateMessageParams,
 } from '../../core/messages.js';
 import type {
-  AddMessageReactionParams,
   DeleteMessageReactionParams,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   MessagesReactions,
+  SendMessageReactionParams,
 } from '../../core/messages-reactions.js'; // imported for typedoc links
 import { MessageRawReactionListener, MessageReactionListener } from '../../core/messages-reactions.js';
 import { Serial } from '../../core/serial.js';
@@ -155,7 +155,7 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
   );
 
   const sendReaction: Messages['reactions']['send'] = useCallback(
-    (serial: Serial, params: AddMessageReactionParams) =>
+    (serial: Serial, params: SendMessageReactionParams) =>
       context.room.then((room) => room.messages.reactions.send(serial, params)),
     [context],
   );

--- a/test/core/messages-reactions.test.ts
+++ b/test/core/messages-reactions.test.ts
@@ -47,31 +47,31 @@ describe('MessagesReactions', () => {
       const { chatApi } = context;
       const timestamp = Date.now();
       const serial = 'abcdefghij@' + String(timestamp) + '-123';
-      vi.spyOn(chatApi, 'addMessageReaction').mockResolvedValue();
+      vi.spyOn(chatApi, 'sendMessageReaction').mockResolvedValue();
 
       const msg = { serial: serial };
 
       await context.room.messages.reactions.send(msg, { type: MessageReactionType.Unique, name: '🥕' });
-      expect(chatApi.addMessageReaction).toHaveBeenLastCalledWith(context.room.name, serial, {
+      expect(chatApi.sendMessageReaction).toHaveBeenLastCalledWith(context.room.name, serial, {
         type: MessageReactionType.Unique,
         name: '🥕',
       });
 
       await context.room.messages.reactions.send(msg, { type: MessageReactionType.Distinct, name: '🥕' });
-      expect(chatApi.addMessageReaction).toHaveBeenLastCalledWith(context.room.name, serial, {
+      expect(chatApi.sendMessageReaction).toHaveBeenLastCalledWith(context.room.name, serial, {
         type: MessageReactionType.Distinct,
         name: '🥕',
       });
 
       await context.room.messages.reactions.send(msg, { type: MessageReactionType.Multiple, name: '🥕' });
-      expect(chatApi.addMessageReaction).toHaveBeenLastCalledWith(context.room.name, serial, {
+      expect(chatApi.sendMessageReaction).toHaveBeenLastCalledWith(context.room.name, serial, {
         type: MessageReactionType.Multiple,
         name: '🥕',
         count: 1,
       });
 
       await context.room.messages.reactions.send(msg, { type: MessageReactionType.Multiple, name: '🥕', count: 10 });
-      expect(chatApi.addMessageReaction).toHaveBeenLastCalledWith(context.room.name, serial, {
+      expect(chatApi.sendMessageReaction).toHaveBeenLastCalledWith(context.room.name, serial, {
         type: MessageReactionType.Multiple,
         name: '🥕',
         count: 10,
@@ -79,7 +79,7 @@ describe('MessagesReactions', () => {
 
       // default is distinct for AllFeaturesEnabled
       await context.room.messages.reactions.send(msg, { name: '👻' });
-      expect(chatApi.addMessageReaction).toHaveBeenLastCalledWith(context.room.name, serial, {
+      expect(chatApi.sendMessageReaction).toHaveBeenLastCalledWith(context.room.name, serial, {
         type: MessageReactionType.Distinct,
         name: '👻',
       });


### PR DESCRIPTION
### Description

Updates a few missing comments and other places to rename `add` to `send` in message reactions.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated terminology related to message reactions from "add" to "send" across the user interface and documentation.
  * Renamed relevant parameters and methods to reflect this change in all related features.

* **Documentation**
  * Improved descriptions and comments to use "send" instead of "add" for message reactions.

* **Tests**
  * Updated test cases to match the new naming conventions for sending message reactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->