### PR TITLE
feat: add opt-in idempotent REST publishing for chat requests

### DIFF
--- a/demo/src/main.tsx
+++ b/demo/src/main.tsx
@@ -94,7 +94,7 @@ const getLogLevel = () => {
 
 const realtimeClient = new Ably.Realtime(getRealtimeOptions());
 
-const chatClient = new ChatClient(realtimeClient, { logLevel: getLogLevel() });
+const chatClient = new ChatClient(realtimeClient, { logLevel: getLogLevel(), idempotentRestPublishing: true });
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -118,7 +118,7 @@ export class ChatApi {
   private readonly _apiProtocolVersion: number = 4;
   private readonly _idempotentRestPublishing: boolean;
 
-  constructor(realtime: Ably.Realtime, logger: Logger, idempotentRestPublishing = false) {
+  constructor(realtime: Ably.Realtime, logger: Logger, idempotentRestPublishing: boolean) {
     this._realtime = realtime;
     this._logger = logger;
     this._idempotentRestPublishing = idempotentRestPublishing;

--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -1,6 +1,7 @@
 import * as Ably from 'ably';
 
 import { ErrorCode } from './errors.js';
+import { idempotencyKey } from './id.js';
 import { Logger } from './logger.js';
 import { Message, MessageHeaders, MessageMetadata, MessageOperationMetadata } from './message.js';
 import { OrderBy } from './messages.js';
@@ -115,10 +116,12 @@ export class ChatApi {
   private readonly _realtime: Ably.Realtime;
   private readonly _logger: Logger;
   private readonly _apiProtocolVersion: number = 4;
+  private readonly _idempotentRestPublishing: boolean;
 
-  constructor(realtime: Ably.Realtime, logger: Logger) {
+  constructor(realtime: Ably.Realtime, logger: Logger, idempotentRestPublishing = false) {
     this._realtime = realtime;
     this._logger = logger;
+    this._idempotentRestPublishing = idempotentRestPublishing;
   }
 
   async history(roomName: string, params: HistoryQueryParams): Promise<PaginatedResult<Message>> {
@@ -195,7 +198,7 @@ export class ChatApi {
       this._messageUrl(roomName, serial, '/delete'),
       'POST',
       body,
-      {},
+      this._idempotencyQueryParams(),
     );
   }
 
@@ -205,11 +208,25 @@ export class ChatApi {
       ...(params.metadata && { metadata: params.metadata }),
       ...(params.headers && { headers: params.headers }),
     };
-    return this._makeAuthorizedRequest<RestMessage>(this._roomUrl(roomName, '/messages'), 'POST', body);
+    return this._makeAuthorizedRequest<RestMessage>(
+      this._roomUrl(roomName, '/messages'),
+      'POST',
+      body,
+      this._idempotencyQueryParams(),
+    );
   }
 
   async updateMessage(roomName: string, serial: string, params: UpdateMessageParams): Promise<UpdateMessageResponse> {
-    return this._makeAuthorizedRequest<UpdateMessageResponse>(this._messageUrl(roomName, serial), 'PUT', params);
+    return this._makeAuthorizedRequest<UpdateMessageResponse>(
+      this._messageUrl(roomName, serial),
+      'PUT',
+      params,
+      this._idempotencyQueryParams(),
+    );
+  }
+
+  private _idempotencyQueryParams(): { idempotencyKey: string } | undefined {
+    return this._idempotentRestPublishing ? { idempotencyKey: idempotencyKey() } : undefined;
   }
 
   async sendMessageReaction(roomName: string, serial: string, data: SendMessageReactionParams): Promise<void> {

--- a/src/core/chat-client.ts
+++ b/src/core/chat-client.ts
@@ -116,7 +116,12 @@ export class ChatClient {
 
     this._connection = new DefaultConnection(realtime, this._logger);
     this._clientIdResolver = new DefaultClientIdResolver(realtime, this._logger);
-    this._rooms = new DefaultRooms(realtime, this._clientIdResolver, this._logger);
+    this._rooms = new DefaultRooms(
+      realtime,
+      this._clientIdResolver,
+      this._logger,
+      this._clientOptions.idempotentRestPublishing,
+    );
     this._addAgent('chat-js');
     this._logger.trace(`ably chat client version ${VERSION}; initialized`);
   }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -15,6 +15,17 @@ export interface ChatClientOptions {
    * @defaultValue LogLevel.error
    */
   logLevel?: LogLevel;
+
+  /**
+   * When `true`, the SDK generates a unique idempotency identifier for each
+   * `send/update/delete` call and sends it with the request. If the request is
+   * retried internally across fallback hosts, the same identifier is used,
+   * allowing the server to deduplicate the attempt.
+   *
+   * The identifier is regenerated for each new call.
+   * @defaultValue false
+   */
+  idempotentRestPublishing?: boolean;
 }
 
 /**
@@ -22,6 +33,7 @@ export interface ChatClientOptions {
  */
 const defaultClientOptions = {
   logLevel: LogLevel.Error,
+  idempotentRestPublishing: false,
 };
 
 /**
@@ -37,6 +49,7 @@ export type NormalizedChatClientOptions = Modify<
   ChatClientOptions,
   {
     logLevel: LogLevel;
+    idempotentRestPublishing: boolean;
   }
 >;
 
@@ -46,5 +59,6 @@ export const normalizeClientOptions = (options?: ChatClientOptions): NormalizedC
   return {
     ...options,
     logLevel: options.logLevel ?? defaultClientOptions.logLevel,
+    idempotentRestPublishing: options.idempotentRestPublishing ?? defaultClientOptions.idempotentRestPublishing,
   };
 };

--- a/src/core/id.ts
+++ b/src/core/id.ts
@@ -4,3 +4,20 @@
  * @returns A random string that can be used as an identifier.
  */
 export const randomId = (): string => Math.random().toString(36).slice(2);
+
+const IDEMPOTENCY_KEY_ENTROPY_BYTES = 9;
+
+/**
+ * Generates an idempotency key for a single publish attempt.
+ * 9 random bytes base64-encoded.
+ * @returns A unique idempotency key for one publish attempt.
+ */
+export const idempotencyKey = (): string => {
+  const bytes = new Uint8Array(IDEMPOTENCY_KEY_ENTROPY_BYTES);
+  crypto.getRandomValues(bytes);
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCodePoint(b);
+  }
+  return btoa(binary);
+};

--- a/src/core/id.ts
+++ b/src/core/id.ts
@@ -15,6 +15,14 @@ const IDEMPOTENCY_KEY_ENTROPY_BYTES = 9;
 export const idempotencyKey = (): string => {
   const bytes = new Uint8Array(IDEMPOTENCY_KEY_ENTROPY_BYTES);
   crypto.getRandomValues(bytes);
+
+  // Prefer Uint8Array.prototype.toBase64() where available (Node 22+, modern
+  // browsers, recent React Native) — operates directly on bytes. Fall back to
+  // btoa for older runtimes where toBase64 isn't yet available.
+  const native = (bytes as Uint8Array & { toBase64?: () => string }).toBase64;
+  if (typeof native === 'function') {
+    return native.call(bytes);
+  }
   let binary = '';
   for (const b of bytes) {
     binary += String.fromCodePoint(b);

--- a/src/core/rooms.ts
+++ b/src/core/rooms.ts
@@ -175,7 +175,7 @@ export class DefaultRooms implements InternalRooms {
     realtime: Ably.Realtime,
     clientIdResolver: ClientIdResolver,
     logger: Logger,
-    idempotentRestPublishing = false,
+    idempotentRestPublishing: boolean,
   ) {
     this._realtime = realtime;
     this._chatApi = new ChatApi(realtime, logger, idempotentRestPublishing);

--- a/src/core/rooms.ts
+++ b/src/core/rooms.ts
@@ -169,10 +169,16 @@ export class DefaultRooms implements InternalRooms {
    * @param realtime An instance of the Ably Realtime client.
    * @param clientIdResolver A resolver for the clientId.
    * @param logger An instance of the Logger.
+   * @param idempotentRestPublishing Whether the ChatApi should attach an idempotency key to outgoing requests.
    */
-  constructor(realtime: Ably.Realtime, clientIdResolver: ClientIdResolver, logger: Logger) {
+  constructor(
+    realtime: Ably.Realtime,
+    clientIdResolver: ClientIdResolver,
+    logger: Logger,
+    idempotentRestPublishing = false,
+  ) {
     this._realtime = realtime;
-    this._chatApi = new ChatApi(realtime, logger);
+    this._chatApi = new ChatApi(realtime, logger, idempotentRestPublishing);
     this._clientIdResolver = clientIdResolver;
     this._logger = logger;
   }

--- a/test/core/chat-api.test.ts
+++ b/test/core/chat-api.test.ts
@@ -10,7 +10,7 @@ vi.mock('ably');
 describe('config', () => {
   it('calls the api with the correct protocol version', async () => {
     const realtime = new Ably.Realtime({ clientId: 'test' });
-    const chatApi = new ChatApi(realtime, makeTestLogger());
+    const chatApi = new ChatApi(realtime, makeTestLogger(), false);
 
     vi.spyOn(realtime, 'request').mockReturnValue(
       Promise.resolve({
@@ -31,7 +31,7 @@ describe('config', () => {
 
   it('throws an error if Realtime returns ErrorInfo on non-paginated request', async () => {
     const realtime = new Ably.Realtime({ clientId: 'test' });
-    const chatApi = new ChatApi(realtime, makeTestLogger());
+    const chatApi = new ChatApi(realtime, makeTestLogger(), false);
 
     vi.spyOn(realtime, 'request').mockReturnValue(
       Promise.resolve({
@@ -51,7 +51,7 @@ describe('config', () => {
 
   it('throws errors if Realtime returns ErrorInfo on paginated request', async () => {
     const realtime = new Ably.Realtime({ clientId: 'test' });
-    const chatApi = new ChatApi(realtime, makeTestLogger());
+    const chatApi = new ChatApi(realtime, makeTestLogger(), false);
 
     vi.spyOn(realtime, 'request').mockReturnValue(
       Promise.resolve({
@@ -71,7 +71,7 @@ describe('config', () => {
 
   it('includes errorDetail in thrown ErrorInfo on non-paginated request', async () => {
     const realtime = new Ably.Realtime({ clientId: 'test' });
-    const chatApi = new ChatApi(realtime, makeTestLogger());
+    const chatApi = new ChatApi(realtime, makeTestLogger(), false);
 
     vi.spyOn(realtime, 'request').mockReturnValue(
       Promise.resolve({
@@ -93,7 +93,7 @@ describe('config', () => {
 
   it('includes errorDetail in thrown ErrorInfo on paginated request', async () => {
     const realtime = new Ably.Realtime({ clientId: 'test' });
-    const chatApi = new ChatApi(realtime, makeTestLogger());
+    const chatApi = new ChatApi(realtime, makeTestLogger(), false);
 
     vi.spyOn(realtime, 'request').mockReturnValue(
       Promise.resolve({
@@ -115,7 +115,7 @@ describe('config', () => {
 
   it('throws errors if invalid OrderBy used on history request', async () => {
     const realtime = new Ably.Realtime({ clientId: 'test' });
-    const chatApi = new ChatApi(realtime, makeTestLogger());
+    const chatApi = new ChatApi(realtime, makeTestLogger(), false);
 
     vi.spyOn(realtime, 'request');
 
@@ -141,7 +141,7 @@ describe('sendMessage idempotency', () => {
 
   it('does not attach an idempotencyKey when disabled (sendMessage)', async () => {
     const realtime = new Ably.Realtime({ clientId: 'test' });
-    const chatApi = new ChatApi(realtime, makeTestLogger());
+    const chatApi = new ChatApi(realtime, makeTestLogger(), false);
     const requestSpy = vi.spyOn(realtime, 'request').mockReturnValue(okResponse());
 
     await chatApi.sendMessage('room1', { text: 'hello' });
@@ -191,7 +191,7 @@ describe('sendMessage idempotency', () => {
 
   it('does not attach an idempotencyKey when disabled (deleteMessage)', async () => {
     const realtime = new Ably.Realtime({ clientId: 'test' });
-    const chatApi = new ChatApi(realtime, makeTestLogger());
+    const chatApi = new ChatApi(realtime, makeTestLogger(), false);
     const requestSpy = vi.spyOn(realtime, 'request').mockReturnValue(okResponse());
 
     await chatApi.deleteMessage('room1', 'serial-1');
@@ -215,7 +215,7 @@ describe('sendMessage idempotency', () => {
 
   it('does not attach an idempotencyKey when disabled (updateMessage)', async () => {
     const realtime = new Ably.Realtime({ clientId: 'test' });
-    const chatApi = new ChatApi(realtime, makeTestLogger());
+    const chatApi = new ChatApi(realtime, makeTestLogger(), false);
     const requestSpy = vi.spyOn(realtime, 'request').mockReturnValue(okResponse());
 
     await chatApi.updateMessage('room1', 'serial-1', { message: { text: 'updated' } });
@@ -227,7 +227,7 @@ describe('sendMessage idempotency', () => {
 describe('getClientReactions', () => {
   it('adds forClientId param when clientId is provided', async () => {
     const realtime = new Ably.Realtime({ clientId: 'test' });
-    const chatApi = new ChatApi(realtime, makeTestLogger());
+    const chatApi = new ChatApi(realtime, makeTestLogger(), false);
     const requestSpy = vi.spyOn(realtime, 'request').mockReturnValue(
       Promise.resolve({
         success: true,
@@ -248,7 +248,7 @@ describe('getClientReactions', () => {
 
   it('does not add forClientId param when clientId is not provided', async () => {
     const realtime = new Ably.Realtime({ clientId: 'test' });
-    const chatApi = new ChatApi(realtime, makeTestLogger());
+    const chatApi = new ChatApi(realtime, makeTestLogger(), false);
     const requestSpy = vi.spyOn(realtime, 'request').mockReturnValue(
       Promise.resolve({
         success: true,

--- a/test/core/chat-api.test.ts
+++ b/test/core/chat-api.test.ts
@@ -130,6 +130,100 @@ describe('config', () => {
   });
 });
 
+describe('sendMessage idempotency', () => {
+  const okResponse = async () =>
+    Promise.resolve({
+      success: true,
+      items: [{ serial: 'srl', clientId: 'test', text: 'hi', timestamp: 1 }],
+    }) as Promise<Ably.HttpPaginatedResponse>;
+
+  const KEY_PATTERN = /^[A-Za-z0-9+/]{12}$/;
+
+  it('does not attach an idempotencyKey when disabled (sendMessage)', async () => {
+    const realtime = new Ably.Realtime({ clientId: 'test' });
+    const chatApi = new ChatApi(realtime, makeTestLogger());
+    const requestSpy = vi.spyOn(realtime, 'request').mockReturnValue(okResponse());
+
+    await chatApi.sendMessage('room1', { text: 'hello' });
+
+    expect(requestSpy).toHaveBeenCalledWith('POST', '/chat/v4/rooms/room1/messages', 4, undefined, {
+      text: 'hello',
+    });
+  });
+
+  it('attaches idempotencyKey as a query param when enabled (sendMessage)', async () => {
+    const realtime = new Ably.Realtime({ clientId: 'test' });
+    const chatApi = new ChatApi(realtime, makeTestLogger(), true);
+    const requestSpy = vi.spyOn(realtime, 'request').mockReturnValue(okResponse());
+
+    await chatApi.sendMessage('room1', { text: 'hello' });
+
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    const params = requestSpy.mock.calls[0]?.[3] as { idempotencyKey?: string };
+    const body = requestSpy.mock.calls[0]?.[4] as Record<string, unknown>;
+    expect(params.idempotencyKey).toMatch(KEY_PATTERN);
+    expect(body).not.toHaveProperty('idempotencyKey');
+  });
+
+  it('generates a fresh idempotencyKey for each send call', async () => {
+    const realtime = new Ably.Realtime({ clientId: 'test' });
+    const chatApi = new ChatApi(realtime, makeTestLogger(), true);
+    const requestSpy = vi.spyOn(realtime, 'request').mockReturnValue(okResponse());
+
+    await chatApi.sendMessage('room1', { text: 'first' });
+    await chatApi.sendMessage('room1', { text: 'second' });
+
+    const firstParams = requestSpy.mock.calls[0]?.[3] as { idempotencyKey: string };
+    const secondParams = requestSpy.mock.calls[1]?.[3] as { idempotencyKey: string };
+    expect(firstParams.idempotencyKey).not.toBe(secondParams.idempotencyKey);
+  });
+
+  it('attaches idempotencyKey as a query param when enabled (deleteMessage)', async () => {
+    const realtime = new Ably.Realtime({ clientId: 'test' });
+    const chatApi = new ChatApi(realtime, makeTestLogger(), true);
+    const requestSpy = vi.spyOn(realtime, 'request').mockReturnValue(okResponse());
+
+    await chatApi.deleteMessage('room1', 'serial-1');
+
+    const params = requestSpy.mock.calls[0]?.[3] as { idempotencyKey?: string };
+    expect(params.idempotencyKey).toMatch(KEY_PATTERN);
+  });
+
+  it('does not attach an idempotencyKey when disabled (deleteMessage)', async () => {
+    const realtime = new Ably.Realtime({ clientId: 'test' });
+    const chatApi = new ChatApi(realtime, makeTestLogger());
+    const requestSpy = vi.spyOn(realtime, 'request').mockReturnValue(okResponse());
+
+    await chatApi.deleteMessage('room1', 'serial-1');
+
+    expect(requestSpy.mock.calls[0]?.[3]).toBeUndefined();
+  });
+
+  it('attaches idempotencyKey as a query param when enabled (updateMessage)', async () => {
+    const realtime = new Ably.Realtime({ clientId: 'test' });
+    const chatApi = new ChatApi(realtime, makeTestLogger(), true);
+    const requestSpy = vi.spyOn(realtime, 'request').mockReturnValue(okResponse());
+
+    await chatApi.updateMessage('room1', 'serial-1', { message: { text: 'updated' } });
+
+    const params = requestSpy.mock.calls[0]?.[3] as { idempotencyKey?: string };
+    const body = requestSpy.mock.calls[0]?.[4] as { message: { text: string } } & Record<string, unknown>;
+    expect(params.idempotencyKey).toMatch(KEY_PATTERN);
+    expect(body.message.text).toBe('updated');
+    expect(body).not.toHaveProperty('idempotencyKey');
+  });
+
+  it('does not attach an idempotencyKey when disabled (updateMessage)', async () => {
+    const realtime = new Ably.Realtime({ clientId: 'test' });
+    const chatApi = new ChatApi(realtime, makeTestLogger());
+    const requestSpy = vi.spyOn(realtime, 'request').mockReturnValue(okResponse());
+
+    await chatApi.updateMessage('room1', 'serial-1', { message: { text: 'updated' } });
+
+    expect(requestSpy.mock.calls[0]?.[3]).toBeUndefined();
+  });
+});
+
 describe('getClientReactions', () => {
   it('adds forClientId param when clientId is provided', async () => {
     const realtime = new Ably.Realtime({ clientId: 'test' });

--- a/test/core/config.test.ts
+++ b/test/core/config.test.ts
@@ -7,12 +7,14 @@ describe('config', () => {
   it('normalizes client options with no options', () => {
     expect(normalizeClientOptions()).toEqual({
       logLevel: LogLevel.Error,
+      idempotentRestPublishing: false,
     });
   });
 
   it('normalizes client options with logLevel', () => {
     expect(normalizeClientOptions({ logLevel: LogLevel.Debug })).toEqual({
       logLevel: LogLevel.Debug,
+      idempotentRestPublishing: false,
     });
   });
 
@@ -21,6 +23,14 @@ describe('config', () => {
     expect(normalizeClientOptions({ logHandler })).toEqual({
       logHandler,
       logLevel: LogLevel.Error,
+      idempotentRestPublishing: false,
+    });
+  });
+
+  it('normalizes client options with idempotentRestPublishing enabled', () => {
+    expect(normalizeClientOptions({ idempotentRestPublishing: true })).toEqual({
+      logLevel: LogLevel.Error,
+      idempotentRestPublishing: true,
     });
   });
 });

--- a/test/core/logger.test.ts
+++ b/test/core/logger.test.ts
@@ -78,7 +78,7 @@ describe('logger', () => {
   );
 
   it('throws exception on invalid log level', () => {
-    expect(() => makeLogger({ logLevel: 'invalid' as LogLevel })).toThrowErrorInfo({
+    expect(() => makeLogger({ logLevel: 'invalid' as LogLevel, idempotentRestPublishing: false })).toThrowErrorInfo({
       message: 'unable to create logger; invalid log level: invalid',
       statusCode: 400,
       code: ErrorCode.InvalidArgument,

--- a/test/core/messages-reactions.test.ts
+++ b/test/core/messages-reactions.test.ts
@@ -37,7 +37,7 @@ describe('MessageReactions', () => {
   describe('message reaction basics', () => {
     beforeEach<TestContext>((context) => {
       context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
-      context.chatApi = new ChatApi(context.realtime, makeTestLogger());
+      context.chatApi = new ChatApi(context.realtime, makeTestLogger(), false);
       context.room = makeRandomRoom({ chatApi: context.chatApi, realtime: context.realtime });
       const channel = context.room.channel;
       context.emulateBackendPublish = channelEventEmitter(channel);
@@ -383,7 +383,7 @@ describe('MessageReactions', () => {
   describe('raw message reactions', () => {
     beforeEach<TestContext>((context) => {
       context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
-      context.chatApi = new ChatApi(context.realtime, makeTestLogger());
+      context.chatApi = new ChatApi(context.realtime, makeTestLogger(), false);
       context.room = makeRandomRoom({
         chatApi: context.chatApi,
         realtime: context.realtime,
@@ -764,7 +764,7 @@ describe('MessageReactions', () => {
   describe('dispose', () => {
     beforeEach<TestContext>((context) => {
       context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
-      context.chatApi = new ChatApi(context.realtime, makeTestLogger());
+      context.chatApi = new ChatApi(context.realtime, makeTestLogger(), false);
       context.room = makeRandomRoom({
         chatApi: context.chatApi,
         realtime: context.realtime,

--- a/test/core/messages.test.ts
+++ b/test/core/messages.test.ts
@@ -56,7 +56,7 @@ vi.mock('ably');
 describe('Messages', () => {
   beforeEach<TestContext>((context) => {
     context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
-    context.chatApi = new ChatApi(context.realtime, makeTestLogger());
+    context.chatApi = new ChatApi(context.realtime, makeTestLogger(), false);
     context.room = makeRandomRoom({ chatApi: context.chatApi, realtime: context.realtime });
     const channel = context.room.channel;
     context.emulateBackendPublish = channelEventEmitter(channel);

--- a/test/core/occupancy.test.ts
+++ b/test/core/occupancy.test.ts
@@ -23,7 +23,7 @@ vi.mock('ably');
 describe('Occupancy', () => {
   beforeEach<TestContext>((context) => {
     context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
-    context.chatApi = new ChatApi(context.realtime, makeTestLogger());
+    context.chatApi = new ChatApi(context.realtime, makeTestLogger(), false);
     context.room = makeRandomRoom({
       chatApi: context.chatApi,
       realtime: context.realtime,

--- a/test/core/presence.test.ts
+++ b/test/core/presence.test.ts
@@ -37,7 +37,7 @@ vi.mock('ably');
 describe('Presence', () => {
   beforeEach<TestContext>((context) => {
     context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
-    context.chatApi = new ChatApi(context.realtime, makeTestLogger());
+    context.chatApi = new ChatApi(context.realtime, makeTestLogger(), false);
     context.makeRoom = (options) => makeRandomRoom({ chatApi: context.chatApi, realtime: context.realtime, options });
     context.room = context.makeRoom();
   });

--- a/test/core/room-reactions.test.ts
+++ b/test/core/room-reactions.test.ts
@@ -30,7 +30,7 @@ describe('Reactions', () => {
     const clientId = 'd.vader';
 
     context.realtime = new Ably.Realtime({ clientId: clientId, key: 'key' });
-    context.chatApi = new ChatApi(context.realtime, makeTestLogger());
+    context.chatApi = new ChatApi(context.realtime, makeTestLogger(), false);
 
     context.publishTimestamp = new Date();
     context.setPublishTimestamp = (date: Date) => {

--- a/test/core/room.test.ts
+++ b/test/core/room.test.ts
@@ -27,7 +27,7 @@ describe('Room', () => {
   beforeEach<TestContext>((context) => {
     context.realtime = ablyRealtimeClient();
     const logger = makeTestLogger();
-    const chatApi = new ChatApi(context.realtime, logger);
+    const chatApi = new ChatApi(context.realtime, logger, false);
     context.getRoom = (options?: RoomOptions, useReact?: boolean) =>
       new DefaultRoom(
         randomRoomName(),

--- a/test/core/rooms.test.ts
+++ b/test/core/rooms.test.ts
@@ -21,7 +21,12 @@ describe('rooms', () => {
   beforeEach<TestContext>((context) => {
     context.realtime = ablyRealtimeClient();
     const logger = makeTestLogger();
-    context.rooms = new DefaultRooms(context.realtime, new DefaultClientIdResolver(context.realtime, logger), logger);
+    context.rooms = new DefaultRooms(
+      context.realtime,
+      new DefaultClientIdResolver(context.realtime, logger),
+      logger,
+      false,
+    );
   });
 
   describe('room get', () => {

--- a/test/core/typing.test.ts
+++ b/test/core/typing.test.ts
@@ -64,7 +64,7 @@ describe('Typing', () => {
       },
     };
     context.realtime = new Ably.Realtime({ clientId: 'clientId', key: 'key' });
-    context.chatApi = new ChatApi(context.realtime, context.logger);
+    context.chatApi = new ChatApi(context.realtime, context.logger, false);
     context.room = makeRandomRoom({
       ...context,
     });

--- a/test/helper/options.ts
+++ b/test/helper/options.ts
@@ -3,6 +3,7 @@ import { LogLevel } from '../../src/core/logger.js';
 
 const defaults: NormalizedChatClientOptions = {
   logLevel: LogLevel.Error,
+  idempotentRestPublishing: false,
 };
 
 export const testClientOptions = (options?: ChatClientOptions): NormalizedChatClientOptions => {

--- a/test/helper/room.ts
+++ b/test/helper/room.ts
@@ -45,7 +45,7 @@ export const makeRandomRoom = (params?: {
 }): Room => {
   const logger = params?.logger ?? makeTestLogger();
   const realtime = params?.realtime ?? ablyRealtimeClient();
-  const chatApi = params?.chatApi ?? new ChatApi(realtime, logger);
+  const chatApi = params?.chatApi ?? new ChatApi(realtime, logger, false);
 
   return new DefaultRoom(
     randomRoomName(),


### PR DESCRIPTION
## Context

[CHA-1254](https://ably.atlassian.net/browse/CHA-1254)

Adds an idempotentRestPublishing zChatClientOptionsz flag (default false). When enabled, the SDK attaches an idempotencyKey query parameter to send, update, and delete message requests so the server can deduplicate retried publish attempts (e.g. for moderation integrations).


### Checklist

* [x] QA'd by the author.
* [x] Unit tests created (if applicable).
* [ ] Integration tests created (if applicable).
* [x] Follow coding style guidelines found [here](https://github.com/ably/engineering/tree/main/best-practices).
* [x] TypeDoc updated (if applicable).
* [ ] Updated the [website documentation](https://github.com/ably/docs) (if applicable).
* [x] Browser tests created (if applicable).
* [x] In repo demo app updated (if applicable).

### Testing Instructions (Optional)

Testing will require either a local farm or to wait until the sandbox deploys.

1. Set idempotentRestPublishing=true on the ChatClient.
2. Send a message and confirm a query param is attached (idempotencyKey)
3. As a bonus step, consume the message via a BP rule (lambda or Webhook) and you should see a message.id field in the req set as `<idempotencyKey>:0`


[CHA-1254]: https://ably.atlassian.net/browse/CHA-1254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional idempotent REST publishing: when enabled, send/update/delete requests include idempotency keys to allow safe retries and reduce duplicate messages (default: disabled).

* **Tests**
  * Added tests validating idempotency-key behavior, uniqueness per request, and enabled vs disabled flows.

* **Chores**
  * Updated defaults and demo initialization to expose the new idempotency option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-chat-js/pull/726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->