### PR TITLE
chore: release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This contains only the most important and/or user-facing changes; for a full cha
 
 ### New Features
 
+- **Message Version History**: Added `room.messages.getVersions(serial)` to retrieve the full version history of a message — the original create followed by any updates and deletes — in oldest-first order. [#730](https://github.com/ably/ably-chat-js/pull/730)
 - **Idempotent REST Publishing**: Added an opt-in `idempotentRestPublishing` flag on `ChatClientOptions` (default `false`). When enabled, the SDK attaches an `idempotencyKey` to send, update, and delete message requests so the server can deduplicate retried publish attempts. [#726](https://github.com/ably/ably-chat-js/pull/726)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [1.4.0](https://github.com/ably/ably-chat-js/tree/1.4.0) (2026-05-28)
+
+### New Features
+
+- **Idempotent REST Publishing**: Added an opt-in `idempotentRestPublishing` flag on `ChatClientOptions` (default `false`). When enabled, the SDK attaches an `idempotencyKey` to send, update, and delete message requests so the server can deduplicate retried publish attempts. [#726](https://github.com/ably/ably-chat-js/pull/726)
+
+### Bug Fixes
+
+- **Package Exports**: Reordered the `"types"` condition to appear first in `package.json` `exports` so type resolution works correctly across bundlers. [#725](https://github.com/ably/ably-chat-js/pull/725)
+- **Security**: Bumped `ws` to `8.20.1` to resolve [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx). [#727](https://github.com/ably/ably-chat-js/pull/727)
+
 ## [1.3.1](https://github.com/ably/ably-chat-js/tree/1.3.1) (2026-03-25)
 
 ### Bug Fixes

--- a/cspell.json
+++ b/cspell.json
@@ -20,7 +20,8 @@
     "retryable",
     "onable",
     "nonprod",
-    "deleter"
+    "deleter",
+    "GHSA"
   ],
   // This will ignore anything that's formatted like a lexicographically ordered timeserial
   "ignoreRegExpList": ["/\\d{14}-\\d{3}@.*/"],

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -38,7 +38,7 @@
     },
     "..": {
       "name": "@ably/chat",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "async-mutex": "^0.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ably/chat",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ably/chat",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "async-mutex": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/chat",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Ably Chat is a set of purpose-built APIs for a host of chat features enabling you to create 1:1, 1:Many, Many:1 and Many:Many chat rooms for any scale. It is designed to meet a wide range of chat use cases, such as livestreams, in-game communication, customer support, or social interactions in SaaS products.",
   "type": "module",
   "main": "dist/chat/ably-chat.umd.cjs",

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,7 +1,7 @@
 import * as Ably from 'ably';
 
 // Update this when you release a new version
-export const VERSION = '1.3.1';
+export const VERSION = '1.4.0';
 export const CHANNEL_OPTIONS_AGENT_STRING = `chat-js/${VERSION}`;
 export const CHANNEL_OPTIONS_AGENT_STRING_REACT = `chat-react/${VERSION}`;
 // Modes required for basic message functionality


### PR DESCRIPTION
## Summary

- Bumps version to `1.4.0` in `package.json`, `package-lock.json`, `demo/package-lock.json`, and `src/core/version.ts`
- Adds `1.4.0` entry to `CHANGELOG.md` covering all customer-facing changes since `1.3.1`

## Changes included in this release

### New Features
- **Idempotent REST Publishing**: opt-in `idempotentRestPublishing` flag on `ChatClientOptions`; attaches an `idempotencyKey` to send/update/delete requests for safe retries ([#726](https://github.com/ably/ably-chat-js/pull/726))

### Bug Fixes
- **Package Exports**: `"types"` condition moved first in `exports` for correct type resolution across bundlers ([#725](https://github.com/ably/ably-chat-js/pull/725))
- **Security**: `ws` bumped to `8.20.1` to resolve [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) ([#727](https://github.com/ably/ably-chat-js/pull/727))

## Test plan

- [x] CI passes on this branch
- [ ] Merge to `main`
- [ ] Tag `1.4.0` GitHub Release (use "Generate release notes")
- [ ] Confirm NPM Publish and CDN Deploy Actions succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added message version history retrieval and an opt-in idempotentRestPublishing flag to deduplicate retried REST publish attempts

* **Bug Fixes**
  * Adjusted package exports/type resolution ordering for correct bundler behavior

* **Chores**
  * Upgraded ws for security; updated release to 1.4.0 and refreshed changelog

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-chat-js/pull/729?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->