### PR TITLE
messages: use server return to create message

### DIFF
--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -188,13 +188,13 @@ export class ChatApi {
     );
   }
 
-  sendMessage(roomName: string, params: SendMessageParams): Promise<CreateMessageResponse> {
+  sendMessage(roomName: string, params: SendMessageParams): Promise<RestMessage> {
     const body = {
       text: params.text,
       ...(params.metadata && { metadata: params.metadata }),
       ...(params.headers && { headers: params.headers }),
     };
-    return this._makeAuthorizedRequest<CreateMessageResponse>(this._roomUrl(roomName, '/messages'), 'POST', body);
+    return this._makeAuthorizedRequest<RestMessage>(this._roomUrl(roomName, '/messages'), 'POST', body);
   }
 
   updateMessage(roomName: string, serial: string, params: UpdateMessageParams): Promise<UpdateMessageResponse> {

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -3,14 +3,7 @@ import * as Ably from 'ably';
 import { ChatApi } from './chat-api.js';
 import { ChatMessageAction, ChatMessageEvent, ChatMessageEventType, RealtimeMessageName } from './events.js';
 import { Logger } from './logger.js';
-import {
-  DefaultMessage,
-  emptyMessageReactions,
-  Message,
-  MessageHeaders,
-  MessageMetadata,
-  MessageOperationMetadata,
-} from './message.js';
+import { Message, MessageHeaders, MessageMetadata, MessageOperationMetadata } from './message.js';
 import { parseMessage } from './message-parser.js';
 import { DefaultMessageReactions, MessagesReactions } from './messages-reactions.js';
 import { PaginatedResult } from './query.js';
@@ -538,22 +531,7 @@ export class DefaultMessages implements Messages {
     const { text, metadata, headers } = params;
 
     const response = await this._chatApi.sendMessage(this._roomName, { text, headers, metadata });
-    // We apply the timestamp to both the message and the version, since they are the same for a newly created message.
-    const timestamp = new Date(response.timestamp);
-    return new DefaultMessage({
-      serial: response.serial,
-      clientId: this._clientId,
-      text: text,
-      metadata: metadata ?? {},
-      headers: headers ?? {},
-      action: ChatMessageAction.MessageCreate,
-      version: {
-        serial: response.serial,
-        timestamp,
-      },
-      timestamp,
-      reactions: emptyMessageReactions(),
-    });
+    return messageFromRest(response);
   }
 
   /**

--- a/test/core/messages.test.ts
+++ b/test/core/messages.test.ts
@@ -68,6 +68,17 @@ describe('Messages', () => {
       vi.spyOn(chatApi, 'sendMessage').mockResolvedValue({
         serial: serial,
         timestamp: timestamp,
+        text: 'hello there',
+        clientId: 'clientId',
+        action: ChatMessageAction.MessageCreate,
+        metadata: {},
+        headers: {},
+        version: {
+          serial: serial,
+          timestamp: timestamp,
+          clientId: 'clientId',
+        },
+        reactions: emptyMessageReactions(),
       });
 
       const messagePromise = context.room.messages.send({ text: 'hello there' });
@@ -88,16 +99,29 @@ describe('Messages', () => {
       const { chatApi, realtime } = context;
       const timestamp = Date.now();
       const serial = 'abcdefghij@' + String(timestamp) + '-123';
+      const headers = { something: 'else', abc: '123' };
+      const metadata = { hello: { name: 'world', more: ['nested', true] }, 'meta-abc': 'abc', '123': 456, pi: 3.14 };
       vi.spyOn(chatApi, 'sendMessage').mockResolvedValue({
         serial: serial,
         timestamp: timestamp,
+        text: 'hello there',
+        clientId: 'clientId',
+        action: ChatMessageAction.MessageCreate,
+        metadata: metadata,
+        headers: headers,
+        version: {
+          serial: serial,
+          timestamp: timestamp,
+          clientId: 'clientId',
+        },
+        reactions: emptyMessageReactions(),
       });
 
       const room = makeRandomRoom({ chatApi, realtime });
       const messagePromise = room.messages.send({
         text: 'hello there',
-        headers: { something: 'else', abc: 123, def: true, bla: null },
-        metadata: { hello: { name: 'world', more: ['nested', true] }, 'meta-abc': 'abc', '123': 456, pi: 3.14 },
+        headers: headers,
+        metadata: metadata,
       });
 
       const message = await messagePromise;
@@ -108,12 +132,7 @@ describe('Messages', () => {
           text: 'hello there',
           clientId: 'clientId',
           timestamp: new Date(timestamp),
-          headers: {
-            something: 'else',
-            abc: 123,
-            def: true,
-            bla: null,
-          },
+          headers: { something: 'else', abc: '123' },
           metadata: { hello: { name: 'world', more: ['nested', true] }, 'meta-abc': 'abc', '123': 456, pi: 3.14 },
         }),
       );
@@ -128,6 +147,17 @@ describe('Messages', () => {
       vi.spyOn(chatApi, 'sendMessage').mockResolvedValue({
         serial: sendSerial,
         timestamp: sendTimestamp,
+        text: 'hello there',
+        clientId: 'clientId',
+        action: ChatMessageAction.MessageCreate,
+        metadata: {},
+        headers: {},
+        version: {
+          serial: sendSerial,
+          timestamp: sendTimestamp,
+          clientId: 'clientId',
+        },
+        reactions: emptyMessageReactions(),
       });
 
       const deleteTimestamp = Date.now();
@@ -170,6 +200,17 @@ describe('Messages', () => {
       vi.spyOn(chatApi, 'sendMessage').mockResolvedValue({
         serial: sendSerial,
         timestamp: sendTimestamp,
+        text: 'hello there',
+        clientId: 'clientId',
+        action: ChatMessageAction.MessageCreate,
+        metadata: {},
+        headers: {},
+        version: {
+          serial: sendSerial,
+          timestamp: sendTimestamp,
+          clientId: 'clientId',
+        },
+        reactions: emptyMessageReactions(),
       });
 
       const deleteTimestamp = Date.now();
@@ -213,6 +254,17 @@ describe('Messages', () => {
       vi.spyOn(chatApi, 'sendMessage').mockResolvedValue({
         serial: sendSerial,
         timestamp: sendTimestamp,
+        text: 'hello there',
+        clientId: 'clientId',
+        action: ChatMessageAction.MessageCreate,
+        metadata: {},
+        headers: {},
+        version: {
+          serial: sendSerial,
+          timestamp: sendTimestamp,
+          clientId: 'clientId',
+        },
+        reactions: emptyMessageReactions(),
       });
 
       const deleteTimestamp = Date.now();
@@ -266,6 +318,17 @@ describe('Messages', () => {
       vi.spyOn(chatApi, 'sendMessage').mockResolvedValue({
         serial: sendSerial,
         timestamp: sendTimestamp,
+        text: 'hello there',
+        clientId: 'clientId',
+        action: ChatMessageAction.MessageCreate,
+        metadata: {},
+        headers: {},
+        version: {
+          serial: sendSerial,
+          timestamp: sendTimestamp,
+          clientId: 'clientId',
+        },
+        reactions: emptyMessageReactions(),
       });
 
       const deleteTimestamp = Date.now();
@@ -313,6 +376,17 @@ describe('Messages', () => {
       vi.spyOn(chatApi, 'sendMessage').mockResolvedValue({
         serial: sendSerial,
         timestamp: sendTimestamp,
+        text: 'hello there',
+        clientId: 'clientId',
+        action: ChatMessageAction.MessageCreate,
+        metadata: {},
+        headers: {},
+        version: {
+          serial: sendSerial,
+          timestamp: sendTimestamp,
+          clientId: 'clientId',
+        },
+        reactions: emptyMessageReactions(),
       });
 
       const deleteTimestamp = Date.now();


### PR DESCRIPTION
### Context

[CHA-1197]

### Description

Previously we took just the serial and the timestamp to form the message, now we use the entire server response.

### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A
