### PR TITLE
Add messages.get(serial) to allow fetching a single message by serial

### DIFF
--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -191,6 +191,16 @@ export class ChatApi {
     return { ...data, ...result };
   }
 
+  async getMessage(roomName: string, serial: string): Promise<Message> {
+    const encodedSerial = encodeURIComponent(serial);
+    roomName = encodeURIComponent(roomName);
+    const restMessage = await this._makeAuthorizedRequest<RestMessage>(
+      `/chat/v3/rooms/${roomName}/messages/${encodedSerial}`,
+      'GET',
+    );
+    return messageFromRest(restMessage);
+  }
+
   deleteMessage(roomName: string, serial: string, params?: DeleteMessageParams): Promise<DeleteMessageResponse> {
     const body: { description?: string; metadata?: MessageOperationMetadata } = {
       description: params?.description,

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -234,6 +234,14 @@ export interface Messages {
   history(options: QueryOptions): Promise<PaginatedResult<Message>>;
 
   /**
+   * Get a message by its serial.
+   *
+   * @param serial The serial of the message to get.
+   * @returns A promise that resolves with the message.
+   */
+  get(serial: Serial): Promise<Message>;
+
+  /**
    * Send a message in the chat room.
    *
    * This method uses the Ably Chat API endpoint for sending messages.
@@ -496,6 +504,14 @@ export class DefaultMessages implements Messages {
   async history(options: QueryOptions): Promise<PaginatedResult<Message>> {
     this._logger.trace('Messages.query();');
     return this._chatApi.history(this._roomName, options);
+  }
+
+  /**
+   * @inheritdoc Messages
+   */
+  get(serial: Serial): Promise<Message> {
+    this._logger.trace('Messages.get();', { serial });
+    return this._chatApi.getMessage(this._roomName, serialToString(serial));
   }
 
   /**

--- a/src/react/hooks/use-messages.ts
+++ b/src/react/hooks/use-messages.ts
@@ -40,6 +40,11 @@ export interface UseMessagesResponse extends ChatStatusResponse {
   readonly sendMessage: Messages['send'];
 
   /**
+   * A shortcut to the {@link Messages.get} method.
+   */
+  readonly getMessage: Messages['get'];
+
+  /**
    * A shortcut to the {@link Messages.update} method.
    */
   readonly updateMessage: Messages['update'];
@@ -139,15 +144,20 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
     (params: SendMessageParams) => context.room.then((room) => room.messages.send(params)),
     [context],
   );
+
+  const getMessage = useCallback((serial: Serial) => context.room.then((room) => room.messages.get(serial)), [context]);
+
   const deleteMessage = useCallback(
     (serial: Serial, deleteMessageParams?: DeleteMessageParams) =>
       context.room.then((room) => room.messages.delete(serial, deleteMessageParams)),
     [context],
   );
+
   const history = useCallback(
     (options: QueryOptions) => context.room.then((room) => room.messages.history(options)),
     [context],
   );
+
   const updateMessage = useCallback(
     (serial: Serial, updateParams: UpdateMessageParams, details?: OperationDetails) =>
       context.room.then((room) => room.messages.update(serial, updateParams, details)),
@@ -265,6 +275,7 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
     roomStatus,
     roomError,
     sendMessage,
+    getMessage,
     updateMessage,
     history,
     deleteMessage,


### PR DESCRIPTION
### Context

For https://ably.atlassian.net/browse/CHA-1069

### Description

Adds `Messages.get(serial)` call and the equivalent `get(roomName, serial)` in chatApi.

### Checklist

* [x] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

* Explain how to test the changes in this PR.
* Provide specific steps or commands to execute.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve a single message by its serial identifier within a specified chat room.
  * Introduced a new method in the messaging interface and hook for easy access to individual messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->