### PR TITLE
dev: add random nonce to chat client logging context

### DIFF
--- a/src/core/chat.ts
+++ b/src/core/chat.ts
@@ -2,6 +2,7 @@ import * as Ably from 'ably';
 
 import { ChatClientOptions, normalizeClientOptions, NormalizedChatClientOptions } from './config.js';
 import { Connection, DefaultConnection } from './connection.js';
+import { randomId } from './id.js';
 import { Logger, makeLogger } from './logger.js';
 import { RealtimeWithOptions } from './realtime-extensions.js';
 import { DefaultRooms, Rooms } from './rooms.js';
@@ -37,6 +38,11 @@ export class ChatClient {
   private readonly _logger: Logger;
 
   /**
+   * @internal
+   */
+  private readonly _nonce: string;
+
+  /**
    * Constructor for Chat
    * @param realtime - The Ably Realtime client.
    * @param clientOptions - The client options.
@@ -44,7 +50,11 @@ export class ChatClient {
   constructor(realtime: Ably.Realtime, clientOptions?: ChatClientOptions) {
     this._realtime = realtime;
     this._clientOptions = normalizeClientOptions(clientOptions);
-    this._logger = makeLogger(this._clientOptions);
+    this._nonce = randomId();
+    this._logger = makeLogger(this._clientOptions).withContext({
+      chatClientNonce: this._nonce,
+    });
+
     this._connection = new DefaultConnection(realtime, this._logger);
     this._rooms = new DefaultRooms(realtime, this._clientOptions, this._logger);
     this._addAgent('chat-js');


### PR DESCRIPTION
### Context

Failing tests where it's not possible to tell which chat client generated what logs.

### Description

This allows us to tie logs to specific chat clients, which makes tests easier to debug.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No end-user visible changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->