### PR TITLE
fix: bump ws to 8.20.1 to resolve GHSA-58qx-3vcg-4xpx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10836,9 +10836,9 @@
       "peer": true
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
Transitive dependency via ably; was failing `npm audit --production` in CI due to a moderate-severity uninitialized memory disclosure advisory affecting ws >=8.0.0 <8.20.1.