### PR TITLE
fix: chat-api protocol version

### DIFF
--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -235,17 +235,7 @@ export class ChatApi {
     body?: unknown,
     params?: unknown,
   ): Promise<RES> {
-    const response = await this._realtime.request<RES>(method, url, this._apiProtocolVersion, params, body);
-    if (!response.success) {
-      this._logger.error('ChatApi._makeAuthorizedRequest(); failed to make request', {
-        url,
-        statusCode: response.statusCode,
-        errorCode: response.errorCode,
-        errorMessage: response.errorMessage,
-      });
-      throw new Ably.ErrorInfo(response.errorMessage, response.errorCode, response.statusCode);
-    }
-
+    const response = await this._doRequest(url, method, params, body);
     return response.items[0] as RES;
   }
 
@@ -254,16 +244,27 @@ export class ChatApi {
     params?: unknown,
     body?: unknown,
   ): Promise<PaginatedResult<RES>> {
-    const response = await this._realtime.request('GET', url, this._apiProtocolVersion, params, body);
+    return this._doRequest(url, 'GET', params, body);
+  }
+
+  private async _doRequest<RES>(
+    url: string,
+    method: 'POST' | 'GET' | 'PUT' | 'DELETE' | 'PATCH',
+    params?: unknown,
+    body?: unknown,
+  ): Promise<PaginatedResult<RES>> {
+    const response = await this._realtime.request(method, url, this._apiProtocolVersion, params, body);
     if (!response.success) {
-      this._logger.error('ChatApi._makeAuthorizedPaginatedRequest(); failed to make request', {
+      this._logger.error('ChatApi._doRequest(); failed to make request', {
         url,
+        method,
         statusCode: response.statusCode,
         errorCode: response.errorCode,
         errorMessage: response.errorMessage,
       });
       throw new Ably.ErrorInfo(response.errorMessage, response.errorCode, response.statusCode);
     }
+
     return response;
   }
 

--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -176,9 +176,9 @@ export class ChatApi {
   }
 
   deleteMessage(roomName: string, serial: string, params?: DeleteMessageParams): Promise<DeleteMessageResponse> {
-    const body: { description?: string; metadata?: MessageOperationMetadata } = {
-      description: params?.description,
-      metadata: params?.metadata,
+    const body = {
+      ...(params?.description && { description: params.description }),
+      ...(params?.metadata && { metadata: params.metadata }),
     };
     return this._makeAuthorizedRequest<DeleteMessageResponse>(
       this._messageUrl(roomName, serial, '/delete'),
@@ -189,17 +189,11 @@ export class ChatApi {
   }
 
   sendMessage(roomName: string, params: SendMessageParams): Promise<CreateMessageResponse> {
-    const body: {
-      text: string;
-      metadata?: MessageMetadata;
-      headers?: MessageHeaders;
-    } = { text: params.text };
-    if (params.metadata) {
-      body.metadata = params.metadata;
-    }
-    if (params.headers) {
-      body.headers = params.headers;
-    }
+    const body = {
+      text: params.text,
+      ...(params.metadata && { metadata: params.metadata }),
+      ...(params.headers && { headers: params.headers }),
+    };
     return this._makeAuthorizedRequest<CreateMessageResponse>(this._roomUrl(roomName, '/messages'), 'POST', body);
   }
 

--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -116,7 +116,7 @@ export interface DeleteMessageReactionParams {
 export class ChatApi {
   private readonly _realtime: Ably.Realtime;
   private readonly _logger: Logger;
-  private readonly _apiProtocolVersion: number = 3;
+  private readonly _apiProtocolVersion: number = 4;
 
   constructor(realtime: Ably.Realtime, logger: Logger) {
     this._realtime = realtime;

--- a/test/core/chat-api.test.ts
+++ b/test/core/chat-api.test.ts
@@ -27,7 +27,7 @@ describe('config', () => {
         statusCode: 400,
       })
       .then(() => {
-        expect(realtime.request).toHaveBeenCalledWith('GET', '/chat/v4/rooms/test/occupancy', 3, undefined, undefined);
+        expect(realtime.request).toHaveBeenCalledWith('GET', '/chat/v4/rooms/test/occupancy', 4, undefined, undefined);
       });
   });
 
@@ -104,7 +104,7 @@ describe('getClientReactions', () => {
     expect(requestSpy).toHaveBeenCalledWith(
       'GET',
       '/chat/v4/rooms/room123/messages/msg-serial-123/client-reactions',
-      3,
+      4,
       { forClientId: 'client123' },
       undefined,
     );
@@ -125,7 +125,7 @@ describe('getClientReactions', () => {
     expect(requestSpy).toHaveBeenCalledWith(
       'GET',
       '/chat/v4/rooms/room123/messages/msg-serial-123/client-reactions',
-      3,
+      4,
       {},
       undefined,
     );


### PR DESCRIPTION
### Description

Something we missed in protocol v4 update - the Chat API needs to send version 4 to the server.

Also took the opportunity to DRY up some of `chat-api.ts` to avoid lots of duplicated code, especially around URL building.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for room and message operations, including correct handling of special characters and consistent pagination.
  * More consistent error reporting for failed requests.

* **Refactor**
  * Unified request and URL handling across chat endpoints for greater consistency and maintainability.
  * Internal API protocol bumped to v4 (no public interface changes).

* **Tests**
  * Pagination-related test expectations updated to match the new protocol version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->