### PR TITLE
dev: validate using jsdoc

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,7 @@ const compat = new FlatCompat({
 
 export default [
   unicorn.configs.recommended,
+  jsdoc.configs['flat/recommended-typescript'],
   {
     ignores: [
       'demo/**',

--- a/src/core/channel.ts
+++ b/src/core/channel.ts
@@ -1,6 +1,5 @@
 /**
  * Gets the single main channel for the chat room.
- *
  * @param roomName The room name.
  * @returns  The channel name.
  */

--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -16,7 +16,6 @@ export interface HistoryQueryParams {
    * Serial indicating the starting point for message retrieval.
    * This serial is specific to the region of the channel the client is connected to. Messages published within
    * the same region of the channel are guaranteed to be received in increasing serial order.
-   *
    * @defaultValue undefined (not used if not specified)
    */
   fromSerial?: string;
@@ -108,7 +107,7 @@ export interface SendMessageReactionParams {
   /**
    * The count of the reaction for type {@link MessageReactionType.Multiple}.
    * Defaults to 1 if not set. Not supported for other reaction types.
-   * @default 1
+   * @defaultValue 1
    */
   count?: number;
 }

--- a/src/core/chat.ts
+++ b/src/core/chat.ts
@@ -63,7 +63,6 @@ export class ChatClient {
 
   /**
    * Returns the rooms object, which provides access to chat rooms.
-   *
    * @returns The rooms object.
    */
   get rooms(): Rooms {
@@ -73,7 +72,6 @@ export class ChatClient {
   /**
    * Returns the underlying connection to Ably, which can be used to monitor the client's
    * connection to Ably servers.
-   *
    * @returns The connection object.
    */
   get connection(): Connection {
@@ -82,7 +80,6 @@ export class ChatClient {
 
   /**
    * Returns the clientId of the current client.
-   *
    * @returns The clientId.
    */
   get clientId(): string {

--- a/src/core/discontinuity.ts
+++ b/src/core/discontinuity.ts
@@ -2,7 +2,6 @@ import * as Ably from 'ably';
 
 /**
  * Handler for discontinuity events
- *
  * @param error - The error that occurred to cause the discontinuity.
  */
 export type DiscontinuityListener = (error: Ably.ErrorInfo) => void;

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -49,7 +49,6 @@ export enum ErrorCode {
 
 /**
  * Returns true if the {@link Ably.ErrorInfo} code matches the provided ErrorCode value.
- *
  * @param errorInfo The error info to check.
  * @param error The error code to compare against.
  * @returns true if the error code matches, false otherwise.

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -238,7 +238,6 @@ export const AnnotationTypeToReactionType: Record<string, MessageReactionType> =
 
 /**
  * Enum representing different message reaction events in the chat system.
- * @enum {string}
  */
 export enum MessageReactionEventType {
   /**

--- a/src/core/id.ts
+++ b/src/core/id.ts
@@ -1,7 +1,6 @@
 /**
  * Generates a random string that can be used as an identifier, for instance, in identifying specific room
  * objects.
- *
  * @returns A random string that can be used as an identifier.
  */
 export const randomId = (): string => Math.random().toString(36).slice(2);

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -106,7 +106,6 @@ export type LogHandler = (message: string, level: LogLevel, context?: LogContext
 
 /**
  * A simple console logger that logs messages to the console.
- *
  * @param message The message to log.
  * @param level The log level of the message.
  * @param context - The context of the log message as key-value pairs.

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -175,9 +175,8 @@ export interface Message {
    * version of the same message, as the two may be different messages entirely.
    *
    * ```ts
-   *  !message.isNewerVersionOf(other) !== message.isOlderVersionOf(other)
+   * !message.isNewerVersionOf(other) !== message.isOlderVersionOf(other)
    * ```
-   *
    * @param message The message to compare against.
    * @returns true if the two messages are the same message (isSameAs returns true) and this message is a newer version.
    */
@@ -231,7 +230,6 @@ export interface Message {
    * Creates a new message instance with the event applied.
    *
    * NOTE: This method will not replace the message reactions if the event is of type `Message`.
-   *
    * @param event The event to be applied to the returned message.
    * @throws {@link ErrorInfo} if the event is for a different message.
    * @throws {@link ErrorInfo} if the event is a {@link ChatMessageEventType.Created}.
@@ -242,9 +240,8 @@ export interface Message {
 
   /**
    * Creates a copy of the message with fields replaced per the parameters.
-   *
    * @param params The parameters to replace in the message.
-   * @return The message copy.
+   * @returns The message copy.
    */
   copy(params?: MessageCopyParams): Message;
 }
@@ -453,7 +450,6 @@ export class DefaultMessage implements Message {
   /**
    * Get the latest message version, based on the event.
    * If "this" is the latest version, return "this", otherwise clone the message and apply the reactions.
-   *
    * @param message The message to get the latest version of
    * @returns The latest message version
    */
@@ -495,6 +491,10 @@ export class DefaultMessage implements Message {
   }
 }
 
+/**
+ * Creates an empty MessageReactions object with empty unique and distinct reaction collections.
+ * @returns An empty MessageReactions object.
+ */
 export const emptyMessageReactions = (): MessageReactions => ({
   unique: {},
   distinct: {},

--- a/src/core/messages-reactions.ts
+++ b/src/core/messages-reactions.ts
@@ -52,7 +52,7 @@ export interface SendMessageReactionParams {
   /**
    * The count of the reaction for type {@link MessageReactionType.Multiple}.
    * Defaults to 1 if not set. Not supported for other reaction types.
-   * @default 1
+   * @defaultValue 1
    */
   count?: number;
 }
@@ -104,8 +104,9 @@ export interface MessagesReactions {
 
   /**
    * Subscribe to individual reaction events.
-   * @remarks If you only need to keep track of reaction counts and clients, use
-   *  {@link subscribe} instead.
+   *
+   * If you only need to keep track of reaction counts and clients, use
+   * {@link subscribe} instead.
    * @param listener The listener to call when a message reaction event is received.
    * @returns A subscription object that should be used to unsubscribe.
    */
@@ -290,7 +291,6 @@ export class DefaultMessageReactions implements MessagesReactions {
 
   /**
    * Merges the channel options to add support for message reactions.
-   *
    * @param roomOptions The room options to merge for.
    * @returns A function that merges the channel options for the room with the ones required for presence.
    */

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -63,7 +63,6 @@ export interface QueryOptions {
   /**
    * The start of the time window to query from. If provided, the response will include
    * messages with timestamps equal to or greater than this value.
-   *
    * @defaultValue The beginning of time
    */
   start?: number;
@@ -71,14 +70,12 @@ export interface QueryOptions {
   /**
    * The end of the time window to query from. If provided, the response will include
    * messages with timestamps less than this value.
-   *
    * @defaultValue Now
    */
   end?: number;
 
   /**
    * The maximum number of messages to return in the response.
-   *
    * @defaultValue 100
    */
   limit?: number;
@@ -88,7 +85,6 @@ export interface QueryOptions {
    * If {@link OrderBy.OldestFirst}, the response will include messages from the start of the time window to the end.
    * If {@link OrderBy.NewestFirst}, the response will include messages from the end of the time window to the start.
    * If not provided, the default is {@link OrderBy.NewestFirst}.
-   *
    * @defaultValue {@link OrderBy.NewestFirst}
    */
   orderBy?: OrderBy;
@@ -203,7 +199,6 @@ export interface MessageSubscriptionResponse extends Subscription {
    * const { historyBeforeSubscribe } = room.messages.subscribe(listener);
    * await historyBeforeSubscribe({ limit: 10 });
    * ```
-   *
    * @param params Options for the history query.
    * @returns A promise that resolves with the paginated result of messages, in newest-to-oldest order.
    */
@@ -226,7 +221,6 @@ export interface Messages {
 
   /**
    * Get messages that have been previously sent to the chat room, based on the provided options.
-   *
    * @param options Options for the query.
    * @returns A promise that resolves with the paginated result of messages. This paginated result can
    * be used to fetch more messages if available.
@@ -249,7 +243,6 @@ export interface Messages {
    * Note that the Promise may resolve before OR after the message is received
    * from the realtime channel. This means you may see the message that was just
    * sent in a callback to `subscribe` before the returned promise resolves.
-   *
    * @param params an object containing {text, headers, metadata} for the message
    * to be sent. Text is required, metadata and headers are optional.
    * @returns A promise that resolves when the message was published.
@@ -274,11 +267,10 @@ export interface Messages {
    * you can simply send an update to the original message.
    * Note: This is subject to change in future versions, whereby a new permissions model will be introduced
    * and a deleted message may not be restorable in this way.
-   *
    * @returns A promise that resolves when the message was deleted.
    * @param serial - A string or object that conveys the serial of the message to delete.
    * @param deleteMessageParams - Optional details to record about the delete action.
-   * @return A promise that resolves to the deleted message.
+   * @returns A promise that resolves to the deleted message.
    */
   delete(serial: Serial, deleteMessageParams?: DeleteMessageParams): Promise<Message>;
 
@@ -296,7 +288,6 @@ export interface Messages {
    *
    * This method uses PUT-like semantics: if headers and metadata are omitted from the updateParams, then
    * the existing headers and metadata are replaced with the empty objects.
-   *
    * @param serial - A string or object that conveys the serial of the message to update.
    * @param updateParams - The parameters for updating the message.
    * @param details - Optional details to record about the update action.
@@ -333,6 +324,7 @@ export class DefaultMessages implements Messages {
   /**
    * Constructs a new `DefaultMessages` instance.
    * @param roomName The unique identifier of the room.
+   * @param options The room options for the messages.
    * @param channel An instance of the Realtime channel for the room.
    * @param chatApi An instance of the ChatApi.
    * @param clientId The client ID of the user.
@@ -380,7 +372,7 @@ export class DefaultMessages implements Messages {
   }
 
   /**
-   * @inheritdoc Messages
+   * @inheritdoc
    */
   private async _getBeforeSubscriptionStart(
     listener: MessageListener,
@@ -414,6 +406,7 @@ export class DefaultMessages implements Messages {
 
   /**
    * Handle the case where the channel experiences a detach and reattaches.
+   * @param fromResume Whether the attach is from a resume operation.
    */
   private _handleAttach(fromResume: boolean) {
     this._logger.trace(`DefaultSubscriptionManager.handleAttach();`);
@@ -430,6 +423,7 @@ export class DefaultMessages implements Messages {
 
   /**
    * Create a promise that resolves with the attachSerial of the channel or the serial of the latest message.
+   * @returns A promise that resolves to an object containing fromSerial and subscriptionPoint.
    */
   private async _resolveSubscriptionStart(): Promise<{
     fromSerial: string;
@@ -499,7 +493,7 @@ export class DefaultMessages implements Messages {
   }
 
   /**
-   * @inheritdoc Messages
+   * @inheritdoc
    */
   async history(options: QueryOptions): Promise<PaginatedResult<Message>> {
     this._logger.trace('Messages.query();');
@@ -507,7 +501,7 @@ export class DefaultMessages implements Messages {
   }
 
   /**
-   * @inheritdoc Messages
+   * @inheritdoc
    */
   get(serial: Serial): Promise<Message> {
     this._logger.trace('Messages.get();', { serial });
@@ -538,7 +532,7 @@ export class DefaultMessages implements Messages {
   }
 
   /**
-   * @inheritdoc Messages
+   * @inheritdoc
    */
   async delete(serial: Serial, params?: DeleteMessageParams): Promise<Message> {
     this._logger.trace('Messages.delete();', { params });
@@ -551,7 +545,7 @@ export class DefaultMessages implements Messages {
   }
 
   /**
-   * @inheritdoc Messages
+   * @inheritdoc
    */
   async update(serial: Serial, updateParams: UpdateMessageParams, details?: OperationDetails): Promise<Message> {
     this._logger.trace('Messages.update();', { updateParams, details });
@@ -572,7 +566,7 @@ export class DefaultMessages implements Messages {
   }
 
   /**
-   * @inheritdoc Messages
+   * @inheritdoc
    */
   subscribe(listener: MessageListener): MessageSubscriptionResponse {
     this._logger.trace('Messages.subscribe();');

--- a/src/core/occupancy-parser.ts
+++ b/src/core/occupancy-parser.ts
@@ -29,7 +29,6 @@ interface OccupancyPayload {
 
 /**
  * Parses occupancy data from an Ably message, using fallback values of 0 for invalid data.
- *
  * @param message The Ably message containing occupancy data
  * @returns Parsed occupancy data with fallback values for invalid fields
  */

--- a/src/core/occupancy.ts
+++ b/src/core/occupancy.ts
@@ -21,7 +21,6 @@ export interface Occupancy {
    *
    * Note: This requires occupancy events to be enabled via the `enableEvents` option in
    * the {@link OccupancyOptions} options provided to the room. If this is not enabled, an error will be thrown.
-   *
    * @param listener A listener to be called when the occupancy of the room changes.
    * @returns A subscription object that can be used to unsubscribe the listener.
    * @throws {Ably.ErrorInfo} If occupancy events are not enabled for this room.
@@ -30,14 +29,12 @@ export interface Occupancy {
 
   /**
    * Get the current occupancy of the chat room.
-   *
    * @returns A promise that resolves to the current occupancy of the chat room.
    */
   get(): Promise<OccupancyData>;
 
   /**
    * Get the latest occupancy data received from realtime events.
-   *
    * @returns The latest occupancy data, or undefined if no realtime events have been received yet.
    * @throws {Ably.ErrorInfo} If occupancy events are not enabled for this room.
    */
@@ -99,7 +96,7 @@ export class DefaultOccupancy implements Occupancy {
   }
 
   /**
-   * @inheritdoc Occupancy
+   * @inheritdoc
    */
   subscribe(listener: OccupancyListener): Subscription {
     this._logger.trace('Occupancy.subscribe();');
@@ -124,7 +121,7 @@ export class DefaultOccupancy implements Occupancy {
   }
 
   /**
-   * @inheritdoc Occupancy
+   * @inheritdoc
    */
   async get(): Promise<OccupancyData> {
     this._logger.trace('Occupancy.get();');
@@ -132,7 +129,7 @@ export class DefaultOccupancy implements Occupancy {
   }
 
   /**
-   * @inheritdoc Occupancy
+   * @inheritdoc
    */
   current(): OccupancyData | undefined {
     this._logger.trace('Occupancy.current();');
@@ -154,6 +151,7 @@ export class DefaultOccupancy implements Occupancy {
   /**
    * An internal listener that listens for occupancy events from the underlying channel and translates them into
    * occupancy events for the public API.
+   * @param message The inbound message containing occupancy data.
    */
   private _internalOccupancyListener(message: Ably.InboundMessage): void {
     this._logger.trace('Occupancy._internalOccupancyListener();', message);
@@ -168,7 +166,7 @@ export class DefaultOccupancy implements Occupancy {
 
   /**
    * Merges the channel options for the room with the ones required for occupancy.
-   *
+   * @param roomOptions The internal room options.
    * @returns A function that merges the channel options for the room with the ones required for occupancy.
    */
   static channelOptionMerger(roomOptions: InternalRoomOptions): ChannelOptionsMerger {

--- a/src/core/presence.ts
+++ b/src/core/presence.ts
@@ -75,41 +75,41 @@ export type PresenceListener = (event: PresenceEvent) => void;
 export interface Presence {
   /**
    * Method to get list of the current online users and returns the latest presence messages associated to it.
-   * @param {Ably.RealtimePresenceParams} params - Parameters that control how the presence set is retrieved.
+   * @param params - Parameters that control how the presence set is retrieved.
    * @throws If the room is not in the `attached` or `attaching` state.
-   * @returns {Promise<PresenceMessage[]>} or upon failure, the promise will be rejected with an {@link Ably.ErrorInfo} object which explains the error.
+   * @returns or upon failure, the promise will be rejected with an {@link Ably.ErrorInfo} object which explains the error.
    */
   get(params?: Ably.RealtimePresenceParams): Promise<PresenceMember[]>;
 
   /**
    * Method to check if user with supplied clientId is online
-   * @param {string} clientId - The client ID to check if it is present in the room.
+   * @param clientId - The client ID to check if it is present in the room.
    * @throws If the room is not in the `attached` or `attaching` state.
-   * @returns {Promise<{boolean}>} or upon failure, the promise will be rejected with an {@link Ably.ErrorInfo} object which explains the error.
+   * @returns or upon failure, the promise will be rejected with an {@link Ably.ErrorInfo} object which explains the error.
    */
   isUserPresent(clientId: string): Promise<boolean>;
 
   /**
    * Method to join room presence, will emit an enter event to all subscribers. Repeat calls will trigger more enter events.
-   * @param {PresenceData} data - The users data, a JSON serializable object that will be sent to all subscribers.
+   * @param data - The users data, a JSON serializable object that will be sent to all subscribers.
    * @throws If the room is not in the `attached` or `attaching` state.
-   * @returns {Promise<void>} or upon failure, the promise will be rejected with an {@link Ably.ErrorInfo} object which explains the error.
+   * @returns or upon failure, the promise will be rejected with an {@link Ably.ErrorInfo} object which explains the error.
    */
   enter(data?: PresenceData): Promise<void>;
 
   /**
    * Method to update room presence, will emit an update event to all subscribers. If the user is not present, it will be treated as a join event.
-   * @param {PresenceData} data - The users data, a JSON serializable object that will be sent to all subscribers.
+   * @param data - The users data, a JSON serializable object that will be sent to all subscribers.
    * @throws If the room is not in the `attached` or `attaching` state.
-   * @returns {Promise<void>} or upon failure, the promise will be rejected with an {@link Ably.ErrorInfo} object which explains the error.
+   * @returns or upon failure, the promise will be rejected with an {@link Ably.ErrorInfo} object which explains the error.
    */
   update(data?: PresenceData): Promise<void>;
 
   /**
    * Method to leave room presence, will emit a leave event to all subscribers. If the user is not present, it will be treated as a no-op.
-   * @param {PresenceData} data - The users data, a JSON serializable object that will be sent to all subscribers.
+   * @param data - The users data, a JSON serializable object that will be sent to all subscribers.
    * @throws If the room is not in the `attached` or `attaching` state.
-   * @returns {Promise<void>} or upon failure, the promise will be rejected with an {@link Ably.ErrorInfo} object which explains the error.
+   * @returns or upon failure, the promise will be rejected with an {@link Ably.ErrorInfo} object which explains the error.
    */
   leave(data?: PresenceData): Promise<void>;
 
@@ -118,7 +118,6 @@ export interface Presence {
    *
    * Note: This requires presence events to be enabled via the `enableEvents` option in
    * the {@link PresenceOptions} provided to the room. If this is not enabled, an error will be thrown.
-   *
    * @param eventOrEvents {'enter' | 'leave' | 'update' | 'present'} single event name or array of events to subscribe to
    * @param listener listener to subscribe
    * @throws An {@link Ably.ErrorInfo} with code 40000 if presence events are not enabled
@@ -130,7 +129,6 @@ export interface Presence {
    *
    * Note: This requires presence events to be enabled via the `enableEvents` option in
    * the {@link PresenceOptions} provided to the room. If this is not enabled, an error will be thrown.
-   *
    * @param listener listener to subscribe
    * @throws An {@link Ably.ErrorInfo} with code 40000 if presence events are not enabled
    */
@@ -271,8 +269,6 @@ export class DefaultPresence implements Presence {
   /**
    * Method to handle and emit presence events
    * @param member - PresenceMessage ably-js object
-   * @returns void - Emits a transformed event to all subscribers, or upon failure,
-   * the promise will be rejected with an {@link ErrorInfo} object which explains the error.
    */
   subscribeToEvents = (member: Ably.PresenceMessage) => {
     this._emitter.emit(member.action as PresenceEventType, {
@@ -283,7 +279,6 @@ export class DefaultPresence implements Presence {
 
   /**
    * Merges the channel options for the room with the ones required for presence.
-   *
    * @param roomOptions The room options to merge for.
    * @returns A function that merges the channel options for the room with the ones required for presence.
    */

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -9,35 +9,30 @@ export interface PaginatedResult<T> {
 
   /**
    * Whether there are more items to query.
-   *
    * @returns `true` if there are more items to query, `false` otherwise.
    */
   hasNext(): boolean;
 
   /**
    * Whether this is the last page of items.
-   *
    * @returns `true` if this is the last page of items, `false` otherwise.
    */
   isLast(): boolean;
 
   /**
    * Fetches the next page of items.
-   *
    * @returns A promise that resolves with the next page of items or `null` if there are no more items.
    */
   next(): Promise<PaginatedResult<T> | null>;
 
   /**
    * Fetches the first page of items.
-   *
    * @returns A promise that resolves with the first page of items.
    */
   first(): Promise<PaginatedResult<T>>;
 
   /**
    * Fetches the current page of items (the same as the current page).
-   *
    * @returns A promise that resolves with the current page of items.
    */
   current(): Promise<PaginatedResult<T>>;

--- a/src/core/realtime-extensions.ts
+++ b/src/core/realtime-extensions.ts
@@ -2,7 +2,6 @@ import * as Ably from 'ably';
 
 /**
  * Exposes the agents option in the Ably Realtime client for typescript.
- *
  * @internal
  */
 export interface RealtimeWithOptions extends Ably.Realtime {
@@ -13,7 +12,6 @@ export interface RealtimeWithOptions extends Ably.Realtime {
 
 /**
  * Exposes the channelOptions property in the Ably Realtime channel for typescript.
- *
  * @internal
  */
 export interface RealtimeChannelWithOptions extends Ably.RealtimeChannel {

--- a/src/core/realtime.ts
+++ b/src/core/realtime.ts
@@ -3,7 +3,6 @@ import * as Ably from 'ably';
 /**
  * Convenience function that takes an event name and optional data and turns it into a
  * message that the server will recognize as ephemeral.
- *
  * @param name The name of the event.
  * @param data Optional data to send with the event.
  * @returns An Ably message.
@@ -19,7 +18,6 @@ export const ephemeralMessage = (name: string, data?: unknown): Ably.Message => 
 /**
  * Takes an existing Ably message and converts it to an ephemeral message by adding
  * the ephemeral flag in the extras field.
- *
  * @param message The Ably message to convert.
  * @returns A new Ably message with the ephemeral flag set.
  */

--- a/src/core/rest-types.ts
+++ b/src/core/rest-types.ts
@@ -45,7 +45,6 @@ export interface RestMessage {
 
 /**
  * Converts a message object from its REST representation to the standard message object in the SDK.
- *
  * @param message The message to convert from REST.
  * @returns The converted message.
  */

--- a/src/core/room-lifecycle-manager.ts
+++ b/src/core/room-lifecycle-manager.ts
@@ -55,7 +55,6 @@ export class RoomLifecycleManager {
   /**
    * Sets up monitoring of channel state changes to keep room status in sync.
    * If an operation is in progress (attach/detach/release), state changes are ignored.
-   * @private
    */
   private _startMonitoringChannelState(): void {
     const channel = this._channelManager.get();
@@ -90,7 +89,6 @@ export class RoomLifecycleManager {
    * Sets up monitoring for channel discontinuities.
    * A discontinuity exists when an attached or update event comes from the channel with resume=false.
    * The first time we attach, or if we attach after an explicit detach call are not considered discontinuities.
-   * @private
    */
   private _startMonitoringDiscontinuity(): void {
     const channel = this._channelManager.get();
@@ -296,6 +294,8 @@ export class RoomLifecycleManager {
 
   /**
    * Maps an Ably channel state to a room status
+   * @param channelState The Ably channel state to map.
+   * @returns The corresponding room status.
    */
   private _mapChannelStateToRoomStatus(channelState: Ably.ChannelState): RoomStatus {
     switch (channelState) {
@@ -383,7 +383,7 @@ export class RoomLifecycleManager {
 
   /**
    * Returns whether there is currently an operation (attach/detach/release) in progress
-   * @private
+   * @returns True if an operation is in progress, false otherwise.
    */
   private _operationInProgress(): boolean {
     return this._mutex.isLocked();

--- a/src/core/room-options.ts
+++ b/src/core/room-options.ts
@@ -54,7 +54,6 @@ export interface MessageOptions {
    *
    * Note reaction summaries (aggregates) are always available regardless of
    * this setting.
-   *
    * @defaultValue false
    */
   rawMessageReactions?: boolean;
@@ -64,7 +63,6 @@ export interface MessageOptions {
    *
    * Any message reaction type can be sent regardless of this setting by specifying the `type` parameter
    * in the {@link MessagesReactions.send} method.
-   *
    * @defaultValue {@link MessageReactionType.Distinct}
    */
   defaultMessageReactionType?: MessageReactionType;
@@ -95,7 +93,6 @@ export interface OccupancyOptions {
    *
    * Note that enabling this feature will increase the number of messages received by the client as additional
    * messages will be sent by the server to indicate occupancy changes.
-   *
    * @defaultValue false
    */
   enableEvents?: boolean;
@@ -109,7 +106,6 @@ export interface PresenceOptions {
    * Whether or not the client should receive presence events from the server. This setting
    * can be disabled if you are using presence in your Chat Room, but this particular client does not
    * need to receive the messages.
-   *
    * @defaultValue true
    */
   enableEvents?: boolean;
@@ -192,7 +188,6 @@ export interface InternalRoomOptions {
 
 /**
  * Creates an {@link ErrorInfo} for invalid room configuration.
- *
  * @param reason The reason for the invalid room configuration.
  * @returns An ErrorInfo.
  */

--- a/src/core/room-reaction-parser.ts
+++ b/src/core/room-reaction-parser.ts
@@ -14,6 +14,12 @@ interface ReactionPayload {
   };
 }
 
+/**
+ * Parses a room reaction from an inbound message.
+ * @param message The inbound message containing the reaction data.
+ * @param clientId The client ID of the user.
+ * @returns The parsed room reaction.
+ */
 export const parseRoomReaction = (message: Ably.InboundMessage, clientId?: string): RoomReaction => {
   const reactionCreatedMessage = message as ReactionPayload;
 

--- a/src/core/room-reactions.ts
+++ b/src/core/room-reactions.ts
@@ -52,7 +52,6 @@ export interface SendReactionParams {
 
 /**
  * The listener function type for room-level reactions.
- *
  * @param event The reaction event that was received.
  */
 export type RoomReactionListener = (event: RoomReactionEvent) => void;
@@ -67,7 +66,6 @@ export interface RoomReactions {
    * Send a reaction to the room including some metadata.
    *
    * This method accepts parameters for a room-level reaction. It accepts an object
-   *
    * @param params an object containing {name, headers, metadata} for the room
    * reaction to be sent. Name is required, metadata and headers are optional.
    * @throws If the `Connection` is not in the `Connected` state.
@@ -79,7 +77,6 @@ export interface RoomReactions {
 
   /**
    * Subscribe to receive room-level reactions.
-   *
    * @param listener The listener function to be called when a reaction is received.
    * @returns A response object that allows you to control the subscription.
    */
@@ -130,7 +127,7 @@ export class DefaultRoomReactions implements RoomReactions {
   }
 
   /**
-   * @inheritDoc Reactions
+   * @inheritDoc
    */
   send(params: SendReactionParams): Promise<void> {
     this._logger.trace('RoomReactions.send();', params);
@@ -163,7 +160,7 @@ export class DefaultRoomReactions implements RoomReactions {
   }
 
   /**
-   * @inheritDoc Reactions
+   * @inheritDoc
    */
   subscribe(listener: RoomReactionListener): Subscription {
     this._logger.trace(`RoomReactions.subscribe();`);

--- a/src/core/room-status.ts
+++ b/src/core/room-status.ts
@@ -117,7 +117,6 @@ export interface RoomLifecycle {
 export interface InternalRoomLifecycle extends RoomLifecycle {
   /**
    * Sets the status of the room.
-   *
    * @param params The new status of the room.
    */
   setStatus(params: NewRoomStatus): void;

--- a/src/core/room.ts
+++ b/src/core/room.ts
@@ -22,49 +22,42 @@ import { DefaultTyping, Typing } from './typing.js';
 export interface Room {
   /**
    * The unique identifier of the room.
-   *
    * @returns The room name.
    */
   get name(): string;
 
   /**
    * Allows you to send, subscribe-to and query messages in the room.
-   *
    * @returns The messages instance for the room.
    */
   get messages(): Messages;
 
   /**
    * Allows you to subscribe to presence events in the room.
-   *
    * @returns The presence instance for the room.
    */
   get presence(): Presence;
 
   /**
    * Allows you to interact with room-level reactions.
-   *
    * @returns The room reactions instance for the room.
    */
   get reactions(): RoomReactions;
 
   /**
    * Allows you to interact with typing events in the room.
-   *
    * @returns The typing instance for the room.
    */
   get typing(): Typing;
 
   /**
    * Allows you to interact with occupancy metrics for the room.
-   *
    * @returns The occupancy instance for the room.
    */
   get occupancy(): Occupancy;
 
   /**
    * The current status of the room.
-   *
    * @returns The current status.
    */
   get status(): RoomStatus;
@@ -90,21 +83,18 @@ export interface Room {
    *
    * If the room enters the suspended state, then the call to attach will reject with the {@link ErrorInfo} that caused the suspension. However,
    * the room will automatically retry attaching after a delay.
-   *
    * @returns A promise that resolves when the room is attached.
    */
   attach(): Promise<void>;
 
   /**
    * Detaches from the room to stop receiving events in realtime.
-   *
    * @returns A promise that resolves when the room is detached.
    */
   detach(): Promise<void>;
 
   /**
    * Returns the room options.
-   *
    * @returns A copy of the options used to create the room.
    */
   options(): RoomOptions;
@@ -112,7 +102,6 @@ export interface Room {
   /**
    * Registers a handler that will be called whenever a discontinuity is detected in the room's connection.
    * A discontinuity occurs when the room's connection is interrupted and cannot be resumed from its previous state.
-   *
    * @param handler The function to call when a discontinuity is detected.
    * @returns An object that can be used to unregister the handler.
    */
@@ -147,14 +136,12 @@ export class DefaultRoom implements Room {
 
   /**
    * Constructs a new Room instance.
-   *
    * @param name The unique identifier of the room.
    * @param nonce A random identifier for the room instance, useful in debugging and logging.
    * @param options The options for the room.
    * @param realtime An instance of the Ably Realtime client.
    * @param chatApi An instance of the ChatApi.
    * @param logger An instance of the Logger.
-   * @param connection An instance of the Connection.
    */
   constructor(
     name: string,
@@ -224,10 +211,10 @@ export class DefaultRoom implements Room {
 
   /**
    * Gets the channel manager for the room, which handles merging channel options together and creating channels.
-   *
    * @param options The room options.
    * @param realtime  An instance of the Ably Realtime client.
    * @param logger An instance of the Logger.
+   * @returns The channel manager instance.
    */
   private _getChannelManager(options: InternalRoomOptions, realtime: Ably.Realtime, logger: Logger): ChannelManager {
     const manager = new ChannelManager(this._name, realtime, logger, options.isReactClient);
@@ -239,77 +226,77 @@ export class DefaultRoom implements Room {
   }
 
   /**
-   * @inheritdoc Room
+   * @inheritdoc
    */
   get name(): string {
     return this._name;
   }
 
   /**
-   * @inheritDoc Room
+   * @inheritDoc
    */
   options(): RoomOptions {
     return cloneDeep(this._options);
   }
 
   /**
-   * @inheritdoc Room
+   * @inheritdoc
    */
   get messages(): Messages {
     return this._messages;
   }
 
   /**
-   * @inheritdoc Room
+   * @inheritdoc
    */
   get presence(): Presence {
     return this._presence;
   }
 
   /**
-   * @inheritdoc Room
+   * @inheritdoc
    */
   get reactions(): RoomReactions {
     return this._reactions;
   }
 
   /**
-   * @inheritdoc Room
+   * @inheritdoc
    */
   get typing(): Typing {
     return this._typing;
   }
 
   /**
-   * @inheritdoc Room
+   * @inheritdoc
    */
   get occupancy(): Occupancy {
     return this._occupancy;
   }
 
   /**
-   * @inheritdoc Room
+   * @inheritdoc
    */
   get status(): RoomStatus {
     return this._lifecycle.status;
   }
 
   /**
-   * @inheritdoc Room
+   * @inheritdoc
    */
   get error(): Ably.ErrorInfo | undefined {
     return this._lifecycle.error;
   }
 
   /**
-   * @inheritdoc Room
+   * @inheritdoc
    */
   onStatusChange(listener: RoomStatusListener): StatusSubscription {
     return this._lifecycle.onChange(listener);
   }
 
   /**
-   * @inheritdoc Room
+   * @inheritdoc
    */
   async attach() {
     this._logger.trace('Room.attach();');
@@ -317,7 +304,7 @@ export class DefaultRoom implements Room {
   }
 
   /**
-   * @inheritdoc Room
+   * @inheritdoc
    */
   async detach(): Promise<void> {
     this._logger.trace('Room.detach();');
@@ -327,6 +314,7 @@ export class DefaultRoom implements Room {
   /**
    * Releases resources associated with the room.
    * We guarantee that this does not throw an error.
+   * @returns A promise that resolves when the room is released.
    */
   release(): Promise<void> {
     this._logger.trace('Room.release();');
@@ -335,7 +323,6 @@ export class DefaultRoom implements Room {
 
   /**
    * A random identifier for the room instance, useful in debugging and logging.
-   *
    * @returns The nonce.
    */
   get nonce(): string {
@@ -344,8 +331,7 @@ export class DefaultRoom implements Room {
 
   /**
    * @internal
-   *
-   * Returns the rooms lifecycle.
+   * @returns The internal room lifecycle.
    */
   get lifecycle(): InternalRoomLifecycle {
     return this._lifecycle;
@@ -353,13 +339,14 @@ export class DefaultRoom implements Room {
 
   /**
    * @internal
+   * @returns The room lifecycle manager.
    */
   get lifecycleManager(): RoomLifecycleManager {
     return this._lifecycleManager;
   }
 
   /**
-   * @inheritdoc Room
+   * @inheritdoc
    */
   onDiscontinuity(handler: DiscontinuityListener): StatusSubscription {
     this._logger.trace('Room.onDiscontinuity();');
@@ -367,7 +354,7 @@ export class DefaultRoom implements Room {
   }
 
   /**
-   * @inheritdoc Room
+   * @inheritdoc
    */
   get channel(): Ably.RealtimeChannel {
     return this._channelManager.get();

--- a/src/core/rooms.ts
+++ b/src/core/rooms.ts
@@ -25,7 +25,6 @@ export interface Rooms {
    *
    * If a call to `get` is made, followed by a subsequent call to `release` before the promise resolves, then the
    * promise will reject with an error.
-   *
    * @param name The unique identifier of the room.
    * @param options The options for the room.
    * @throws {@link ErrorInfo} if a room with the same name but different options already exists.
@@ -42,7 +41,6 @@ export interface Rooms {
    * you must call {@link Rooms.get}.
    *
    * Calling this function will abort any in-progress `get` calls for the same room.
-   *
    * @param name The unique identifier of the room.
    */
   release(name: string): Promise<void>;
@@ -93,7 +91,6 @@ export class DefaultRooms implements Rooms {
 
   /**
    * Constructs a new Rooms instance.
-   *
    * @param realtime An instance of the Ably Realtime client.
    * @param clientOptions The client options from the chat instance.
    * @param logger An instance of the Logger.
@@ -247,11 +244,9 @@ export class DefaultRooms implements Rooms {
 
   /**
    * makes a new room object
-   *
    * @param name The unique identifier of the room.
    * @param nonce A random, internal identifier useful for debugging and logging.
    * @param options The options for the room.
-   *
    * @returns DefaultRoom A new room object.
    */
   private _makeRoom(name: string, nonce: string, options: RoomOptions | undefined): DefaultRoom {

--- a/src/core/serial.ts
+++ b/src/core/serial.ts
@@ -24,7 +24,6 @@ export type Serial =
 
 /**
  * Convert a type that may contain a serial into a string.
- *
  * @param serial - The serial to convert.
  * @returns The serial as a string.
  */

--- a/src/core/subscription.ts
+++ b/src/core/subscription.ts
@@ -2,8 +2,6 @@
  * Represents a subscription that can be unsubscribed from.
  * This interface provides a way to clean up and remove subscriptions when they
  * are no longer needed.
- *
- * @interface
  * @example
  * ```typescript
  * const s = someService.subscribe();
@@ -23,8 +21,6 @@ export interface Subscription {
 /**
  * Represents a subscription to status change events that can be unsubscribed from. This
  * interface provides a way to clean up and remove subscriptions when they are no longer needed.
- *
- * @interface
  * @example
  * ```typescript
  * const s = someService.onStatusChange();

--- a/src/core/typing.ts
+++ b/src/core/typing.ts
@@ -17,7 +17,6 @@ import EventEmitter, { wrap } from './utils/event-emitter.js';
 export interface Typing {
   /**
    * Subscribe a given listener to all typing events from users in the chat room.
-   *
    * @param listener A listener to be called when the typing state of a user in the room changes.
    * @returns A response object that allows you to control the subscription to typing events.
    */
@@ -37,12 +36,11 @@ export interface Typing {
    *
    * Calls to `keystroke()` and `stop()` are serialized and will always resolve in the correct order.
    * - For example, if multiple `keystroke()` calls are made in quick succession before the first `keystroke()` call has
-   *   sent a `typing.started` event to the server, followed by one `stop()` call, the `stop()` call will execute
-   *   as soon as the first `keystroke()` call completes.
-   *   All intermediate `keystroke()` calls will be treated as no-ops.
+   * sent a `typing.started` event to the server, followed by one `stop()` call, the `stop()` call will execute
+   * as soon as the first `keystroke()` call completes.
+   * All intermediate `keystroke()` calls will be treated as no-ops.
    * - The most recent operation (`keystroke()` or `stop()`) will always determine the final state, ensuring operations
-   *   resolve to a consistent and correct state.
-   *
+   * resolve to a consistent and correct state.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link Ably.ErrorInfo} object upon its failure.
    * @throws If the `Connection` is not in the `Connected` state.
    * @throws If the operation fails to send the event to the server.
@@ -56,12 +54,11 @@ export interface Typing {
    *
    * Calls to `keystroke()` and `stop()` are serialized and will always resolve in the correct order.
    * - For example, if multiple `keystroke()` calls are made in quick succession before the first `keystroke()` call has
-   *   sent a `typing.started` event to the server, followed by one `stop()` call, the `stop()` call will execute
-   *   as soon as the first `keystroke()` call completes.
-   *   All intermediate `keystroke()` calls will be treated as no-ops.
+   * sent a `typing.started` event to the server, followed by one `stop()` call, the `stop()` call will execute
+   * as soon as the first `keystroke()` call completes.
+   * All intermediate `keystroke()` calls will be treated as no-ops.
    * - The most recent operation (`keystroke()` or `stop()`) will always determine the final state, ensuring operations
-   *   resolve to a consistent and correct state.
-   *
+   * resolve to a consistent and correct state.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link Ably.ErrorInfo} object upon its failure.
    * @throws If the `Connection` is not in the `Connected` state.
    * @throws If the operation fails to send the event to the server.
@@ -155,7 +152,6 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
   /**
    * Clears all typing states.
    * This includes clearing all timeouts and the currently typing map.
-   * @private
    */
   private _clearAllTypingStates(): void {
     this._logger.debug(`DefaultTyping._clearAllTypingStates(); clearing all typing states`);
@@ -165,7 +161,6 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
 
   /**
    * Clears the heartbeat timer.
-   * @private
    */
   private _clearHeartbeatTimer(): void {
     this._logger.trace(`DefaultTyping._clearHeartbeatTimer(); clearing heartbeat timer`);
@@ -177,7 +172,6 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
 
   /**
    * Clears the currently typing store and removes all timeouts for associated clients.
-   * @private
    */
   private _clearCurrentlyTyping(): void {
     this._logger.trace('DefaultTyping._clearCurrentlyTyping(); clearing current store and timeouts');
@@ -191,7 +185,6 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
 
   /**
    * CHA-T16
-   *
    * @inheritDoc
    */
   current(): Set<string> {
@@ -389,7 +382,8 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
    * Starts a new inactivity timer for the client.
    * This timer will expire after the configured timeout,
    * which is the sum of the heartbeat interval and the inactivity timeout.
-   * @param clientId
+   * @param clientId The client ID for which to start the timer.
+   * @returns The timeout ID for the new timer.
    */
   private _startNewClientInactivityTimer(clientId: string): ReturnType<typeof setTimeout> {
     this._logger.trace(`DefaultTyping._startNewClientInactivityTimer(); starting new inactivity timer`, {
@@ -424,7 +418,7 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
 
   /**
    * Handles logic for TypingEventType.Started, including starting a new timeout or resetting an existing one.
-   * @param clientId
+   * @param clientId The client ID that started typing.
    */
   private _handleTypingStart(clientId: string): void {
     this._logger.debug(`DefaultTyping._handleTypingStart();`, { clientId });
@@ -460,8 +454,7 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
 
   /**
    * Handles logic for TypingEventType.Stopped, including clearing the timeout for the client.
-   * @param clientId
-   * @private
+   * @param clientId The client ID that stopped typing.
    */
   private _handleTypingStop(clientId: string): void {
     const existingTimeout = this._currentlyTyping.get(clientId);
@@ -491,6 +484,7 @@ export class DefaultTyping extends EventEmitter<TypingEventsMap> implements Typi
 
   /**
    * Subscribe to internal events. This listens to events and converts them into typing updates, with validation.
+   * @param inbound The inbound message containing typing event data.
    */
   private _internalSubscribeToEvents = (inbound: Ably.InboundMessage): void => {
     const { name, clientId } = inbound;

--- a/src/react/contexts/chat-client-context.tsx
+++ b/src/react/contexts/chat-client-context.tsx
@@ -13,8 +13,7 @@ const contextKey = Symbol.for('__ABLY_CHAT_CLIENT_CONTEXT__');
 /**
  * Extends GlobalThis interface with chat context.
  * The {@link ChatClientContext} is created once and stored in the global state to ensure a single context instance.
- *
- * @property {React.Context<ChatClientContextValue> | undefined} contextKey Ably Chat client context.
+ * contextKey Ably Chat client context.
  */
 interface GlobalThis {
   [contextKey]?: React.Context<ChatClientContextValue>;
@@ -49,9 +48,7 @@ export type ChatClientContextValue = Record<string, ChatClientContextProviderPro
  * Returns a {@link ChatClientContext}.
  * Retrieve the context from the global object if initialized,
  * else, initialize and store the context in the global object.
- *
- * @return {React.Context<ChatClientContextValue>} Global context for {@link ChatClient}.
- *
+ * @returns Global context for {@link ChatClient}.
  */
 const getChatContext = (): React.Context<ChatClientContextValue> => {
   let context = globalObjectForContext[contextKey];
@@ -64,7 +61,5 @@ const getChatContext = (): React.Context<ChatClientContextValue> => {
 /**
  * Global context for {@link ChatClientProvider}.
  * Access point for {@link ChatClient} context in the application.
- *
- * @type {React.Context<ChatClientContextValue>}
  */
 export const ChatClientContext: React.Context<ChatClientContextValue> = getChatContext();

--- a/src/react/helper/room-promise.ts
+++ b/src/react/helper/room-promise.ts
@@ -51,7 +51,6 @@ class DefaultRoomPromise implements RoomPromise {
 
   /**
    * Creates a new DefaultRoomPromise and starts the resolution of the promise.
-   *
    * @param room  The promise that resolves to a Room instance.
    * @param onResolve  The callback that is called when the promise resolves to a Room instance.
    * @param logger  The logger to use for logging.
@@ -68,7 +67,6 @@ class DefaultRoomPromise implements RoomPromise {
   /**
    * Wait for the room promise to resolve, then execute the onResolve callback, storing its response as an unmount function.
    * If the component is unmounted before the promise resolves, then this will do nothing.
-   *
    * @param promise The promise that resolves to a Room instance.
    * @returns A promise that we simply resolve when it's done.
    */
@@ -96,12 +94,11 @@ class DefaultRoomPromise implements RoomPromise {
    * Example usage:
    *
    * ```ts
-   *  useEffect(() => {
-   *    const roomPromise = wrapRoomPromise(...);
-   *    return roomPromise.unmount();
-   *  }, []);
+   * useEffect(() => {
+   * const roomPromise = wrapRoomPromise(...);
+   * return roomPromise.unmount();
+   * }, []);
    * ```
-   *
    * @returns A function that should be called when the component is unmounted.
    */
   unmount() {
@@ -126,12 +123,11 @@ class DefaultRoomPromise implements RoomPromise {
  * Example usage:
  *
  * ```ts
- *  useEffect(() => {
- *    const roomPromise = wrapRoomPromise(...);
- *    return roomPromise.unmount();
- *  }, []);
+ * useEffect(() => {
+ * const roomPromise = wrapRoomPromise(...);
+ * return roomPromise.unmount();
+ * }, []);
  * ```
- *
  * @internal
  * @param room The promise that resolves to a Room instance.
  * @param onResolve The callback that is called when the promise resolves to a Room instance.

--- a/src/react/helper/room-reference-manager.ts
+++ b/src/react/helper/room-reference-manager.ts
@@ -21,6 +21,8 @@ interface RoomRefCountEntry {
 
 /**
  * Normalizes an array item by sorting the keys of the object and recursively sorting the items in the array.
+ * @param item The item to normalize.
+ * @returns The normalized item.
  */
 const normalizeArrayItem = (item: unknown): unknown => {
   if (item === null || typeof item !== 'object') {
@@ -41,6 +43,9 @@ const normalizeArrayItem = (item: unknown): unknown => {
 /**
  * Replacer function for JSON.stringify that normalizes values to ensure consistent serialization.
  * Recursively sorts object keys and array items for deterministic output.
+ * @param key The key being processed.
+ * @param value The value being processed.
+ * @returns The normalized value.
  */
 const roomKeyReplacer = (key: string, value: unknown): unknown => {
   // Handle undefined values consistently
@@ -70,6 +75,9 @@ const roomKeyReplacer = (key: string, value: unknown): unknown => {
 /**
  * Creates a unique key for a room based on name and options.
  * Ensures that objects with the same properties but different key order produce the same key.
+ * @param roomName The name of the room.
+ * @param options The room options.
+ * @returns A unique string key for the room.
  */
 const createRoomKey = (roomName: string, options?: RoomOptions): string =>
   JSON.stringify({ roomName, options }, roomKeyReplacer);
@@ -92,6 +100,7 @@ export class RoomReferenceManager {
 
   /**
    * Get the client this manager is associated with.
+   * @returns The chat client.
    */
   get client(): ChatClient {
     return this._client;
@@ -99,6 +108,9 @@ export class RoomReferenceManager {
 
   /**
    * Increment reference count for a room. Attaches on first reference.
+   * @param roomName The name of the room.
+   * @param options The room options.
+   * @returns A promise that resolves to the room instance.
    */
   async addReference(roomName: string, options?: RoomOptions): Promise<Room> {
     this._logger.trace('RoomReferenceManager.addReference();');
@@ -278,6 +290,8 @@ export class RoomReferenceManager {
 
   /**
    * Decrement reference count for a room. Releases on last reference after a delay.
+   * @param roomName The name of the room.
+   * @param options The room options.
    */
   removeReference(roomName: string, options?: RoomOptions): void {
     this._logger.trace('RoomReferenceManager.removeReference();');

--- a/src/react/helper/use-event-listener-ref.ts
+++ b/src/react/helper/use-event-listener-ref.ts
@@ -12,21 +12,21 @@ type Callback<CallbackArguments extends unknown[]> = (...args: CallbackArguments
  * For example, doing this:
  *
  * ```jsx
- *   export function MySubscription() {
- *     useHookWithListener(() => {})
+ * export function MySubscription() {
+ * useHookWithListener(() => {})
  *
- *     return <div>My Subscription</div>
- *   }
+ * return <div>My Subscription</div>
+ * }
  * ```
  *
  * Where the `useHookWithListener` hook is defined as:
  *
  * ```jsx
- *  export function useHookWithListener(listener) {
- *    const listenerRef = useEventListenerRef(listener);
- *    useEffect(() => {
- *      // Use the listenerRef
- *    }, [listenerRef]);
+ * export function useHookWithListener(listener) {
+ * const listenerRef = useEventListenerRef(listener);
+ * useEffect(() => {
+ * // Use the listenerRef
+ * }, [listenerRef]);
  * }
  * ```
  *
@@ -35,7 +35,6 @@ type Callback<CallbackArguments extends unknown[]> = (...args: CallbackArguments
  *
  * We allow for the callback to be undefined, as callbacks in the majority of our hooks are optional. In this instance we return undefined,
  * so that subscriptions will be unwound by the useEffect hook that's using them.
- *
  * @internal
  * @template Arguments - The type of arguments accepted by the callback function.
  * @param callback - The callback function to be stored in the reference.

--- a/src/react/helper/use-eventual-room.ts
+++ b/src/react/helper/use-eventual-room.ts
@@ -9,7 +9,6 @@ import { useStableReference } from './use-stable-reference.js';
  * This hook will take the room promise from the current context and return the room object once it has been resolved.
  * This is useful in hooks like useRoom to provide a direct reference to the room object, as Promises aren't usually
  * the best thing to be passing around React components.
- *
  * @internal
  * @returns The room object if it has resolved, otherwise undefined
  */
@@ -49,7 +48,7 @@ export const useEventualRoom = (): Room | undefined => {
  * Similar to useEventualRoom, but instead of providing the room itself, it provides a property of the room - e.g.
  * Messages. We use this to eventually provide access to underlying room interfaces as non-promise values
  * in hooks like useMessages.
- *
+ * @param onResolve Callback function that receives the room and returns a property of it.
  * @internal
  * @returns The property of the room object that's been resolved, as returned by the onResolve callback,
  * or undefined if the room hasn't resolved yet.

--- a/src/react/helper/use-room-context.ts
+++ b/src/react/helper/use-room-context.ts
@@ -5,7 +5,6 @@ import { ChatRoomContext, ChatRoomContextType } from '../contexts/chat-room-cont
 
 /**
  * A hook that returns the current ChatRoomContext. This should be used within a ChatRoomProvider.
- *
  * @internal
  * @param callingHook The name of the hook that is calling this function, for logging purposes.
  * @throws {@link Ably.ErrorInfo} if the hook is not used within a ChatRoomProvider.

--- a/src/react/helper/use-room-status.ts
+++ b/src/react/helper/use-room-status.ts
@@ -35,7 +35,6 @@ export interface UseRoomStatusParams {
 
 /**
  * A hook that returns the current status of the room, and listens for changes to the room status.
- *
  * @internal
  * @param params An optional user-provided listener for room status changes.
  * @returns The current status of the room, and an error if the room is in an errored state.

--- a/src/react/helper/use-stable-reference.ts
+++ b/src/react/helper/use-stable-reference.ts
@@ -9,7 +9,6 @@ type Callback<CallbackArguments extends unknown[], ReturnType> = (...args: Callb
  * In some cases, we want to use a callback that is always the same, and always persists across renders.
  * This function creates a stable reference to a callback, so that it can be used in a `useEffect` or `useCallback`
  * without causing unnecessary re-renders.
- *
  * @internal
  * @param callback The callback to turn into a stable reference
  * @returns A stable reference to the callback

--- a/src/react/hooks/use-chat-client.ts
+++ b/src/react/hooks/use-chat-client.ts
@@ -8,11 +8,8 @@ import { DEFAULT_CHAT_CLIENT_ID } from '../providers/chat-client-provider.js';
 /**
  * Hook to access the chat client provided the current {@link ChatClientProvider}.
  * This hook must be used within a {@link ChatClientProvider}.
- *
  * @throws {ErrorInfo} When the hook is not used within a {@link ChatClientProvider}.
- *
- * @returns {ChatClient} The {@link ChatClient} instance provided by the context.
- *
+ * @returns The {@link ChatClient} instance provided by the context.
  */
 export const useChatClient = (): ChatClient => {
   const context = React.useContext(ChatClientContext)[DEFAULT_CHAT_CLIENT_ID];

--- a/src/react/hooks/use-chat-connection.ts
+++ b/src/react/hooks/use-chat-connection.ts
@@ -44,7 +44,6 @@ export interface UseChatConnectionResponse {
 
 /**
  * A hook that provides the current connection status and error, and allows the user to listen to connection status changes.
- *
  * @param options - The options for the hook
  * @returns The current connection status and error, as well as the {@link Connection} instance.
  */

--- a/src/react/hooks/use-logger.ts
+++ b/src/react/hooks/use-logger.ts
@@ -7,7 +7,6 @@ import { useChatClient } from './use-chat-client.js';
  * A hook that provides access to the {@link Logger} instance of the {@link ChatClient}.
  * It will use the instance belonging to the {@link ChatClient} in the nearest {@link ChatClientProvider} in the component tree.
  * @internal
- *
  * @returns Logger - The logger instance.
  */
 export const useLogger = (): Logger => {
@@ -18,7 +17,6 @@ export const useLogger = (): Logger => {
 /**
  * A hook that returns a logger with the room context pre-applied.
  * @internal
- *
  * @returns Logger - The logger instance.
  */
 export const useRoomLogger = (): Logger => {

--- a/src/react/hooks/use-messages.ts
+++ b/src/react/hooks/use-messages.ts
@@ -85,9 +85,7 @@ export interface UseMessagesResponse extends ChatStatusResponse {
    * before the listener was re-attached.
    *
    * This is removed when the component unmounts or when the previously provided listener is removed.
-   *
    * @param options - The query options to use when fetching the previous messages.
-   *
    * @defaultValue - This will be undefined if no listener is provided in the {@link UseMessagesParams}.
    */
   readonly historyBeforeSubscribe?: MessageSubscriptionResponse['historyBeforeSubscribe'];
@@ -119,7 +117,6 @@ export interface UseMessagesParams extends StatusParams, Listenable<MessageListe
  * It will use the instance belonging to the room in the nearest {@link ChatRoomProvider} in the component tree.
  * If a listener is provided, it will subscribe to new messages in the room,
  * and will also set the {@link UseMessagesResponse.historyBeforeSubscribe}.
- *
  * @param params - Allows the registering of optional callbacks.
  * @returns UsePresenceResponse - An object containing the {@link Messages} instance and methods to interact with it.
  */

--- a/src/react/hooks/use-occupancy.ts
+++ b/src/react/hooks/use-occupancy.ts
@@ -46,7 +46,6 @@ export interface UseOccupancyResponse extends ChatStatusResponse {
 /**
  * A hook that provides access to the {@link Occupancy} instance of the room.
  * It will use the instance belonging to the nearest {@link ChatRoomProvider} in the component tree.
- *
  * @param params - Allows the registering of optional callbacks.
  * @returns UseOccupancyResponse
  */

--- a/src/react/hooks/use-presence-listener.ts
+++ b/src/react/hooks/use-presence-listener.ts
@@ -68,7 +68,6 @@ export interface UsePresenceListenerResponse extends ChatStatusResponse {
  * A hook that provides access to the {@link Presence} instance in the room and the current presence state.
  * It will use the instance belonging to the room in the nearest {@link ChatRoomProvider} in the component tree.
  * On calling, the hook will subscribe to the presence state of the room and update the state accordingly.
- *
  * @param params - Allows the registering of optional callbacks.
  * @returns UsePresenceResponse - An object containing the {@link Presence} instance and the current presence state.
  */

--- a/src/react/hooks/use-presence.ts
+++ b/src/react/hooks/use-presence.ts
@@ -62,7 +62,6 @@ const INACTIVE_CONNECTION_STATES = new Set<ConnectionStatus>([ConnectionStatus.S
  * It will use the instance belonging to the room in the nearest {@link ChatRoomProvider} in the component tree.
  * On calling, the hook will `enter` the room with the provided data and `leave` the room when the component unmounts.
  * The {@link UsePresenceResponse.isPresent} flag will indicate when the user has become present in the room.
- *
  * @param params - Allows the registering of optional callbacks.
  * @returns UsePresenceResponse - An object containing the {@link Presence} instance and methods to interact with it.
  */

--- a/src/react/hooks/use-room-reactions.ts
+++ b/src/react/hooks/use-room-reactions.ts
@@ -40,7 +40,6 @@ export interface UseRoomReactionsResponse extends ChatStatusResponse {
 /**
  * A hook that provides access to the {@link RoomReactions} instance in the room.
  * It will use the instance belonging to the nearest {@link ChatRoomProvider} in the component tree.
- *
  * @param params - Allows the registering of optional callbacks.
  * @returns UseRoomReactionsResponse
  */

--- a/src/react/hooks/use-room-reference-manager.ts
+++ b/src/react/hooks/use-room-reference-manager.ts
@@ -16,7 +16,6 @@ export interface ExtendedChatClientContextValue extends ChatClientContextValue {
 
 /**
  * Hook to access the room reference manager from the current ChatClientProvider.
- *
  * @returns The room reference manager instance
  * @throws ErrorInfo if used outside of a ChatClientProvider
  */

--- a/src/react/hooks/use-room.ts
+++ b/src/react/hooks/use-room.ts
@@ -56,9 +56,8 @@ export interface UseRoomResponse extends ChatStatusResponse {
 
 /**
  * A hook that provides access to the current room.
- *
  * @param params Register optional callbacks, see {@link UseRoomParams}.
- * @returns {@link UseRoomResponse}
+ * @returns An object containing room data and status information.
  */
 export const useRoom = (params?: UseRoomParams): UseRoomResponse => {
   const context = useRoomContext('useRoom');

--- a/src/react/hooks/use-typing.ts
+++ b/src/react/hooks/use-typing.ts
@@ -60,7 +60,6 @@ export interface UseTypingResponse extends ChatStatusResponse {
 /**
  * A hook that provides access to the {@link Typing} instance in the room.
  * It will use the instance belonging to the room in the nearest {@link ChatRoomProvider} in the component tree.
- *
  * @param params - Allows the registering of optional callbacks.
  * @returns UseTypingResponse - An object containing the {@link Typing} instance and methods to interact with it.
  */

--- a/src/react/providers/chat-client-provider.tsx
+++ b/src/react/providers/chat-client-provider.tsx
@@ -30,10 +30,10 @@ export interface ChatClientProviderProps {
 /**
  * Returns a React component that provides a {@link ChatClient} in a React context to the component subtree.
  * Updates the context value when the client prop changes.
- *
- * @param {ChatClientProviderProps} props - The props for the {@link ChatClientProvider} component.
- *
- * @returns {ChatClientProvider} component.
+ * @param props - The props for the {@link ChatClientProvider} component.
+ * @param props.children The child components to render.
+ * @param props.client The chat client instance to provide in context.
+ * @returns component.
  */
 export const ChatClientProvider = ({ children, client }: ChatClientProviderProps) => {
   const context = React.useContext(ChatClientContext);

--- a/src/react/providers/chat-client-provider.tsx
+++ b/src/react/providers/chat-client-provider.tsx
@@ -33,7 +33,7 @@ export interface ChatClientProviderProps {
  * @param props - The props for the {@link ChatClientProvider} component.
  * @param props.children The child components to render.
  * @param props.client The chat client instance to provide in context.
- * @returns component.
+ * @returns A React element that provides the chat client context to its children.
  */
 export const ChatClientProvider = ({ children, client }: ChatClientProviderProps) => {
   const context = React.useContext(ChatClientContext);

--- a/src/react/providers/chat-room-provider.tsx
+++ b/src/react/providers/chat-room-provider.tsx
@@ -38,7 +38,7 @@ export interface ChatRoomProviderProps {
  * @param props.children The child components to render.
  * @returns The ChatRoomProvider component.
  */
-export const ChatRoomProvider: React.FC<ChatRoomProviderProps> = ({ name: roomName, options, children }) => {
+export const ChatRoomProvider = ({ name: roomName, options, children }: ChatRoomProviderProps): React.ReactElement => {
   const client = useChatClient();
   const clientLogger = useLogger();
   const logger = useMemo(() => clientLogger.withContext({ roomName }), [clientLogger, roomName]);

--- a/src/react/providers/chat-room-provider.tsx
+++ b/src/react/providers/chat-room-provider.tsx
@@ -32,6 +32,11 @@ export interface ChatRoomProviderProps {
  *
  * The provider automatically manages room attachment and release based on reference counting.
  * The first provider for a room will attach it, and the last provider to unmount will release it.
+ * @param root0 The props object for the ChatRoomProvider.
+ * @param root0.name The name of the room.
+ * @param root0.options The room options.
+ * @param root0.children The child components to render.
+ * @returns The ChatRoomProvider component.
  */
 export const ChatRoomProvider: React.FC<ChatRoomProviderProps> = ({ name: roomName, options, children }) => {
   const client = useChatClient();

--- a/src/react/providers/chat-room-provider.tsx
+++ b/src/react/providers/chat-room-provider.tsx
@@ -32,10 +32,10 @@ export interface ChatRoomProviderProps {
  *
  * The provider automatically manages room attachment and release based on reference counting.
  * The first provider for a room will attach it, and the last provider to unmount will release it.
- * @param root0 The props object for the ChatRoomProvider.
- * @param root0.name The name of the room.
- * @param root0.options The room options.
- * @param root0.children The child components to render.
+ * @param props The props object for the ChatRoomProvider.
+ * @param props.name The name of the room.
+ * @param props.options The room options.
+ * @param props.children The child components to render.
  * @returns The ChatRoomProvider component.
  */
 export const ChatRoomProvider: React.FC<ChatRoomProviderProps> = ({ name: roomName, options, children }) => {

--- a/test/helper/common.ts
+++ b/test/helper/common.ts
@@ -4,6 +4,13 @@ import { expect, vi } from 'vitest';
 import { OccupancyEvent, PresenceEventType } from '../../src/core/events.ts';
 import { PresenceEvent } from '../../src/core/presence.ts';
 
+/**
+ * Waits for an expected occupancy event to appear in the provided occupancy events array.
+ * @param occupancyEvents The array of occupancy events to search through.
+ * @param expectedOccupancy The expected occupancy event to wait for.
+ * @param timeoutMs The timeout in milliseconds to wait for the event.
+ * @returns A promise that resolves when the expected occupancy is found.
+ */
 export const waitForExpectedInbandOccupancy = (
   occupancyEvents: OccupancyEvent[],
   expectedOccupancy: OccupancyEvent,

--- a/test/helper/common.ts
+++ b/test/helper/common.ts
@@ -29,6 +29,12 @@ export const waitForExpectedInbandOccupancy = (
     { timeout: timeoutMs, interval: 1000 },
   );
 
+/**
+ * Waits for the length of an array to match the expected count.
+ * @param array The array to check the length of.
+ * @param expectedCount The expected length of the array.
+ * @param timeoutMs The timeout in milliseconds to wait for the array length to match the expected count.
+ */
 export const waitForArrayLength = async (array: unknown[], expectedCount: number, timeoutMs = 3000): Promise<void> => {
   await vi.waitFor(
     () => {
@@ -38,6 +44,15 @@ export const waitForArrayLength = async (array: unknown[], expectedCount: number
   );
 };
 
+/**
+ * Waits for an expected presence event to appear in the provided presence events array.
+ * @param event The expected presence event to wait for.
+ * @param event.clientId The client ID of the expected presence event.
+ * @param event.data The data of the expected presence event.
+ * @param event.type The type of the expected presence event.
+ * @param presenceEvents The array of presence events to search through.
+ * @returns A promise that resolves when the expected presence event is found.
+ */
 export const waitForExpectedPresenceEvent = (
   event: { clientId: string; data: unknown; type: PresenceEventType },
   presenceEvents: PresenceEvent[],


### PR DESCRIPTION
### Description

We always had the jsdoc plugin turned on, but we didn't enforce the rules.

This change enforces the rules, and cleans up the linting errors.

Also fixes an issue with the `ChatRoomProvider` that means it doesn't show up nicely in typedoc (it shows up as a variable so misses all the nice typehinting)

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved and standardized JSDoc comments throughout the codebase for enhanced clarity and consistency.
  * Added detailed parameter and return annotations to several exported functions and components.
  * Updated and clarified documentation for React components and hooks.
  * Added new JSDoc comments describing function purposes and parameters.
  * Removed redundant or extraneous lines and formatting from documentation blocks.

* **Style**
  * Cleaned up comment formatting by removing unnecessary blank lines, asterisks, and outdated tags from JSDoc comments.

* **Refactor**
  * Updated the signature of the `ChatRoomProvider` component to use explicit props and return type.

* **Chores**
  * Updated ESLint configuration to include recommended TypeScript settings for improved code quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->