### PR TITLE
refactor: enforce JSON serializable on metadata

### DIFF
--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -1,5 +1,7 @@
+import { JsonObject } from './json.js';
+
 /**
- * Metadata is a map of extra information that can be attached to chat
+ * Metadata is a JSON-serializable object of extra information that can be attached to chat
  * messages. It is not used by Ably and is sent as part of the realtime
  * message payload. Example use cases are setting custom styling like
  * background or text colors or fonts, adding links to external images,
@@ -9,4 +11,4 @@
  * validation. When reading the metadata, treat it like user input.
  *
  */
-export type Metadata = Record<string, unknown>;
+export type Metadata = JsonObject;

--- a/src/core/rest-types.ts
+++ b/src/core/rest-types.ts
@@ -1,4 +1,5 @@
 import { ChatMessageAction } from './events.js';
+import { JsonObject } from './json.js';
 import { DefaultMessage, emptyMessageReactions, Message } from './message.js';
 
 // RestClientIdList represents a list of client IDs with aggregation data
@@ -37,7 +38,7 @@ export interface RestMessage {
   text: string;
   clientId: string;
   action: 'message.create' | 'message.update' | 'message.delete';
-  metadata: Record<string, unknown>;
+  metadata: JsonObject;
   headers: Record<string, string>;
   timestamp: number;
   reactions?: RestChatMessageReactions;


### PR DESCRIPTION
### Description

Currently metadata types have `Record<string, unknown>` as their definition, but unknown can include things that are not JSON-serialisable such as functions. As the data goes into `message.data` on the channel, it must be serialisable. This change enforces the `JsonObject` type for this purpose.


### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [x] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [x] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

N/A
