### PR TITLE
chore: release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [0.11.0](https://github.com/ably/ably-chat-js/tree/0.11.0) (2025-01-23)
+
+### Breaking Changes
+
+This release contains breaking API changes. Please see `UPGRADING.md` for full guidance on upgrading from version 0.10.0.
+
+- **useMessages Helpers Rename**: Renamed `send()` to `sendMessage()`, `send()` to `sendRoomReaction()` and `update()` to `updateMessage()` in the `useMessages` hook for clarity. [#595](https://github.com/ably/ably-chat-js/pull/595)
+- **useRoomReactions Helpers Rename**: Renamed `send()` to `sendRoomReaction()` in the `useRoomReactions` hook for clarity. [#595](https://github.com/ably/ably-chat-js/pull/595)
+- **Message Reactions Method Rename**: Renamed `add()` to `send()` in the Message Reactions interface. [#603](https://github.com/ably/ably-chat-js/pull/603)
+- **Typing Event Enum**: Renamed `TypingEventType` values to match to `Started` and `Stopped`. [#599](https://github.com/ably/ably-chat-js/pull/599)
+- **Presence Data Structure**: Updated presence member structure to include `connectionId` and changed `updatedAt` to use Date type. [#600](https://github.com/ably/ably-chat-js/pull/600)
+
+### Improvements
+
+- **React Room Management**: Improved room management in React via reference counting for better resource management. [#572](https://github.com/ably/ably-chat-js/pull/572)
+- **Logging**: Added random identifier to chat client logging context for better debugging. [#609](https://github.com/ably/ably-chat-js/pull/609)
+
 ## [0.10.0](https://github.com/ably/ably-chat-js/tree/0.10.0) (2025-01-08)
 
 ### Breaking Changes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,133 @@
 
 This guide provides detailed instructions on how to upgrade between major versions of the Chat SDK.
 
+## 0.10.x to 0.11.x
+
+### Method Renames
+
+**Expected Impact: High**
+
+Several methods have been renamed for clarity and consistency.
+
+#### useMessages Hook
+
+The `send()` and `update()` methods returned by the `useMessages` React hook have been renamed for clarity and consistency.
+
+**Before**
+
+```ts
+import { useMessages } from '@ably/chat/react`
+
+const { send, update } = useMessages();
+```
+
+**After**
+
+```ts
+import { useMessages } from '@ably/chat/react`
+
+const { sendMessage, updateMessage } = useMessages();
+```
+
+#### useRoomReactions Hook
+
+The `send()` method in the `useRoomReactions` React hook has been renamed to avoid ambiguity and clashes with `useMessages` if being used in the same component.
+
+**Before**
+
+```ts
+import { useMessages } from '@ably/chat/react`
+
+const { send } = useRoomReactions();
+```
+
+**After**
+
+```ts
+import { useMessages } from '@ably/chat/react`
+
+const { sendRoomReactions } = useRoomReactions();
+```
+
+### Typing Event Enum Values
+
+**Expected Impact: Medium**
+
+The `TypingEventType` enum values have been renamed.
+
+**Before**
+
+```ts
+import { TypingEventType } from '@ably/chat';
+
+TypingEventType.Start
+TypingEventType.Stop
+```
+
+**After**
+
+```ts
+import { TypingEventType } from '@ably/chat';
+
+TypingEventType.Started
+TypingEventType.Stopped
+```
+
+### Presence Data Structure Changes
+
+**Expected Impact: High**
+
+The presence member structure has been updated:
+
+**Before**
+
+```ts
+interface PresenceMember {
+  clientId: string;
+  data?: any;
+  updatedAt: number; // timestamp
+  // other fields...
+}
+```
+
+**After**
+
+```ts
+interface PresenceMember {
+  clientId: string;
+  connectionId: string; // New field
+  data?: any;
+  updatedAt: Date; // Now uses Date type instead of number
+  // other fields...
+}
+```
+
+#### Code Changes Required
+
+If you were accessing presence member data:
+
+**Before**
+
+```ts
+room.presence.subscribe((event) => {
+  const member = event.member;
+  const timestamp = member.updatedAt; // number
+  console.log('Updated at:', new Date(timestamp));
+});
+```
+
+**After**
+
+```ts
+room.presence.subscribe((event) => {
+  const member = event.member;
+  const date = member.updatedAt; // Date
+  const connectionId = member.connectionId; // New field available
+  console.log('Updated at:', date);
+  console.log('Connection ID:', connectionId);
+});
+```
+
 ## 0.9.x to 0.10.x
 
 ### Room Reaction Wire Protocol

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,7 +17,7 @@ The `send()` and `update()` methods returned by the `useMessages` React hook hav
 **Before**
 
 ```ts
-import { useMessages } from '@ably/chat/react`
+import { useMessages } from '@ably/chat/react';
 
 const { send, update } = useMessages();
 ```
@@ -25,7 +25,7 @@ const { send, update } = useMessages();
 **After**
 
 ```ts
-import { useMessages } from '@ably/chat/react`
+import { useMessages } from '@ably/chat/react';
 
 const { sendMessage, updateMessage } = useMessages();
 ```
@@ -37,7 +37,7 @@ The `send()` method in the `useRoomReactions` React hook has been renamed to avo
 **Before**
 
 ```ts
-import { useMessages } from '@ably/chat/react`
+import { useRoomReactions } from '@ably/chat/react';
 
 const { send } = useRoomReactions();
 ```
@@ -45,7 +45,7 @@ const { send } = useRoomReactions();
 **After**
 
 ```ts
-import { useMessages } from '@ably/chat/react`
+import { useRoomReactions } from '@ably/chat/react';
 
 const { sendRoomReactions } = useRoomReactions();
 ```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -32,7 +32,7 @@ const { sendMessage, updateMessage } = useMessages();
 
 #### useRoomReactions Hook
 
-The `send()` method in the `useRoomReactions` React hook has been renamed to avoid ambiguity and clashes with `useMessages` if being used in the same component.
+The `send()` method in the `useRoomReactions` React hook has been renamed to `sendRoomReaction()` to avoid ambiguity and clashes with `useMessages` when both hooks are used in the same component.
 
 **Before**
 

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -36,7 +36,7 @@
     },
     "..": {
       "name": "@ably/chat",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "async-mutex": "^0.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ably/chat",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ably/chat",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "async-mutex": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/chat",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Ably Chat is a set of purpose-built APIs for a host of chat features enabling you to create 1:1, 1:Many, Many:1 and Many:Many chat rooms for any scale. It is designed to meet a wide range of chat use cases, such as livestreams, in-game communication, customer support, or social interactions in SaaS products.",
   "type": "module",
   "main": "dist/chat/ably-chat.umd.cjs",

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,7 +1,7 @@
 import * as Ably from 'ably';
 
 // Update this when you release a new version
-export const VERSION = '0.10.0';
+export const VERSION = '0.11.0';
 export const CHANNEL_OPTIONS_AGENT_STRING = `chat-js/${VERSION}`;
 export const CHANNEL_OPTIONS_AGENT_STRING_REACT = `chat-react/${VERSION}`;
 // Modes required for basic message functionality


### PR DESCRIPTION
### Context

Release for chat-js 0.11.

### Description

- Update version to 0.11.0 in package.json and version.ts
- Update CHANGELOG.md with 0.11.0 changes
- Update UPGRADING.md with upgrade guidance for breaking changes
- Update demo dependencies

Breaking changes in this release:
- Method renames: send() -> sendMessage(), update() -> updateMessage()
- Room Reactions: send() -> sendRoomReaction()
- Message Reactions: add() -> send()
- API rename: GetMessages -> History
- Typing event enum values renamed
- Presence data structure updated

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry for version 0.11.0, highlighting breaking changes including method renames, enum value updates, and presence member structure changes.
  * Updated the upgrade guide with detailed migration instructions and code examples for version 0.11.0.

* **Chores**
  * Updated the package version to 0.11.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->