### PR TITLE
Rename `QueryOptions` to `HistoryParams`

### DIFF
--- a/.cursor/rules/typescript-conventions.mdc
+++ b/.cursor/rules/typescript-conventions.mdc
@@ -44,9 +44,9 @@ interface MessageEventPayload {
 - Link using {@link} to types mentioned.
 ```typescript
 /**
- * Options for querying messages in a chat room.
+ * Parameters for querying messages in a chat room.
  */
-interface QueryOptions {
+interface HistoryParams {
   /**
    * The start of the time window to query from.
    * @defaultValue The beginning of time

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -402,9 +402,9 @@ interface MessageEventPayload {
 - Link using {@link} to types mentioned.
 ```typescript
 /**
- * Options for querying messages in a chat room.
+ * Parameters for querying messages in a chat room.
  */
-interface QueryOptions {
+interface HistoryParams {
   /**
    * The start of the time window to query from.
    * @defaultValue The beginning of time

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -51,11 +51,11 @@ export type {
 } from './message-reactions.js';
 export type {
   DeleteMessageParams,
+  HistoryParams,
   MessageListener,
   Messages,
   MessageSubscriptionResponse,
   OperationDetails,
-  QueryOptions,
   SendMessageParams,
   UpdateMessageParams,
 } from './messages.js';

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -51,9 +51,9 @@ export enum OrderBy {
 }
 
 /**
- * Options for querying messages in a chat room.
+ * Parameters for querying messages in a chat room.
  */
-export interface QueryOptions {
+export interface HistoryParams {
   /**
    * The start of the time window to query from. If provided, the response will include
    * messages with timestamps equal to or greater than this value.
@@ -193,10 +193,10 @@ export interface MessageSubscriptionResponse extends Subscription {
    * const { historyBeforeSubscribe } = room.messages.subscribe(listener);
    * await historyBeforeSubscribe({ limit: 10 });
    * ```
-   * @param params Options for the history query.
+   * @param params Parameters for the history query.
    * @returns A promise that resolves with the paginated result of messages, in newest-to-oldest order.
    */
-  historyBeforeSubscribe(params: Omit<QueryOptions, 'orderBy'>): Promise<PaginatedResult<Message>>;
+  historyBeforeSubscribe(params: Omit<HistoryParams, 'orderBy'>): Promise<PaginatedResult<Message>>;
 }
 
 /**
@@ -214,12 +214,12 @@ export interface Messages {
   subscribe(listener: MessageListener): MessageSubscriptionResponse;
 
   /**
-   * Get messages that have been previously sent to the chat room, based on the provided options.
-   * @param options Options for the query.
+   * Get messages that have been previously sent to the chat room, based on the provided parameters.
+   * @param params Parameters for the query.
    * @returns A promise that resolves with the paginated result of messages. This paginated result can
    * be used to fetch more messages if available.
    */
-  history(options: QueryOptions): Promise<PaginatedResult<Message>>;
+  history(params: HistoryParams): Promise<PaginatedResult<Message>>;
 
   /**
    * Get a message by its serial.
@@ -370,7 +370,7 @@ export class DefaultMessages implements Messages {
    */
   private async _getBeforeSubscriptionStart(
     listener: MessageListener,
-    params: Omit<QueryOptions, 'orderBy'>,
+    params: Omit<HistoryParams, 'orderBy'>,
   ): Promise<PaginatedResult<Message>> {
     this._logger.trace(`DefaultSubscriptionManager.getBeforeSubscriptionStart();`);
 
@@ -505,7 +505,7 @@ export class DefaultMessages implements Messages {
   /**
    * @inheritdoc
    */
-  async history(options: QueryOptions): Promise<PaginatedResult<Message>> {
+  async history(options: HistoryParams): Promise<PaginatedResult<Message>> {
     this._logger.trace('Messages.query();');
     return this._chatApi.history(this._roomName, options);
   }
@@ -592,7 +592,7 @@ export class DefaultMessages implements Messages {
         this._logger.trace('Messages.unsubscribe();');
         this._emitter.off(wrapped);
       },
-      historyBeforeSubscribe: (params: Omit<QueryOptions, 'orderBy'>) =>
+      historyBeforeSubscribe: (params: Omit<HistoryParams, 'orderBy'>) =>
         this._getBeforeSubscriptionStart(wrapped, params),
     };
   }

--- a/src/react/hooks/use-messages.ts
+++ b/src/react/hooks/use-messages.ts
@@ -10,11 +10,11 @@ import type {
 import { MessageRawReactionListener, MessageReactionListener } from '../../core/message-reactions.js';
 import {
   DeleteMessageParams,
+  HistoryParams,
   MessageListener,
   Messages,
   MessageSubscriptionResponse,
   OperationDetails,
-  QueryOptions,
   SendMessageParams,
   UpdateMessageParams,
 } from '../../core/messages.js';
@@ -79,7 +79,7 @@ export interface UseMessagesResponse extends ChatStatusResponse {
    * before the listener was re-attached.
    *
    * This is removed when the component unmounts or when the previously provided listener is removed.
-   * @param options - The query options to use when fetching the previous messages.
+   * @param params - The query parameters to use when fetching the previous messages.
    * @defaultValue - This will be undefined if no listener is provided in the {@link UseMessagesParams}.
    */
   readonly historyBeforeSubscribe?: MessageSubscriptionResponse['historyBeforeSubscribe'];
@@ -145,7 +145,7 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
   );
 
   const history = useCallback(
-    (options: QueryOptions) => context.room.then((room) => room.messages.history(options)),
+    (params: HistoryParams) => context.room.then((room) => room.messages.history(params)),
     [context],
   );
 
@@ -190,7 +190,7 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
             return;
           }
 
-          return (params: Omit<QueryOptions, 'orderBy'>) => {
+          return (params: Omit<HistoryParams, 'orderBy'>) => {
             // If we've unmounted, then the subscription is gone and we can't call historyBeforeSubscribe
             // So return a dummy object that should be thrown away anyway
             logger.debug('useMessages(); historyBeforeSubscribe called');


### PR DESCRIPTION
Elsewhere, we use `Options` for overall configuration and `Params` for per-request settings.

Change agreed in [internal Slack conversation](https://ably-real-time.slack.com/archives/C02NY1VT3LY/p1759853005380729).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Renamed the public message history parameter type from QueryOptions to HistoryParams; TypeScript consumers should update imports and parameter names.
- Documentation
  - Updated examples and JSDoc to use HistoryParams and revised wording to "Parameters for querying messages in a chat room."
- Chores
  - Aligned internal guidance and examples with the new public API terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->