### PR TITLE
Add release step: update ExampleRenderer in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@
    1. Update the JS and React version for the chat language selector in [src/data/languages/languageData.ts](https://github.com/ably/docs/blob/main/src/data/languages/languageData.ts#L25-L26).
    2. Update the version used by the [examples](https://github.com/ably/docs/blob/main/examples/package.json), and the examples code if needed.
       - you can do this by running `yarn upgrade @ably/chat@latest` from the `examples` folder
+   3. Update [ExamplesRenderer](https://github.com/ably/docs/blob/main/src/components/Examples/ExamplesRenderer.tsx#L45) `src/components/Examples/ExamplesRenderer.tsx`
 7. Update [`@ably/cli`](https://github.com/ably/cli). This SDK is used to power Chat interactions on the Ably CLI, so please update the Chat SDK version for that repo if necessary (e.g. new features, bug fixes).
 
 ## Running The Test Suite


### PR DESCRIPTION
### Context

Add a missed step in the release process for updating the docs repo with the new version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Contributing guide updated to add an extra step in the docs release workflow to update example rendering after version bumps.
  * No user-facing changes; behavior and public APIs remain unchanged.
  * Applies only to project contributors performing documentation releases; no code, tests, or styles modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->