### PR TITLE
presence: update PresenceData to be a JSONable type

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -30,6 +30,7 @@ export {
   TypingSetEventType,
 } from './events.js';
 export type { Headers } from './headers.js';
+export type { JsonArray, JsonObject, JsonValue } from './json.js';
 export type { LogContext, Logger, LogHandler } from './logger.js';
 export { LogLevel } from './logger.js';
 export type {

--- a/src/core/json.ts
+++ b/src/core/json.ts
@@ -1,0 +1,16 @@
+/**
+ * Represents any valid JSON value including primitives, objects, and arrays.
+ */
+export type JsonValue = string | number | boolean | null | JsonObject | JsonArray;
+
+/**
+ * Represents a JSON object with string keys and JSON values.
+ */
+export interface JsonObject {
+  [key: string]: JsonValue;
+}
+
+/**
+ * Represents a JSON array containing JSON values.
+ */
+export type JsonArray = JsonValue[];

--- a/src/core/presence.ts
+++ b/src/core/presence.ts
@@ -2,6 +2,7 @@ import * as Ably from 'ably';
 
 import { ChannelOptionsMerger } from './channel-manager.js';
 import { PresenceEventType } from './events.js';
+import { JsonObject } from './json.js';
 import { Logger } from './logger.js';
 import { on, subscribe } from './realtime-subscriptions.js';
 import { InternalRoomOptions } from './room-options.js';
@@ -55,9 +56,28 @@ interface PresenceEventsMap {
 }
 
 /**
- * Type for PresenceData. Any JSON serializable data type.
+ * Type for data that can be entered into presence as an object literal.
+ * @example
+ * ```ts
+ * const foo: PresenceData = {
+ *   bar: {
+ *     baz: 1
+ *   }
+ * }
+ * ```
+ * @example
+ * ```ts
+ * // Defining a custom type for presence data. It must be a JSON serializable object.
+ * interface MyPresenceData {
+ *   [key: string]: JsonValue; // Type check for JSON compatibility.
+ *   foo: string;
+ *   bar: {
+ *     baz: string;
+ *   }
+ *  }
+ * ```
  */
-export type PresenceData = unknown;
+export type PresenceData = JsonObject;
 
 /**
  * Type for PresenceEvent
@@ -89,7 +109,7 @@ export type PresenceMember = Omit<Ably.PresenceMessage, 'id' | 'action' | 'times
   /**
    * The data associated with the presence member.
    */
-  data: PresenceData;
+  data: PresenceData | undefined;
 
   /**
    * The extras associated with the presence member.

--- a/test/core/presence.integration.test.ts
+++ b/test/core/presence.integration.test.ts
@@ -335,9 +335,9 @@ describe('UserPresence', { timeout: 30000 }, () => {
       presenceEvents,
     );
     // Update with string
-    await context.chatRoom.presence.update('string');
+    await context.chatRoom.presence.update({ foo: 'string' });
     await waitForExpectedPresenceEvent(
-      { clientId: context.chat.clientId, type: PresenceEventType.Update, data: 'string' },
+      { clientId: context.chat.clientId, type: PresenceEventType.Update, data: { foo: 'string' } },
       presenceEvents,
     );
     // Update with number (wrapped in object as Ably doesn't support primitive numbers)

--- a/test/react/hooks/use-presence-listener.integration.test.tsx
+++ b/test/react/hooks/use-presence-listener.integration.test.tsx
@@ -68,19 +68,19 @@ describe('usePresenceListener', () => {
     );
 
     // enter presence with room two, then update the presence state
-    await roomTwo.presence.enter('test enter');
-    await roomTwo.presence.update('test update');
+    await roomTwo.presence.enter({ foo: 'test enter' });
+    await roomTwo.presence.update({ foo: 'test update' });
 
     // expect a presence enter and update event from the test component to be received
     await waitForArrayLength(presenceEventsReceived, 2);
     expect(presenceEventsReceived[0]?.member.clientId).toBe(chatClientTwo.clientId);
-    expect(presenceEventsReceived[0]?.member.data).toBe('test enter');
+    expect(presenceEventsReceived[0]?.member.data).toEqual({ foo: 'test enter' });
     expect(presenceEventsReceived[1]?.member.clientId).toBe(chatClientTwo.clientId);
-    expect(presenceEventsReceived[1]?.member.data).toBe('test update');
+    expect(presenceEventsReceived[1]?.member.data).toEqual({ foo: 'test update' });
 
     // expect the current presence state to reflect only the latest presence data
     expect(currentPresenceData.length).toBe(1);
     expect(currentPresenceData[0]?.clientId).toBe(chatClientTwo.clientId);
-    expect(currentPresenceData[0]?.data).toBe('test update');
+    expect(currentPresenceData[0]?.data).toEqual({ foo: 'test update' });
   }, 20000);
 });

--- a/test/react/hooks/use-presence.integration.test.tsx
+++ b/test/react/hooks/use-presence.integration.test.tsx
@@ -50,7 +50,7 @@ describe('usePresence', () => {
         // wait till we have entered presence
         if (!myPresenceState.present) return;
         // send a presence update event
-        setTimeout(() => void update('test update'), 500);
+        setTimeout(() => void update({ foo: 'test update' }), 500);
       }, [myPresenceState.present, update]);
 
       isPresentState = myPresenceState.present;
@@ -65,7 +65,7 @@ describe('usePresence', () => {
 
     const { unmount, rerender } = render(
       <Providers>
-        <TestComponent initialData={'test enter'} />
+        <TestComponent initialData={{ foo: 'test enter' }} />
       </Providers>,
     );
 
@@ -78,11 +78,11 @@ describe('usePresence', () => {
 
     // expect a presence enter and update event from the test component to be received by the second room
     await waitForExpectedPresenceEvent(
-      { clientId: chatClientOne.clientId, type: PresenceEventType.Enter, data: 'test enter' },
+      { clientId: chatClientOne.clientId, type: PresenceEventType.Enter, data: { foo: 'test enter' } },
       presenceEventsRoomTwo,
     );
     await waitForExpectedPresenceEvent(
-      { clientId: chatClientOne.clientId, type: PresenceEventType.Update, data: 'test update' },
+      { clientId: chatClientOne.clientId, type: PresenceEventType.Update, data: { foo: 'test update' } },
       presenceEventsRoomTwo,
     );
 
@@ -92,7 +92,7 @@ describe('usePresence', () => {
     // expect a presence leave event from the test component to be received by the second room
     // it will have the data of whatever was in the presence set at the time
     await waitForExpectedPresenceEvent(
-      { clientId: chatClientOne.clientId, type: PresenceEventType.Leave, data: 'test update' },
+      { clientId: chatClientOne.clientId, type: PresenceEventType.Leave, data: { foo: 'test update' } },
       presenceEventsRoomTwo,
     );
 


### PR DESCRIPTION
### Context

[CHA-1166]

### Description

- This change makes the PresenceData type a JSON serialisable object.
- This provides a much cleaner API in other strongly-typed SDKs.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A


[CHA-1166]: https://ably.atlassian.net/browse/CHA-1166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Public JSON type declarations added and made available for consumers.
  - Standardized JSON data model for payloads, supporting nested objects and arrays.

- Refactor
  - Presence data now modeled as JSON objects (and may be optional) instead of primitive strings.

- Documentation
  - Examples and docs updated to show object-based presence payloads.

- Tests
  - Integration tests updated to send and assert object payloads for presence enter/update/leave events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->