### PR TITLE
feat: add getVersions() to retrieve full message version history

### DIFF
--- a/src/core/chat-api.ts
+++ b/src/core/chat-api.ts
@@ -247,6 +247,13 @@ export class ChatApi {
     );
   }
 
+  async getMessageVersions(roomName: string, serial: string): Promise<PaginatedResult<Message>> {
+    const data = await this._makeAuthorizedPaginatedRequest<RestMessage>(
+      this._messageUrl(roomName, serial, '/versions'),
+    );
+    return this._recursivePaginateMessages(data);
+  }
+
   async getOccupancy(roomName: string): Promise<OccupancyData> {
     return this._makeAuthorizedRequest<OccupancyData>(this._roomUrl(roomName, '/occupancy'), 'GET');
   }

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -577,18 +577,21 @@ export interface Messages {
   update(serial: string, updateParams: UpdateMessageParams, details?: OperationDetails): Promise<Message>;
 
   /**
-   * Get all getVersions of a message by its serial, in oldest-first order.
+   * Get all versions of a message by its serial, in oldest-first order.
    *
    * Returns the original create event followed by any subsequent update and delete events.
    *
    * **NOTE**: This method uses the Ably Chat REST API and so does not require the room
    * to be attached to be called.
    * @param serial - The unique serial identifier of the message.
-   * @returns A Promise that resolves to a {@link PaginatedResult} of {@link Message} objects representing each version.
+   * @returns A Promise that resolves to a {@link PaginatedResult} of {@link Message} objects representing each version,
+   * or rejects with:
+   * - {@link Ably.ErrorInfo} when the serial is null, undefined, or empty
+   * - {@link Ably.ErrorInfo} when the Ably Chat REST API request fails due to network or authorization errors
    * @example
    * ```typescript
-   * const getVersions = await room.messages.getVersions('01726585978590-001@abcdefghij:001');
-   * for (const version of getVersions.items) {
+   * const versions = await room.messages.getVersions('01726585978590-001@abcdefghij:001');
+   * for (const version of versions.items) {
    *   console.log(version.action, version.text);
    * }
    * ```

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -577,6 +577,25 @@ export interface Messages {
   update(serial: string, updateParams: UpdateMessageParams, details?: OperationDetails): Promise<Message>;
 
   /**
+   * Get all getVersions of a message by its serial, in oldest-first order.
+   *
+   * Returns the original create event followed by any subsequent update and delete events.
+   *
+   * **NOTE**: This method uses the Ably Chat REST API and so does not require the room
+   * to be attached to be called.
+   * @param serial - The unique serial identifier of the message.
+   * @returns A Promise that resolves to a {@link PaginatedResult} of {@link Message} objects representing each version.
+   * @example
+   * ```typescript
+   * const getVersions = await room.messages.getVersions('01726585978590-001@abcdefghij:001');
+   * for (const version of getVersions.items) {
+   *   console.log(version.action, version.text);
+   * }
+   * ```
+   */
+  getVersions(serial: string): Promise<PaginatedResult<Message>>;
+
+  /**
    * Send, delete, and subscribe to message reactions.
    *
    * This property provides access to the message reactions functionality, allowing you to
@@ -862,6 +881,15 @@ export class DefaultMessages implements Messages {
 
     this._logger.debug('Messages.update(); message update successfully', { updateParams });
     return messageFromRest(response);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  async getVersions(serial: string): Promise<PaginatedResult<Message>> {
+    this._logger.trace('Messages.getVersions();', { serial });
+    assertValidSerial(serial, 'get message getVersions', 'serial');
+    return this._chatApi.getMessageVersions(this._roomName, serial);
   }
 
   /**

--- a/test/core/chat-api.test.ts
+++ b/test/core/chat-api.test.ts
@@ -267,3 +267,31 @@ describe('getClientReactions', () => {
     );
   });
 });
+
+describe('getMessageVersions', () => {
+  it('calls the correct URL with GET and no params', async () => {
+    const realtime = new Ably.Realtime({ clientId: 'test' });
+    const chatApi = new ChatApi(realtime, makeTestLogger(), false);
+    const requestSpy = vi.spyOn(realtime, 'request').mockReturnValue(
+      Promise.resolve({
+        success: true,
+        items: [],
+        hasNext: () => false,
+        isLast: () => true,
+        first: async () => await Promise.resolve({ items: [] }),
+        next: async () => await Promise.resolve(null),
+        current: async () => await Promise.resolve({ items: [] }),
+      }) as unknown as Promise<Ably.HttpPaginatedResponse>,
+    );
+
+    await chatApi.getMessageVersions('room123', 'msg-serial-123');
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      'GET',
+      '/chat/v4/rooms/room123/messages/msg-serial-123/versions',
+      4,
+      undefined,
+      undefined,
+    );
+  });
+});

--- a/test/core/messages.integration.test.ts
+++ b/test/core/messages.integration.test.ts
@@ -1265,15 +1265,16 @@ describe('messages integration', { timeout: 10000 }, () => {
         // Delete it
         const deleted = await room.messages.delete(sent.serial, { description: 'removed' });
 
-        // Wait for persistence before querying versions
-        await new Promise((resolve) => setTimeout(resolve, 3000));
-
-        const result = await room.messages.getVersions(sent.serial);
-
-        expect(result.items).toHaveLength(3);
-        expect(result.items[0]).toEqual(sent);
-        expect(result.items[1]).toEqual(updated);
-        expect(result.items[2]).toEqual(deleted);
+        await vi.waitFor(
+          async () => {
+            const result = await room.messages.getVersions(sent.serial);
+            expect(result.items).toHaveLength(3);
+            expect(result.items[0]).toEqual(sent);
+            expect(result.items[1]).toEqual(updated);
+            expect(result.items[2]).toEqual(deleted);
+          },
+          { timeout: 5000, interval: 1000 },
+        );
       });
     });
 

--- a/test/core/messages.integration.test.ts
+++ b/test/core/messages.integration.test.ts
@@ -1251,6 +1251,32 @@ describe('messages integration', { timeout: 10000 }, () => {
       expect(historyPreSubscription2.items).toEqual(historyPreSubscription3.items);
     });
 
+    describe('versions', () => {
+      it<TestContext>('should return create, update, and delete versions in order', async (context) => {
+        const { chat } = context;
+        const room = await getRandomRoom(chat);
+
+        // Send the initial message
+        const sent = await room.messages.send({ text: 'original text' });
+
+        // Update it
+        const updated = await room.messages.update(sent.serial, { text: 'updated text' });
+
+        // Delete it
+        const deleted = await room.messages.delete(sent.serial, { description: 'removed' });
+
+        // Wait for persistence before querying versions
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+
+        const result = await room.messages.getVersions(sent.serial);
+
+        expect(result.items).toHaveLength(3);
+        expect(result.items[0]).toEqual(sent);
+        expect(result.items[1]).toEqual(updated);
+        expect(result.items[2]).toEqual(deleted);
+      });
+    });
+
     it<TestContext>('handles the room being released before historyBeforeSubscribe is called', async (context) => {
       const chat = context.chat;
       const roomName = randomRoomName();

--- a/test/core/messages.test.ts
+++ b/test/core/messages.test.ts
@@ -441,6 +441,50 @@ describe('Messages', () => {
     });
   });
 
+  describe('getting message versions', () => {
+    describe.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['empty string', ''],
+    ])('when serial is %s', (_, serial: unknown) => {
+      it<TestContext>('should throw InvalidArgument error', async (context) => {
+        await expect(context.room.messages.getVersions(serial as string)).rejects.toBeErrorInfoWithCode(
+          ErrorCode.InvalidArgument,
+        );
+      });
+    });
+
+    it<TestContext>('should return the paginated result from chatApi', async (context) => {
+      const { room, chatApi } = context;
+      const serial = '01672531200001-123@abcdefghij:0';
+      const timestamp = Date.now();
+
+      const mockVersions = await mockPaginatedResultWithItems([
+        {
+          serial,
+          clientId: 'clientId',
+          text: 'original text',
+          timestamp: new Date(timestamp),
+          metadata: {},
+          headers: {},
+          action: ChatMessageAction.MessageCreate,
+          version: { serial, timestamp: new Date(timestamp) },
+          reactions: emptyMessageReactions(),
+          isDeleted: false,
+          isUpdated: false,
+          with: vi.fn(),
+        } as unknown as Message,
+      ]);
+
+      vi.spyOn(chatApi, 'getMessageVersions').mockResolvedValue(mockVersions);
+
+      const result = await room.messages.getVersions(serial);
+
+      expect(chatApi.getMessageVersions).toHaveBeenCalledWith(room.name, serial);
+      expect(result).toBe(mockVersions);
+    });
+  });
+
   describe('subscribing to updates', () => {
     it<TestContext>('should subscribe to all message events', async (context) =>
       new Promise<void>((done, reject) => {


### PR DESCRIPTION
## Summary

Implements [CHA-1261](https://ably.atlassian.net/browse/CHA-1261).

Adds `room.messages.getVersions(serial)` which retrieves the full version history of a message — the original create followed by any updates and deletes — in oldest-first order.

## What changed

- **`ChatApi.getMessageVersions(roomName, serial)`** — calls `GET /chat/v4/rooms/{room}/messages/{serial}/versions`, returns `PaginatedResult<Message>` via the same paginator used by `history()`
- **`Messages.getVersions(serial)`** — validates the serial (throws `ErrorCode.InvalidArgument` for null/undefined/empty), delegates to `ChatApi`
- No query parameters — version counts are expected to be in the tens at most

## Tests

- **Unit (`chat-api.test.ts`)** — asserts correct URL, method, and protocol version
- **Unit (`messages.test.ts`)** — invalid serial validation (null/undefined/empty string), paginated result passthrough
- **Integration (`messages.integration.test.ts`)** — send → update → delete, then `getVersions()` with exact `toEqual` match against the original REST responses for all three items

## Related tickets

- [CHA-1258](https://ably.atlassian.net/browse/CHA-1258) — Docs: API reference + guide
- [CHA-1259](https://ably.atlassian.net/browse/CHA-1259) — Kotlin & Swift parity
- [CHA-1260](https://ably.atlassian.net/browse/CHA-1260) — Spec points

## Checklist

- [x] QA'd by the author
- [x] Unit tests created
- [x] Integration tests created
- [x] Follow coding style guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHA-1261]: https://ably.atlassian.net/browse/CHA-1261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CHA-1258]: https://ably.atlassian.net/browse/CHA-1258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message version history is now accessible. Users can retrieve the complete version history of messages, including the original creation, subsequent updates, and deletions presented in chronological order, enabling full visibility into message evolution and lifecycle tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-chat-js/pull/730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->