### PR TITLE
ci: zizmor-driven GHA workflow security cleanup

### DIFF
--- a/.github/workflows/deps-updated-correctly.yml
+++ b/.github/workflows/deps-updated-correctly.yml
@@ -19,11 +19,11 @@ jobs:
   check-all-package-lock-updated:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           persist-credentials: false
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.9.0'
       - run: npm install

--- a/.github/workflows/deps-updated-correctly.yml
+++ b/.github/workflows/deps-updated-correctly.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          persist-credentials: false
       - uses: actions/setup-node@v1
         with:
           node-version: '24.9.0'

--- a/.github/workflows/deps-updated-correctly.yml
+++ b/.github/workflows/deps-updated-correctly.yml
@@ -12,6 +12,9 @@ on:
       - package.json
       - demo/package.json
 
+permissions:
+  contents: read
+
 jobs:
   check-all-package-lock-updated:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          persist-credentials: false
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ env.BASE_NODE_VERSION }}
@@ -30,6 +31,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          persist-credentials: false
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ env.BASE_NODE_VERSION }}
@@ -41,6 +43,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          persist-credentials: false
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ env.BASE_NODE_VERSION }}
@@ -52,6 +55,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          persist-credentials: false
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ env.BASE_NODE_VERSION }}
@@ -63,6 +67,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          persist-credentials: false
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ env.BASE_NODE_VERSION }}
@@ -82,6 +87,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          persist-credentials: false
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
@@ -100,6 +106,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          persist-credentials: false
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ env.BASE_NODE_VERSION }}
@@ -111,6 +118,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          persist-credentials: false
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ env.BASE_NODE_VERSION }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,11 +16,11 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           persist-credentials: false
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.BASE_NODE_VERSION }}
       - run: npm ci
@@ -28,11 +28,11 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           persist-credentials: false
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.BASE_NODE_VERSION }}
       - run: npm ci
@@ -40,11 +40,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           persist-credentials: false
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.BASE_NODE_VERSION }}
       - run: npm ci
@@ -52,11 +52,11 @@ jobs:
   test-typescript:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           persist-credentials: false
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.BASE_NODE_VERSION }}
       - run: npm ci
@@ -64,11 +64,11 @@ jobs:
   check-error-codes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           persist-credentials: false
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.BASE_NODE_VERSION }}
       - run: npm ci
@@ -84,11 +84,11 @@ jobs:
         node-version: [20, 22, 24]
     name: test node ${{ matrix.node-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           persist-credentials: false
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
@@ -98,16 +98,16 @@ jobs:
       - run: VITE_TEST_LOG_LEVEL=trace npm run test
         name: test
         if: ${{ matrix.node-version != env.BASE_NODE_VERSION }}
-      - uses: davelosert/vitest-coverage-report-action@v2
+      - uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2.12.0
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'ably/ably-chat-js' && matrix.node-version == env.BASE_NODE_VERSION && (failure() || success()) }}
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           persist-credentials: false
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.BASE_NODE_VERSION }}
       - run: npm ci
@@ -115,11 +115,11 @@ jobs:
   demo-app:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           persist-credentials: false
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.BASE_NODE_VERSION }}
       - name: npm ci (lib)

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -9,6 +9,9 @@ on:
 env:
   BASE_NODE_VERSION: 24
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,13 +15,13 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           persist-credentials: false
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v3 # zizmor: ignore[cache-poisoning] no cache input is set, so npm cache is not enabled
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning] no cache input is set, so npm cache is not enabled
         with:
           node-version: 20.x
 
@@ -32,7 +32,7 @@ jobs:
         run: npm run docs
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         # Only run this step if it's a PR from the main repository, as forks won't have the necessary secrets
         if: github.repository == 'ably/ably-chat-js' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)) && github.actor != 'dependabot[bot]'
         with:
@@ -41,7 +41,7 @@ jobs:
           role-session-name: '${{ github.run_id }}-${{ github.run_number }}'
 
       - name: Upload Documentation
-        uses: ably/sdk-upload-action@v2
+        uses: ably/sdk-upload-action@4e694297f208b72b5a9f6b1248a1556f19f821d6 # v2.2.0
         # Only run this step if it's a PR from the main repository, as forks won't have the necessary secrets
         if: github.repository == 'ably/ably-chat-js' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)) && github.actor != 'dependabot[bot]'
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3 # zizmor: ignore[cache-poisoning] no cache input is set, so npm cache is not enabled
         with:
           node-version: 20.x
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Use Node.js 20.x
         uses: actions/setup-node@v3

--- a/.github/workflows/publish.cdn.yml
+++ b/.github/workflows/publish.cdn.yml
@@ -22,7 +22,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/prod-ably-sdk-cdn
           role-session-name: '${{ github.run_id }}-${{ github.run_number }}'
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v1 # zizmor: ignore[cache-poisoning] no cache input is set, so npm cache is not enabled
         with:
           node-version: 20.x
       - run: npm ci

--- a/.github/workflows/publish.cdn.yml
+++ b/.github/workflows/publish.cdn.yml
@@ -26,4 +26,7 @@ jobs:
         with:
           node-version: 20.x
       - run: npm ci
-      - run: node scripts/cdn_deploy.js --skipCheckout --tag=${{ github.ref_name }}
+      - name: Deploy to CDN
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: node scripts/cdn_deploy.js --skipCheckout --tag="$RELEASE_TAG"

--- a/.github/workflows/publish.cdn.yml
+++ b/.github/workflows/publish.cdn.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/publish.cdn.yml
+++ b/.github/workflows/publish.cdn.yml
@@ -11,18 +11,18 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref }}
           persist-credentials: false
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/prod-ably-sdk-cdn
           role-session-name: '${{ github.run_id }}-${{ github.run_number }}'
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v1 # zizmor: ignore[cache-poisoning] no cache input is set, so npm cache is not enabled
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning] no cache input is set, so npm cache is not enabled
         with:
           node-version: 20.x
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3 # zizmor: ignore[cache-poisoning] no cache input is set, so npm cache is not enabled
         with:
           node-version: '20.10.0'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ jobs:
       contents: 'write'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           persist-credentials: false
-      - uses: actions/setup-node@v3 # zizmor: ignore[cache-poisoning] no cache input is set, so npm cache is not enabled
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning] no cache input is set, so npm cache is not enabled
         with:
           node-version: '20.10.0'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+          persist-credentials: false
       - uses: actions/setup-node@v3
         with:
           node-version: '20.10.0'


### PR DESCRIPTION
Routine hygiene pass over the five GitHub Actions workflows in this repo, driven by zizmor static analysis. The changes are split into five commits, one per finding type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD security by pinning GitHub Action versions and adding workflow-level permission restrictions (read-only content token).
  * Improved workflow reliability by disabling credential persistence in checkout steps.
  * Minor deployment workflow tweak to pass release tag as an explicit parameter during CDN publish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->