### PR TITLE
Fix: "types" condition should come first in "exports" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
   "react-native": "dist/chat/ably-chat.umd.cjs",
   "exports": {
     ".": {
-      "react-native": "./dist/chat/ably-chat.umd.cjs",
       "types": "./dist/chat/index.d.ts",
+      "react-native": "./dist/chat/ably-chat.umd.cjs",
       "import": "./dist/chat/ably-chat.js",
       "require": "./dist/chat/ably-chat.umd.cjs"
     },
     "./react": {
-      "react-native": "./dist/react/ably-chat-react.umd.cjs",
       "types": "./dist/react/index.d.ts",
+      "react-native": "./dist/react/ably-chat-react.umd.cjs",
       "import": "./dist/react/ably-chat-react.js",
       "require": "./dist/react/ably-chat-react.umd.cjs"
     },


### PR DESCRIPTION
See [1], mentioned [by Owen](https://github.com/ably/ably-ai-transport-js/pull/9#discussion_r2996852564) when setting up exports for ai-transport sdk. exports was largely based on chat-js package.json, so figured should fix it here too.

[1] https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#:~:text=The%20%22types%22%20condition%20should%20always%20come%20first%20in%20%22exports%22.

### Checklist

* [ ] QA'd by the author.
* [ ] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [ ] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [ ] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [ ] Browser tests created (if applicable).
* [ ] In repo demo app updated (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized package exports configuration for internal consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->