### PR TITLE
Rename GetMessages to History in chat-api

### DIFF
--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -7,7 +7,7 @@ import { OccupancyData } from './occupancy-parser.js';
 import { PaginatedResult } from './query.js';
 import { messageFromRest, RestMessage } from './rest-types.js';
 
-export interface GetMessagesQueryParams {
+export interface HistoryQueryParams {
   start?: number;
   end?: number;
   orderBy?: OrderBy;
@@ -26,7 +26,7 @@ export interface GetMessagesQueryParams {
  * In the REST API, we currently use the `direction` query parameter to specify the order of messages instead
  * of orderBy. So define this type for conversion purposes.
  */
-type ApiGetMessagesQueryParams = Omit<GetMessagesQueryParams, 'orderBy'> & {
+type ApiHistoryQueryParams = Omit<HistoryQueryParams, 'orderBy'> & {
   direction?: 'forwards' | 'backwards';
 };
 
@@ -142,11 +142,11 @@ export class ChatApi {
     this._logger = logger;
   }
 
-  async getMessages(roomName: string, params: GetMessagesQueryParams): Promise<PaginatedResult<Message>> {
+  async history(roomName: string, params: HistoryQueryParams): Promise<PaginatedResult<Message>> {
     roomName = encodeURIComponent(roomName);
 
     // convert the params into internal format
-    const apiParams: ApiGetMessagesQueryParams = { ...params };
+    const apiParams: ApiHistoryQueryParams = { ...params };
     if (params.orderBy) {
       switch (params.orderBy) {
         case OrderBy.NewestFirst: {

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -397,7 +397,7 @@ export class DefaultMessages implements Messages {
     const subscriptionPointParams = await subscriptionPoint;
 
     // Query messages from the subscription point to the start of the time window
-    return this._chatApi.getMessages(this._roomName, {
+    return this._chatApi.history(this._roomName, {
       ...params,
       orderBy: OrderBy.NewestFirst,
       ...subscriptionPointParams,
@@ -495,7 +495,7 @@ export class DefaultMessages implements Messages {
    */
   async history(options: QueryOptions): Promise<PaginatedResult<Message>> {
     this._logger.trace('Messages.query();');
-    return this._chatApi.getMessages(this._roomName, options);
+    return this._chatApi.history(this._roomName, options);
   }
 
   /**

--- a/test/core/chat-api.test.ts
+++ b/test/core/chat-api.test.ts
@@ -64,7 +64,7 @@ describe('config', () => {
       }) as Promise<Ably.HttpPaginatedResponse>,
     );
 
-    await expect(chatApi.getMessages('test', {})).rejects.toBeErrorInfo({
+    await expect(chatApi.history('test', {})).rejects.toBeErrorInfo({
       message: 'test',
       code: 40000,
       statusCode: 400,
@@ -78,7 +78,7 @@ describe('config', () => {
     vi.spyOn(realtime, 'request');
 
     // @ts-expect-error Testing invalid OrderBy
-    await expect(chatApi.getMessages('test', { orderBy: 'foo' })).rejects.toBeErrorInfo({
+    await expect(chatApi.history('test', { orderBy: 'foo' })).rejects.toBeErrorInfo({
       message: 'invalid orderBy value: foo',
       code: 40000,
       statusCode: 400,

--- a/test/core/messages.test.ts
+++ b/test/core/messages.test.ts
@@ -2,7 +2,7 @@ import * as Ably from 'ably';
 import { RealtimeChannel } from 'ably';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ChatApi, GetMessagesQueryParams } from '../../src/core/chat-api.ts';
+import { ChatApi, HistoryQueryParams } from '../../src/core/chat-api.ts';
 import { ChatMessageAction, ChatMessageEvent, ChatMessageEventType } from '../../src/core/events.ts';
 import { emptyMessageReactions, Message } from '../../src/core/message.ts';
 import { OrderBy } from '../../src/core/messages.ts';
@@ -723,15 +723,13 @@ describe('Messages', () => {
 
       const { room, chatApi } = context;
 
-      vi.spyOn(chatApi, 'getMessages').mockImplementation(
-        (roomName, params): Promise<Ably.PaginatedResult<Message>> => {
-          expect(roomName).toEqual(room.name);
-          expect(params.orderBy).toEqual(testOrderBy);
-          expect(params.limit).toEqual(testLimit);
-          expect(params.fromSerial).toEqual(testAttachSerial);
-          return Promise.resolve(mockPaginatedResultWithItems([]));
-        },
-      );
+      vi.spyOn(chatApi, 'history').mockImplementation((roomName, params): Promise<Ably.PaginatedResult<Message>> => {
+        expect(roomName).toEqual(room.name);
+        expect(params.orderBy).toEqual(testOrderBy);
+        expect(params.limit).toEqual(testLimit);
+        expect(params.fromSerial).toEqual(testAttachSerial);
+        return Promise.resolve(mockPaginatedResultWithItems([]));
+      });
 
       const msgChannel = room.channel;
 
@@ -785,15 +783,13 @@ describe('Messages', () => {
 
       const { room, chatApi } = context;
 
-      vi.spyOn(chatApi, 'getMessages').mockImplementation(
-        (roomName, params): Promise<Ably.PaginatedResult<Message>> => {
-          expect(roomName).toEqual(room.name);
-          expect(params.orderBy).toEqual(testOrderBy);
-          expect(params.limit).toEqual(testLimit);
-          expect(params.fromSerial).toEqual(latestChannelSerial);
-          return Promise.resolve(mockPaginatedResultWithItems([]));
-        },
-      );
+      vi.spyOn(chatApi, 'history').mockImplementation((roomName, params): Promise<Ably.PaginatedResult<Message>> => {
+        expect(roomName).toEqual(room.name);
+        expect(params.orderBy).toEqual(testOrderBy);
+        expect(params.limit).toEqual(testLimit);
+        expect(params.fromSerial).toEqual(latestChannelSerial);
+        return Promise.resolve(mockPaginatedResultWithItems([]));
+      });
 
       const msgChannel = room.channel;
 
@@ -823,16 +819,14 @@ describe('Messages', () => {
       const testOrderBy = OrderBy.NewestFirst;
       const testLimit = 50;
 
-      let expectFunction: (roomName: string, params: GetMessagesQueryParams) => void = () => {};
+      let expectFunction: (roomName: string, params: HistoryQueryParams) => void = () => {};
 
       const { room, chatApi } = context;
 
-      vi.spyOn(chatApi, 'getMessages').mockImplementation(
-        (roomName, params): Promise<Ably.PaginatedResult<Message>> => {
-          expectFunction(roomName, params);
-          return Promise.resolve(mockPaginatedResultWithItems([]));
-        },
-      );
+      vi.spyOn(chatApi, 'history').mockImplementation((roomName, params): Promise<Ably.PaginatedResult<Message>> => {
+        expectFunction(roomName, params);
+        return Promise.resolve(mockPaginatedResultWithItems([]));
+      });
 
       const msgChannel = room.channel;
       const channel = msgChannel as RealtimeChannel & {
@@ -865,7 +859,7 @@ describe('Messages', () => {
       });
 
       // Check we are using the attachSerial
-      expectFunction = (roomName: string, params: GetMessagesQueryParams) => {
+      expectFunction = (roomName: string, params: HistoryQueryParams) => {
         expect(roomName).toEqual(room.name);
         expect(params.orderBy).toEqual(testOrderBy);
         expect(params.limit).toEqual(testLimit);
@@ -887,7 +881,7 @@ describe('Messages', () => {
       });
 
       // Check we are now using the new attachSerial
-      expectFunction = (_: string, params: GetMessagesQueryParams) => {
+      expectFunction = (_: string, params: HistoryQueryParams) => {
         expect(params.fromSerial).toEqual(secondAttachmentSerial);
       };
 
@@ -907,7 +901,7 @@ describe('Messages', () => {
       });
 
       // Check we are using the previous attachSerial
-      expectFunction = (_: string, params: GetMessagesQueryParams) => {
+      expectFunction = (_: string, params: HistoryQueryParams) => {
         expect(params.fromSerial).toEqual(secondAttachmentSerial);
       };
 
@@ -922,16 +916,14 @@ describe('Messages', () => {
       const testOrderBy = OrderBy.NewestFirst;
       const testLimit = 50;
 
-      let expectFunction: (roomName: string, params: GetMessagesQueryParams) => void = () => {};
+      let expectFunction: (roomName: string, params: HistoryQueryParams) => void = () => {};
 
       const { room, chatApi } = context;
 
-      vi.spyOn(chatApi, 'getMessages').mockImplementation(
-        (roomName, params): Promise<Ably.PaginatedResult<Message>> => {
-          expectFunction(roomName, params);
-          return Promise.resolve(mockPaginatedResultWithItems([]));
-        },
-      );
+      vi.spyOn(chatApi, 'history').mockImplementation((roomName, params): Promise<Ably.PaginatedResult<Message>> => {
+        expectFunction(roomName, params);
+        return Promise.resolve(mockPaginatedResultWithItems([]));
+      });
 
       const msgChannel = room.channel;
       const channel = msgChannel as RealtimeChannel & {
@@ -956,7 +948,7 @@ describe('Messages', () => {
       const { historyBeforeSubscribe } = room.messages.subscribe(() => {});
 
       // Check we are using the channel serial
-      expectFunction = (roomName: string, params: GetMessagesQueryParams) => {
+      expectFunction = (roomName: string, params: HistoryQueryParams) => {
         expect(roomName).toEqual(room.name);
         expect(params.orderBy).toEqual(testOrderBy);
         expect(params.limit).toEqual(testLimit);
@@ -980,7 +972,7 @@ describe('Messages', () => {
       });
 
       // Check we are using the previous channel serial
-      expectFunction = (_: string, params: GetMessagesQueryParams) => {
+      expectFunction = (_: string, params: HistoryQueryParams) => {
         expect(params.fromSerial).toEqual(firstChannelSerial);
       };
 
@@ -995,7 +987,7 @@ describe('Messages', () => {
       });
 
       // Check we are using the new attach serial
-      expectFunction = (_: string, params: GetMessagesQueryParams) => {
+      expectFunction = (_: string, params: HistoryQueryParams) => {
         expect(params.fromSerial).toEqual(secondAttachSerial);
       };
 
@@ -1012,16 +1004,14 @@ describe('Messages', () => {
       const testOrderBy = OrderBy.NewestFirst;
       const testLimit = 50;
 
-      let expectFunction: (roomName: string, params: GetMessagesQueryParams) => void = () => {};
+      let expectFunction: (roomName: string, params: HistoryQueryParams) => void = () => {};
 
       const { room, chatApi } = context;
 
-      vi.spyOn(chatApi, 'getMessages').mockImplementation(
-        (roomName, params): Promise<Ably.PaginatedResult<Message>> => {
-          expectFunction(roomName, params);
-          return Promise.resolve(mockPaginatedResultWithItems([]));
-        },
-      );
+      vi.spyOn(chatApi, 'history').mockImplementation((roomName, params): Promise<Ably.PaginatedResult<Message>> => {
+        expectFunction(roomName, params);
+        return Promise.resolve(mockPaginatedResultWithItems([]));
+      });
 
       const msgChannel = room.channel;
       const channel = msgChannel as RealtimeChannel & {
@@ -1047,7 +1037,7 @@ describe('Messages', () => {
       const { historyBeforeSubscribe } = room.messages.subscribe(() => {});
 
       // Check we are using the channel serial
-      expectFunction = (roomName: string, params: GetMessagesQueryParams) => {
+      expectFunction = (roomName: string, params: HistoryQueryParams) => {
         expect(roomName).toEqual(room.name);
         expect(params.orderBy).toEqual(testOrderBy);
         expect(params.limit).toEqual(testLimit);
@@ -1074,7 +1064,7 @@ describe('Messages', () => {
       );
 
       // Check we are using the previous channel serial
-      expectFunction = (_: string, params: GetMessagesQueryParams) => {
+      expectFunction = (_: string, params: HistoryQueryParams) => {
         expect(params.fromSerial).toEqual(firstChannelSerial);
       };
 
@@ -1092,7 +1082,7 @@ describe('Messages', () => {
       );
 
       // Check we are using the new attach serial
-      expectFunction = (_: string, params: GetMessagesQueryParams) => {
+      expectFunction = (_: string, params: HistoryQueryParams) => {
         expect(params.fromSerial).toEqual(secondAttachSerial);
       };
 
@@ -1114,7 +1104,7 @@ describe('Messages', () => {
       );
 
       // Check we are using the new attach serial
-      expectFunction = (_: string, params: GetMessagesQueryParams) => {
+      expectFunction = (_: string, params: HistoryQueryParams) => {
         expect(params.fromSerial).toEqual(channel.properties.attachSerial);
       };
 


### PR DESCRIPTION
This is for consistency with the public API and endpoint names, and because we'll add a get single message endpoint.