### PR TITLE
message: rename Version to MessageVersion

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -40,7 +40,7 @@ export type {
   MessageMetadata,
   MessageOperationMetadata,
   MessageReactions,
-  Version,
+  MessageVersion,
 } from './message.js';
 export type {
   DeleteMessageParams,

--- a/src/core/message-parser.ts
+++ b/src/core/message-parser.ts
@@ -1,7 +1,14 @@
 import * as Ably from 'ably';
 
 import { ChatMessageAction } from './events.js';
-import { DefaultMessage, emptyMessageReactions, Message, MessageHeaders, MessageMetadata, Version } from './message.js';
+import {
+  DefaultMessage,
+  emptyMessageReactions,
+  Message,
+  MessageHeaders,
+  MessageMetadata,
+  MessageVersion,
+} from './message.js';
 
 interface MessagePayload {
   data?: {
@@ -42,7 +49,7 @@ export const parseMessage = (inboundMessage: Ably.InboundMessage): Message => {
           timestamp: versionTimestamp,
         }
       : message.version
-  ) as Version;
+  ) as MessageVersion;
 
   // Use current time as default for missing timestamps
   const currentTime = Date.now();

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -30,7 +30,7 @@ export type MessageOperationMetadata = OperationMetadata;
 /**
  * Represents the detail of a message deletion or update.
  */
-export interface Version {
+export interface MessageVersion {
   /**
    * A unique identifier for the latest version of this message.
    */
@@ -60,7 +60,7 @@ export interface Version {
 /**
  * A helper for versions that we know have a serial.
  */
-type VersionWithSerial = Required<Pick<Version, 'serial'>>;
+type MessageVersionWithSerial = Required<Pick<MessageVersion, 'serial'>>;
 
 /**
  * Represents a single message in a chat room.
@@ -123,7 +123,7 @@ export interface Message {
   /**
    * Information about the latest version of this message.
    */
-  readonly version: Version;
+  readonly version: MessageVersion;
 
   /**
    * The reactions summary for this message.
@@ -302,7 +302,7 @@ export interface DefaultMessageParams {
   metadata: MessageMetadata;
   headers: MessageHeaders;
   action: ChatMessageAction;
-  version: Version;
+  version: MessageVersion;
   timestamp: Date;
   reactions: MessageReactions;
 }
@@ -319,7 +319,7 @@ export class DefaultMessage implements Message {
   public readonly metadata: MessageMetadata;
   public readonly headers: MessageHeaders;
   public readonly action: ChatMessageAction;
-  public readonly version: Version;
+  public readonly version: MessageVersion;
   public readonly timestamp: Date;
   public readonly reactions: MessageReactions;
 
@@ -380,7 +380,7 @@ export class DefaultMessage implements Message {
     return this._compareVersions(
       this,
       message,
-      (first: VersionWithSerial, second: VersionWithSerial) => first.serial < second.serial,
+      (first: MessageVersionWithSerial, second: MessageVersionWithSerial) => first.serial < second.serial,
     );
   }
 
@@ -388,7 +388,7 @@ export class DefaultMessage implements Message {
     return this._compareVersions(
       this,
       message,
-      (first: VersionWithSerial, second: VersionWithSerial) => first.serial > second.serial,
+      (first: MessageVersionWithSerial, second: MessageVersionWithSerial) => first.serial > second.serial,
     );
   }
 
@@ -396,7 +396,7 @@ export class DefaultMessage implements Message {
     return this._compareVersions(
       this,
       message,
-      (first: VersionWithSerial, second: VersionWithSerial) => first.serial === second.serial,
+      (first: MessageVersionWithSerial, second: MessageVersionWithSerial) => first.serial === second.serial,
     );
   }
 
@@ -404,7 +404,7 @@ export class DefaultMessage implements Message {
     return this._compareVersions(
       this,
       message,
-      (first: VersionWithSerial, second: VersionWithSerial) => first.serial >= second.serial,
+      (first: MessageVersionWithSerial, second: MessageVersionWithSerial) => first.serial >= second.serial,
     );
   }
 
@@ -457,7 +457,7 @@ export class DefaultMessage implements Message {
   private _compareVersions(
     first: Message,
     second: Message,
-    comparator: (first: VersionWithSerial, second: VersionWithSerial) => boolean,
+    comparator: (first: MessageVersionWithSerial, second: MessageVersionWithSerial) => boolean,
   ): boolean {
     // If our serials aren't the same, not same message and cannot compare1
     if (!first.equal(second)) {
@@ -470,7 +470,7 @@ export class DefaultMessage implements Message {
     }
 
     // Use the comparator to determine the comparison
-    return comparator(first.version as VersionWithSerial, second.version as VersionWithSerial);
+    return comparator(first.version as MessageVersionWithSerial, second.version as MessageVersionWithSerial);
   }
 
   /**


### PR DESCRIPTION
### Description

This change renames Version to MessageVersion for consistency with PubSub and also other fields such as MessageMetadata.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the public type Version to MessageVersion across the messaging API, including related aliases (e.g., VersionWithSerial → MessageVersionWithSerial).
  * Updated public type exports to reflect the new names; TypeScript consumers should update imports and references.
  * No changes to runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->