### PR TITLE
feat: expose getVersions() via the useMessages React hook

### DIFF
--- a/src/react/hooks/use-messages.ts
+++ b/src/react/hooks/use-messages.ts
@@ -100,6 +100,40 @@ export interface UseMessagesResponse extends ChatStatusResponse {
   readonly getMessage: (serial: string) => Promise<Message>;
 
   /**
+   * A shortcut to the {@link Messages.getVersions} method.
+   *
+   * Get all versions of a message by its serial, in oldest-first order.
+   *
+   * Returns the original create event followed by any subsequent update and delete events.
+   *
+   * **NOTE**: This method uses the Ably Chat REST API and so does not require the room
+   * to be attached to be called.
+   *
+   * This is a stable reference and will not be changed between renders for the same room.
+   * @param serial - The unique serial identifier of the message.
+   * @returns A Promise that resolves to a {@link PaginatedResult} of {@link Message} objects representing each version,
+   * or rejects with:
+   * - {@link Ably.ErrorInfo} when the serial is null, undefined, or empty
+   * - {@link Ably.ErrorInfo} when the Ably Chat REST API request fails due to network or authorization errors
+   * @example
+   * ```tsx
+   * const { getVersions } = useMessages();
+   *
+   * const handleGetVersions = async (messageSerial: string) => {
+   *   try {
+   *     const versions = await getVersions(messageSerial);
+   *     for (const version of versions.items) {
+   *       console.log(version.action, version.text);
+   *     }
+   *   } catch (error) {
+   *     console.error('Failed to get message versions:', error);
+   *   }
+   * };
+   * ```
+   */
+  readonly getVersions: (serial: string) => Promise<PaginatedResult<Message>>;
+
+  /**
    * A shortcut to the {@link Messages.update} method.
    *
    * Update a message in the chat room.
@@ -511,6 +545,14 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
     [context],
   );
 
+  const getVersions = useCallback(
+    async (serial: string) => {
+      const room = await context.room;
+      return room.messages.getVersions(serial);
+    },
+    [context],
+  );
+
   const deleteMessage = useCallback(
     async (serial: string, details?: OperationDetails) => {
       const room = await context.room;
@@ -655,6 +697,7 @@ export const useMessages = (params?: UseMessagesParams): UseMessagesResponse => 
     roomError,
     sendMessage,
     getMessage,
+    getVersions,
     updateMessage,
     history,
     deleteMessage,

--- a/test/react/hooks/use-messages.test.tsx
+++ b/test/react/hooks/use-messages.test.tsx
@@ -195,6 +195,10 @@ describe('useMessages', () => {
 
     const deleteSpy = vi.spyOn(mockRoom.messages, 'delete').mockResolvedValue({} as unknown as Message);
 
+    const getVersionsSpy = vi
+      .spyOn(mockRoom.messages, 'getVersions')
+      .mockResolvedValue({} as unknown as PaginatedResult<Message>);
+
     const message = new DefaultMessage({
       serial: '01719948956834-000@108TeGZDQBderu97202638',
       clientId: 'client-1',
@@ -214,6 +218,7 @@ describe('useMessages', () => {
         description: 'deleted',
         metadata: { reason: 'test' },
       });
+      await result.current.getVersions(message.serial);
     });
 
     expect(sendSpy).toHaveBeenCalledWith({ text: 'test message' });
@@ -222,6 +227,7 @@ describe('useMessages', () => {
       description: 'deleted',
       metadata: { reason: 'test' },
     });
+    expect(getVersionsSpy).toHaveBeenCalledWith(message.serial);
   });
 
   it('should handle rerender if the room instance changes', async () => {


### PR DESCRIPTION
## Summary

Closes the React parity gap for the `getVersions()` method shipped in v1.4.0 ([#730](https://github.com/ably/ably-chat-js/pull/730)). The core SDK exposes `room.messages.getVersions(serial)`, but it was never surfaced through the `useMessages` hook.

## What changed

- **`UseMessagesResponse.getVersions`** — new shortcut field with JSDoc, mirroring the existing `getMessage` shortcut
- **`useMessages`** — `getVersions` `useCallback` delegating to `room.messages.getVersions(serial)`, added to the returned object
- Stable reference across renders for the same room, consistent with the other method shortcuts

## Tests

- Extended the "should correctly call the methods exposed by the hook" test to spy on `getVersions` and assert it delegates with the correct serial

## Validation

- `npm run test:typescript` ✅
- `npm run test:react-unit` ✅ (146 passed)
- `npm run docs:lint` ✅
- ESLint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message version history is now available via a paginated endpoint, letting users retrieve and browse previous message versions in chronological order.
* **Tests**
  * Hook behavior updated with tests to verify the new version-retrieval method is exposed and invoked correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->